### PR TITLE
Add Codex-native MCP tools

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -9,6 +9,7 @@
   "homepage": "https://github.com/hogancv/coordinate-agents#readme",
   "repository": "https://github.com/hogancv/coordinate-agents",
   "license": "MIT",
+  "mcpServers": "./.mcp.json",
   "keywords": [
     "multi-agent",
     "coordination",

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "coordinate-agents": {
+      "command": "node",
+      "args": ["./mcp/server.mjs", "--stdio"],
+      "cwd": "."
+    }
+  }
+}

--- a/AI_INSTALL.md
+++ b/AI_INSTALL.md
@@ -55,10 +55,14 @@ debugging surface.
 
 The Plugin homepage prompts are deliberately ordered as Discover → Configure →
 Try. The Try prompt uses the ordinary Task workflow for the Todo web app; it
-does not create a special demo path. Runtime state should be read through JSON:
+does not create a special demo path. Normal Plugin machine operations use the
+structured MCP tools and return the existing JSON Runtime contract:
 
 **A Codex Plugin user does not need `npm install -g @hogancv/coordinate-agents`.** All five Skills
-invoke the bundled canonical Runtime with one resolver convention, never by assuming a PATH command:
+use the bundled Coordinate Agents MCP server first, never by assuming a PATH command. If MCP is
+unavailable, or the user explicitly requests debugging, use the fallback resolver.
+The following shell syntax is fallback/debug/standalone only, not the normal
+Plugin machine path:
 
 ```text
 node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs" <command> ...
@@ -67,7 +71,9 @@ node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs" <command> ...
 The active Skill supplies the absolute `<skill-dir>`. The resolver handles the active Plugin payload,
 personal local marketplace sources, cached Git marketplace roots, Node/npm package fallback, and
 Windows paths with spaces. The npm CLI remains a standalone Runtime, compatibility, and debugging
-surface, not a Plugin prerequisite.
+surface, not a Plugin prerequisite. Do not silently retry between MCP and fallback.
+
+Fallback/debug examples only:
 
 ```text
 node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs" setup --root "<repository>" --json
@@ -117,9 +123,9 @@ When an AI assistant is asked to install `coordinate-agents`:
 - **通过 npm 同时为两个 CLI 宿主安装**：
   - 使用 `npx --yes @hogancv/coordinate-agents@<VERIFIED_VERSION> install`。
 
-普通 Codex Plugin 用户不需要 `npm install -g @hogancv/coordinate-agents`；五个 Skill 统一通过
-`node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs" <command> ...` 找到 Plugin 载荷中的
-唯一 canonical Runtime。只有 standalone、兼容安装或调试场景才使用 npm CLI。
+普通 Codex Plugin 用户不需要 `npm install -g @hogancv/coordinate-agents`；五个 Skill 优先使用
+Plugin 自带的 Coordinate Agents MCP tools。只有 MCP 不可用、standalone、兼容安装或调试场景，才通过
+`node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs" <command> ...` 使用 fallback Runtime。
 
 ## Canonical identity / 官方身份
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,24 @@ The normal Plugin path is **Install Plugin → Discover → Configure → Build*
 4. Let `coordinate-review` inspect the commit/evidence and record `REVIEW_APPROVED` or
    `CHANGES_REQUESTED` without editing the Task file directly.
 
-The Runtime invocation convention used by all five Skills is:
+The normal machine path is structured MCP, not generated shell commands:
+
+```text
+User <-> Codex
+  -> Skills
+  -> Coordinate Agents MCP Tools
+  -> Canonical Runtime
+  -> Task API
+  -> Agent Bus
+  -> External Implementer
+```
+
+The Plugin exposes `coordinate_agents_setup_discover`,
+`coordinate_agents_setup_configure`, the Task create/dispatch/status/inspect/
+review/resume/stop tools, and `coordinate_agents_recover_inspect`. MCP and CLI
+call the same Runtime operations and return the same canonical error contract.
+
+Only when MCP is unavailable, or for explicit debugging, use the fallback:
 
 ```text
 node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs" <command> ...
@@ -67,7 +84,10 @@ node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs" <command> ...
 
 `<skill-dir>` is the absolute directory containing the active Skill's `SKILL.md`; the Skill supplies
 that concrete path. The resolver starts the one canonical `bin/coordinate-agents.mjs` from the Plugin
-payload, so the Plugin path has no hidden global npm prerequisite.
+payload. Do not silently retry between MCP and fallback.
+
+See [MCP tools and integration](./docs/mcp.md) for the stdio lifecycle, schemas,
+error semantics, fallback behavior, and release safety.
 
 ## Advanced: standalone npm Runtime and debugging
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -54,14 +54,34 @@ Antigravity 是参考适配器，不再是产品绑定。
    负责 Agent Bus handoff 和 Implementer launch。
 4. `coordinate-review` 检查真实 commit/证据，并记录 `REVIEW_APPROVED` 或 `CHANGES_REQUESTED`，不直接编辑 Task 文件。
 
-五个 Skill 统一使用以下 Runtime 调用约定：
+普通 Plugin 的机器调用路径优先使用结构化 MCP，而不是让 Skill 生成 shell command：
+
+```text
+用户 <-> Codex
+  -> Skills
+  -> Coordinate Agents MCP Tools
+  -> Canonical Runtime
+  -> Task API
+  -> Agent Bus
+  -> External Implementer
+```
+
+Plugin 提供 `coordinate_agents_setup_discover`、
+`coordinate_agents_setup_configure`、Task create/dispatch/status/inspect/
+review/resume/stop，以及 `coordinate_agents_recover_inspect`。MCP 与 CLI
+调用同一套 Runtime operation，并返回相同的 canonical error contract。
+
+只有在 MCP 不可用，或用户明确要求调试时，才使用以下 fallback：
 
 ```text
 node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs" <command> ...
 ```
 
 其中 `<skill-dir>` 是当前 Skill 的 `SKILL.md` 所在绝对目录，由 Skill 传入具体路径。Resolver 会从
-Plugin 载荷中启动唯一的 `bin/coordinate-agents.mjs`，因此 Plugin 路径没有隐藏的 global npm 前置依赖。
+Plugin 载荷中启动唯一的 `bin/coordinate-agents.mjs`。不要在 MCP 与 fallback 之间静默循环重试。
+
+详见 [MCP 工具与集成文档](./docs/mcp.md)，其中包含 stdio 生命周期、schema、错误语义、fallback
+行为和 release safety。
 
 ## 高级：standalone npm Runtime 与调试
 

--- a/bin/coordinate-agents.mjs
+++ b/bin/coordinate-agents.mjs
@@ -944,6 +944,104 @@ function statusJson(options) {
   return jsonSuccess('status', { root, bus, tasks });
 }
 
+function readLatestErrorArtifact(root, agentId) {
+  const logsDirectory = join(root, '.agent-bus', 'logs');
+  if (!existsSync(logsDirectory)) return null;
+  const candidates = readdirSync(logsDirectory)
+    .filter(name => name.endsWith('-ERROR.json') && (!agentId || name.includes(`-${agentId}-ERROR.json`)))
+    .sort()
+    .reverse();
+  for (const name of candidates) {
+    const path = join(logsDirectory, name);
+    try {
+      assertSafePath(root, path, messages.en, false);
+      const record = JSON.parse(readFileSync(path, 'utf8'));
+      return {
+        path: resolve(path),
+        artifact: {
+          ...record,
+          details: redactOutput(record.details || '', 2 * 1024),
+          stdoutTail: redactOutput(record.stdoutTail || '', 8 * 1024),
+          stderrTail: redactOutput(record.stderrTail || '', 8 * 1024),
+        },
+      };
+    } catch {
+      // Ignore malformed or unsafe artifacts; the Task error remains the
+      // authoritative recovery fact.
+    }
+  }
+  return null;
+}
+
+function recoverInspectCommand(options) {
+  const root = assertGitRepository(options.root, messages.en);
+  const id = options.taskId || options.positionals?.[0] || null;
+  const taskId = resolveTaskId(root, id);
+  const task = syncTaskFromAgentBus(root, taskId);
+  const busPath = join(root, '.agent-bus');
+  const busConfig = readConfig(busPath);
+  const agentConfig = busConfig.agents.find(agent => agent.id === task.implementer) || null;
+  let executable = {
+    agent: task.implementer,
+    adapter: agentConfig?.adapter || null,
+    command: null,
+    commandSource: null,
+    available: false,
+    code: 'INVALID_AGENT_CONFIG',
+    details: agentConfig ? null : `Task implementer is not registered: ${task.implementer}`,
+    resolvedCommand: null,
+  };
+  let agentState = null;
+  let artifact = null;
+  if (agentConfig) {
+    try {
+      const resolved = runtimeAgentConfig(agentConfig, readUserConfig());
+      const adapter = getAdapter(resolved.adapter, resolved);
+      const detection = adapter.detect({ version: false });
+      executable = {
+        agent: task.implementer,
+        adapter: resolved.adapter,
+        command: resolved.command || null,
+        commandSource: resolved.commandSource || null,
+        available: Boolean(detection.available),
+        code: detection.available ? null : canonicalErrorCode(detection.code || 'EXECUTABLE_NOT_FOUND', 'EXECUTABLE_NOT_FOUND'),
+        details: detection.available ? null : (detection.details || null),
+        resolvedCommand: detection.resolvedCommand || null,
+      };
+    } catch (error) {
+      executable = {
+        ...executable,
+        code: canonicalErrorCode(error.code, 'INVALID_AGENT_CONFIG'),
+        details: redactOutput(error.message || String(error), 2 * 1024),
+      };
+    }
+    try {
+      agentState = observeAgentBus(busPath, task.implementer);
+    } catch (error) {
+      agentState = { error: redactOutput(error.message || String(error), 2 * 1024) };
+    }
+    artifact = readLatestErrorArtifact(root, task.implementer);
+  }
+  return jsonSuccess('recover.inspect', {
+    root,
+    task,
+    lastError: task.lastError || null,
+    agent: {
+      id: task.implementer,
+      registered: Boolean(agentConfig),
+      state: agentState,
+    },
+    errorArtifact: artifact,
+    executable,
+    recommendedRecovery: {
+      factsOnly: true,
+      resumeRequired: ['ERROR', 'STOPPED'].includes(task.status),
+      dispatchRequiredAfterResume: ['ERROR', 'STOPPED', 'CHANGES_REQUESTED'].includes(task.status),
+      automaticRetry: false,
+    },
+  });
+}
+
 function sendTaskBusMessage(root, { from, to, type, subject, body, dedupeKey, relatedCommit = '' }) {
   const busPath = join(root, '.agent-bus');
   const temporary = join(busPath, 'tmp', `.task-${process.pid}-${randomUUID().replaceAll('-', '')}.md`);
@@ -1189,7 +1287,10 @@ function taskReview(root, task, options) {
     dedupeKey: `task:${task.id}:round:${task.round}:review:${decision}`,
     relatedCommit: task.implementationCommit || '',
   });
-  const updated = recordReviewDecision(root, task.id, decision, { feedback, evidence: { messagePath } });
+  const updated = recordReviewDecision(root, task.id, decision, {
+    feedback,
+    evidence: options.evidence || { messagePath },
+  });
   try { recordBusState(root, task.reviewer, decision === 'REVIEW_APPROVED' ? 'APPROVED' : 'CHANGES_REQUESTED', `Task ${task.id}: ${decision}`); } catch { /* Task decision remains authoritative. */ }
   return { root, task: updated, review: { decision, feedback, messagePath } };
 }
@@ -1247,7 +1348,11 @@ async function taskCommand(options, { json = false } = {}) {
 
 function setupCommand(options, { json = false } = {}) {
   let root = resolve(options.root);
-  try { root = assertGitRepository(options.root, messages.en); } catch { /* Discovery is also useful before a project is selected. */ }
+  if (options.requireRepository) {
+    root = assertGitRepository(options.root, messages.en);
+  } else {
+    try { root = assertGitRepository(options.root, messages.en); } catch { /* Discovery is also useful before a project is selected. */ }
+  }
   const userConfig = readUserConfig();
   const snapshot = setupSnapshot({ root, userConfig });
   const result = jsonSuccess('setup', {
@@ -2581,4 +2686,94 @@ async function run(argv) {
   process.exitCode = 2;
 }
 
-await run(process.argv.slice(2));
+function serviceOptions(input = {}) {
+  return {
+    command: 'help',
+    subcommand: null,
+    root: resolve(`${input.root || process.cwd()}`),
+    language: 'en',
+    json: true,
+    codex: false,
+    antigravity: false,
+    once: false,
+    force: false,
+    role: 'implementer',
+    roleExplicit: false,
+    adapter: 'generic-cli',
+    adapterExplicit: false,
+    agent: null,
+    agentCommand: null,
+    agentArgs: null,
+    planner: null,
+    implementer: null,
+    reviewer: null,
+    title: '',
+    spec: '',
+    taskId: null,
+    reason: '',
+    decision: null,
+    feedback: '',
+    evidence: null,
+    positionals: [],
+    ...input,
+  };
+}
+
+/**
+ * Reusable high-level Runtime operations for non-CLI transports.  The CLI
+ * handlers above remain the canonical implementation; these adapters only
+ * supply their structured options and never spawn the CLI or parse stdout.
+ */
+export function runtimeSetupDiscover(input = {}) {
+  return setupCommand(serviceOptions({ ...input, requireRepository: true }), { json: true });
+}
+
+export function runtimeSetupConfigure(input = {}) {
+  const options = serviceOptions({
+    ...input,
+    agent: `${input.agent || ''}`.trim().toLowerCase(),
+    agentCommand: `${input.command || ''}`.trim(),
+    adapter: input.adapter || 'generic-cli',
+    adapterExplicit: input.adapter !== undefined,
+    role: `${input.role || 'implementer'}`.trim().toLowerCase(),
+    roleExplicit: true,
+    agentArgs: input.args === undefined ? null : JSON.stringify(input.args),
+  });
+  return setupConfigureCommand(options, { json: true });
+}
+
+export async function runtimeTaskCreate(input = {}) {
+  return taskCommand(serviceOptions({
+    ...input,
+    command: 'task',
+    subcommand: 'create',
+    title: input.title || '',
+    spec: input.spec || '',
+    taskId: input.id || null,
+  }), { json: true });
+}
+
+export async function runtimeTaskOperation(subcommand, input = {}) {
+  return taskCommand(serviceOptions({
+    ...input,
+    command: 'task',
+    subcommand,
+    taskId: input.taskId || null,
+    positionals: [],
+  }), { json: true });
+}
+
+export function runtimeRecoverInspect(input = {}) {
+  return recoverInspectCommand(serviceOptions({
+    ...input,
+    command: 'recover',
+    subcommand: 'inspect',
+    taskId: input.taskId || null,
+  }));
+}
+
+export { recoverInspectCommand };
+
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+  await run(process.argv.slice(2));
+}

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -11,6 +11,7 @@ header_pages:
   - getting-started.md
   - install-with-ai.md
   - protocol.md
+  - mcp.md
   - security.md
   - troubleshooting.md
   - faq.md

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -13,6 +13,7 @@ Install with AI: https://hogancv.github.io/coordinate-agents/install-with-ai.htm
 Codex role (Reference planner/reviewer): https://hogancv.github.io/coordinate-agents/codex-cli.html
 Antigravity role (Reference implementer): https://hogancv.github.io/coordinate-agents/antigravity-cli.html
 Protocol: https://hogancv.github.io/coordinate-agents/protocol.html
+MCP tools: https://hogancv.github.io/coordinate-agents/mcp.html
 Security: https://hogancv.github.io/coordinate-agents/security.html
 Troubleshooting: https://hogancv.github.io/coordinate-agents/troubleshooting.html
 Comparison: https://hogancv.github.io/coordinate-agents/comparison.html
@@ -29,13 +30,13 @@ Review Skill: https://github.com/hogancv/coordinate-agents/blob/main/skills/coor
 Recovery Skill: https://github.com/hogancv/coordinate-agents/blob/main/skills/coordinate-recover/SKILL.md
 
 Plugin-first onboarding: Install the Plugin, Discover local coding CLIs with
-`setup --json`, Configure the selected Implementer through one `setup configure`
-transaction, and Build through `task create` followed by `task dispatch` over the
-same durable `.agent-bus`. Every Skill invokes the one canonical Runtime with
-`node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs"`; a global
-npm CLI is not required. Dispatch owns executable validation, `IMPLEMENT`
-transport, Implementer launch, `IMPLEMENTATION_DONE` synchronization, and
-failure propagation. Runtime JSON uses stable error codes and stops on a failed
+`coordinate_agents_setup_discover`, Configure the selected Implementer through
+`coordinate_agents_setup_configure`, and Build through the structured Task MCP
+tools over the same durable `.agent-bus`. MCP is the normal Plugin machine path;
+`runtime-entry.mjs` and the npm CLI remain compatibility/fallback/debugging
+surfaces. Dispatch owns executable validation, `IMPLEMENT` transport,
+Implementer launch, `IMPLEMENTATION_DONE` synchronization, and failure
+propagation. Runtime JSON uses stable error codes and stops on a failed
 activation instead of retrying automatically.
 
 Use this project for structured multi-agent software engineering where workflow roles (such as planner, implementer, and reviewer) coordinate across distinct CLI or adapter-extended agents via durable local messaging, explicit leases, and human release authorization. The default reference workflow pairs Codex as planner/reviewer with Antigravity as exclusive implementer. Do not use it for single-agent coding tasks or concurrent conflicting worktree writes.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,124 @@
+---
+layout: default
+title: Coordinate Agents MCP
+description: Local stdio MCP tools over the canonical Coordinate Agents Runtime.
+---
+
+# Coordinate Agents MCP
+
+Coordinate Agents exposes a local, stdio-only MCP server for Codex Plugins.
+The MCP layer is a structured transport over the existing Runtime, Task API,
+and Agent Bus; it is not a second workflow engine.
+
+```text
+User <-> Codex
+  -> Skills
+  -> MCP Tools
+  -> Canonical Runtime
+  -> Task API
+  -> Agent Bus
+  -> External Implementer
+```
+
+## Installation and lifecycle
+
+`.codex-plugin/plugin.json` points to the companion `./.mcp.json`. The server
+starts as a local child process:
+
+```json
+{
+  "mcpServers": {
+    "coordinate-agents": {
+      "command": "node",
+      "args": ["./mcp/server.mjs", "--stdio"],
+      "cwd": "."
+    }
+  }
+}
+```
+
+The server reads newline-delimited JSON-RPC from stdin and writes only valid
+JSON-RPC messages to stdout. It does not open an HTTP server, listen on a
+network port, create a daemon, initialize the Agent Bus, scan repositories, or
+start an Implementer until a tool is called.
+
+## Tools
+
+| Tool | Required input | Optional input | Runtime command |
+| --- | --- | --- | --- |
+| `coordinate_agents_setup_discover` | `root` | — | `setup` |
+| `coordinate_agents_setup_configure` | `root`, `agent`, `command` | `adapter`, `args`, `role` | `setup.configure` |
+| `coordinate_agents_task_create` | `root`, `title` | `id`, `spec`, `planner`, `implementer`, `reviewer` | `task.create` |
+| `coordinate_agents_task_dispatch` | `root`, `taskId` | `spec` | `task.dispatch` |
+| `coordinate_agents_task_status` | `root`, `taskId` | — | `task.status` |
+| `coordinate_agents_task_inspect` | `root`, `taskId` | — | `task.inspect` |
+| `coordinate_agents_task_review` | `root`, `taskId`, `decision` | `feedback`, `evidence` | `task.review` |
+| `coordinate_agents_task_resume` | `root`, `taskId` | — | `task.resume` |
+| `coordinate_agents_task_stop` | `root`, `taskId` | `reason` | `task.stop` |
+| `coordinate_agents_recover_inspect` | `root`, `taskId` | — | `recover.inspect` |
+
+Tool schemas are advertised by `tools/list` and reject unknown top-level
+arguments. `root` is validated as a Git repository by the canonical Runtime.
+The setup tool keeps Agent identity, Adapter, and executable command separate;
+for example, `antigravity` may use `agy-proxy`.
+
+## Output and errors
+
+Successful and business-failure results use the existing Runtime contract:
+
+```json
+{
+  "ok": false,
+  "command": "task.dispatch",
+  "error": {
+    "code": "EXECUTABLE_NOT_FOUND",
+    "message": "...",
+    "recoverable": true
+  }
+}
+```
+
+The same object is returned in `structuredContent` and as a JSON text content
+block. Business failures use MCP `isError: true`; they are not converted to a
+new `MCP_ERROR_*` code. JSON-RPC protocol errors are reserved for malformed
+requests, unknown methods/tools, or invalid tool arguments.
+
+The server reads its name as `coordinate-agents` and its version from the
+bundled package manifest. Protocol compatibility is not represented as a
+second product version. Task records continue to use `schemaVersion: 1`.
+
+## Workflow boundaries
+
+MCP does not plan specifications, automatically review changes, retry failed
+activations, or authorize release. Codex remains responsible for clarification,
+approved specifications, evidence review, and the human release gate.
+`REVIEW_APPROVED` means Task `APPROVED`; it never means merge, push, tag,
+publish, deploy, or release.
+
+`coordinate_agents_recover_inspect` is facts-only. It reports Task state,
+`lastError`, Agent state, executable facts, and bounded error artifacts. It does
+not resume or dispatch. Recovery is an explicit follow-up operation.
+
+## Fallback and security
+
+If the MCP server is unavailable, Skills may use the bundled
+`skills/coordinate-agents/scripts/runtime-entry.mjs` fallback. This fallback is
+for compatibility, standalone Runtime use, and debugging; it is not the normal
+Plugin machine path. Skills must not silently loop between MCP and fallback.
+
+The server is local-only and uses existing repository validation, safe-path and
+symlink protections, bounded/redacted error output, user/project executable
+precedence, argument-array child-process spawning, and the existing release
+gate. It exposes no general shell, command execution, or Agent Bus mutation
+tool and persists no credentials.
+
+## Protocol schemas
+
+The stable Task, Runtime error, and evidence shapes are documented in:
+
+- `schemas/task.schema.json`
+- `schemas/runtime-error.schema.json`
+- `schemas/evidence.schema.json`
+
+These files describe the current implementation; they do not drive runtime
+behavior. A future breaking Task contract must increment `schemaVersion`.

--- a/llms.txt
+++ b/llms.txt
@@ -13,6 +13,7 @@ Install with AI: https://hogancv.github.io/coordinate-agents/install-with-ai.htm
 Codex role (Reference planner/reviewer): https://hogancv.github.io/coordinate-agents/codex-cli.html
 Antigravity role (Reference implementer): https://hogancv.github.io/coordinate-agents/antigravity-cli.html
 Protocol: https://hogancv.github.io/coordinate-agents/protocol.html
+MCP tools: https://hogancv.github.io/coordinate-agents/mcp.html
 Security: https://hogancv.github.io/coordinate-agents/security.html
 Troubleshooting: https://hogancv.github.io/coordinate-agents/troubleshooting.html
 Comparison: https://hogancv.github.io/coordinate-agents/comparison.html
@@ -29,13 +30,13 @@ Review Skill: https://github.com/hogancv/coordinate-agents/blob/main/skills/coor
 Recovery Skill: https://github.com/hogancv/coordinate-agents/blob/main/skills/coordinate-recover/SKILL.md
 
 Plugin-first onboarding: Install the Plugin, Discover local coding CLIs with
-`setup --json`, Configure the selected Implementer through one `setup configure`
-transaction, and Build through `task create` followed by `task dispatch` over the
-same durable `.agent-bus`. Every Skill invokes the one canonical Runtime with
-`node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs"`; a global
-npm CLI is not required. Dispatch owns executable validation, `IMPLEMENT`
-transport, Implementer launch, `IMPLEMENTATION_DONE` synchronization, and
-failure propagation. Runtime JSON uses stable error codes and stops on a failed
+`coordinate_agents_setup_discover`, Configure the selected Implementer through
+`coordinate_agents_setup_configure`, and Build through the structured Task MCP
+tools over the same durable `.agent-bus`. MCP is the normal Plugin machine path;
+`runtime-entry.mjs` and the npm CLI remain compatibility/fallback/debugging
+surfaces. Dispatch owns executable validation, `IMPLEMENT` transport,
+Implementer launch, `IMPLEMENTATION_DONE` synchronization, and failure
+propagation. Runtime JSON uses stable error codes and stops on a failed
 activation instead of retrying automatically.
 
 Use this project for structured multi-agent software engineering where workflow roles (such as planner, implementer, and reviewer) coordinate across distinct CLI or adapter-extended agents via durable local messaging, explicit leases, and human release authorization. The default reference workflow pairs Codex as planner/reviewer with Antigravity as exclusive implementer. Do not use it for single-agent coding tasks or concurrent conflicting worktree writes.

--- a/mcp/server.mjs
+++ b/mcp/server.mjs
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from 'node:fs';
+import { createInterface } from 'node:readline';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  jsonFailure,
+  normalizeRuntimeError,
+} from '../skills/coordinate-agents/scripts/runtime-contract.mjs';
+import { invokeRuntimeOperation } from '../skills/coordinate-agents/scripts/runtime-services.mjs';
+
+const SERVER_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const PROTOCOL_VERSION = '2025-06-18';
+const SUPPORTED_PROTOCOL_VERSIONS = new Set(['2025-03-26', '2025-06-18', '2025-11-25']);
+const MAX_LINE_LENGTH = 1024 * 1024;
+
+function readJson(path) {
+  try { return JSON.parse(readFileSync(path, 'utf8')); } catch { return null; }
+}
+
+function serverVersion(root = SERVER_ROOT) {
+  const packageJson = readJson(join(root, 'package.json'));
+  if (packageJson?.version) return `${packageJson.version}`;
+  const pluginJson = readJson(join(root, '.codex-plugin', 'plugin.json'));
+  return `${pluginJson?.version || '0.0.0'}`;
+}
+
+const stringProperty = (description, { minLength = 1 } = {}) => ({
+  type: 'string',
+  minLength,
+  description,
+});
+
+const rootProperty = {
+  type: 'string',
+  minLength: 1,
+  description: 'Absolute or repository-relative Git repository root.',
+};
+
+const taskIdentityProperties = {
+  root: rootProperty,
+  taskId: stringProperty('Existing Task identifier.'),
+};
+
+const TOOL_DEFINITIONS = Object.freeze([
+  {
+    name: 'coordinate_agents_setup_discover',
+    description: 'Discover available coding CLIs without changing configuration.',
+    operation: 'setupDiscover',
+    command: 'setup',
+    inputSchema: {
+      type: 'object',
+      properties: { root: rootProperty },
+      required: ['root'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'coordinate_agents_setup_configure',
+    description: 'Configure an agent executable and assign a project workflow role transactionally.',
+    operation: 'setupConfigure',
+    command: 'setup.configure',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        root: rootProperty,
+        agent: stringProperty('Agent identity, independent from its executable command.'),
+        command: stringProperty('Executable command or safe path.'),
+        adapter: stringProperty('Registered adapter name.', { minLength: 1 }),
+        args: { type: 'array', items: { type: 'string' }, description: 'Adapter argument template.' },
+        role: { type: 'string', enum: ['implementer', 'planner', 'reviewer'] },
+      },
+      required: ['root', 'agent', 'command'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'coordinate_agents_task_create',
+    description: 'Create a durable Task without dispatching an Implementer.',
+    operation: 'taskCreate',
+    command: 'task.create',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        root: rootProperty,
+        id: stringProperty('Optional deterministic Task identifier.'),
+        title: stringProperty('Task title.'),
+        spec: { type: 'string', description: 'Optional specification saved for later dispatch.' },
+        planner: stringProperty('Planner Agent identity.'),
+        implementer: stringProperty('Implementer Agent identity.'),
+        reviewer: stringProperty('Reviewer Agent identity.'),
+      },
+      required: ['root', 'title'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'coordinate_agents_task_dispatch',
+    description: 'Validate and explicitly dispatch an approved Task to the configured Implementer.',
+    operation: 'taskDispatch',
+    command: 'task.dispatch',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ...taskIdentityProperties,
+        spec: { type: 'string', description: 'Optional approved specification override.' },
+      },
+      required: ['root', 'taskId'],
+      additionalProperties: false,
+    },
+  },
+  ...['status', 'inspect'].map(subcommand => ({
+    name: `coordinate_agents_task_${subcommand}`,
+    description: `Read the durable Task ${subcommand} view.`,
+    operation: `task${subcommand[0].toUpperCase()}${subcommand.slice(1)}`,
+    command: `task.${subcommand}`,
+    inputSchema: {
+      type: 'object',
+      properties: taskIdentityProperties,
+      required: ['root', 'taskId'],
+      additionalProperties: false,
+    },
+  })),
+  {
+    name: 'coordinate_agents_task_review',
+    description: 'Record a Codex review decision without authorizing release actions.',
+    operation: 'taskReview',
+    command: 'task.review',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ...taskIdentityProperties,
+        decision: { type: 'string', enum: ['REVIEW_APPROVED', 'CHANGES_REQUESTED'] },
+        feedback: { type: 'string', description: 'Required when decision is CHANGES_REQUESTED.' },
+        evidence: { type: 'object', description: 'Optional review evidence reference.' },
+      },
+      required: ['root', 'taskId', 'decision'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'coordinate_agents_task_resume',
+    description: 'Explicitly clear a Task recovery gate; this does not dispatch.',
+    operation: 'taskResume',
+    command: 'task.resume',
+    inputSchema: {
+      type: 'object',
+      properties: taskIdentityProperties,
+      required: ['root', 'taskId'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'coordinate_agents_task_stop',
+    description: 'Stop a non-approved Task explicitly.',
+    operation: 'taskStop',
+    command: 'task.stop',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ...taskIdentityProperties,
+        reason: { type: 'string', description: 'Optional stop reason.' },
+      },
+      required: ['root', 'taskId'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'coordinate_agents_recover_inspect',
+    description: 'Inspect Task, Agent, executable, and bounded error facts without resuming or retrying.',
+    operation: 'recoverInspect',
+    command: 'recover.inspect',
+    inputSchema: {
+      type: 'object',
+      properties: taskIdentityProperties,
+      required: ['root', 'taskId'],
+      additionalProperties: false,
+    },
+  },
+]);
+
+const TOOL_MAP = new Map(TOOL_DEFINITIONS.map(tool => [tool.name, tool]));
+
+function protocolError(id, code, message, data = undefined) {
+  const error = { jsonrpc: '2.0', id: id ?? null, error: { code, message } };
+  if (data !== undefined) error.error.data = data;
+  return error;
+}
+
+function isObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function validateArguments(tool, args) {
+  if (!isObject(args)) return 'Tool arguments must be a JSON object.';
+  const schema = tool.inputSchema;
+  for (const required of schema.required || []) {
+    if (!(required in args)) return `Missing required argument: ${required}`;
+  }
+  for (const key of Object.keys(args)) {
+    if (schema.additionalProperties === false && !schema.properties[key]) return `Unknown argument: ${key}`;
+    const property = schema.properties[key];
+    if (!property) continue;
+    const value = args[key];
+    if (property.type === 'string' && (typeof value !== 'string' || value.length < (property.minLength || 0))) {
+      return `Argument ${key} must be a non-empty string.`;
+    }
+    if (property.type === 'array' && (!Array.isArray(value) || value.some(item => typeof item !== 'string'))) {
+      return `Argument ${key} must be an array of strings.`;
+    }
+    if (property.type === 'object' && !isObject(value)) return `Argument ${key} must be an object.`;
+    if (property.enum && !property.enum.includes(value)) return `Argument ${key} has an unsupported value.`;
+  }
+  return null;
+}
+
+function resultContent(payload) {
+  return [{ type: 'text', text: JSON.stringify(payload) }];
+}
+
+async function callTool(tool, args) {
+  try {
+    const payload = await invokeRuntimeOperation(tool.operation, args);
+    return {
+      content: resultContent(payload),
+      structuredContent: payload,
+      isError: payload?.ok === false,
+    };
+  } catch (error) {
+    const payload = jsonFailure(tool.command, normalizeRuntimeError(error));
+    return {
+      content: resultContent(payload),
+      structuredContent: payload,
+      isError: true,
+    };
+  }
+}
+
+function initializeResult(root, params = {}) {
+  const requested = params.protocolVersion;
+  return {
+    protocolVersion: SUPPORTED_PROTOCOL_VERSIONS.has(requested) ? requested : PROTOCOL_VERSION,
+    capabilities: { tools: {} },
+    serverInfo: { name: 'coordinate-agents', version: serverVersion(root) },
+    instructions: 'Use Coordinate Agents tools for setup, durable Task operations, review, and recovery facts. Agent Bus transport and release actions remain internal or user-gated.',
+  };
+}
+
+export function createMcpServer({ root = SERVER_ROOT } = {}) {
+  const serverRoot = resolve(root);
+  return {
+    async handle(message) {
+      if (!isObject(message) || message.jsonrpc !== '2.0') return protocolError(message?.id, -32600, 'Invalid JSON-RPC request.');
+      const { id = null, method, params = {} } = message;
+      if (method === 'notifications/initialized' || method === 'notifications/cancelled' || method === '$/cancelRequest') return null;
+      if (method === 'initialize') return { jsonrpc: '2.0', id, result: initializeResult(serverRoot, params) };
+      if (method === 'ping') return { jsonrpc: '2.0', id, result: {} };
+      if (method === 'tools/list') return { jsonrpc: '2.0', id, result: { tools: TOOL_DEFINITIONS.map(({ operation, command, ...tool }) => tool) } };
+      if (method !== 'tools/call') return protocolError(id, -32601, `Method not found: ${method}`);
+      if (!isObject(params) || typeof params.name !== 'string') return protocolError(id, -32602, 'tools/call requires a tool name.');
+      const tool = TOOL_MAP.get(params.name);
+      if (!tool) return protocolError(id, -32601, `Unknown tool: ${params.name}`);
+      const args = params.arguments === undefined ? {} : params.arguments;
+      const validationError = validateArguments(tool, args);
+      if (validationError) return protocolError(id, -32602, validationError);
+      const result = await callTool(tool, args);
+      return { jsonrpc: '2.0', id, result };
+    },
+  };
+}
+
+function writeMessage(message) {
+  process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+export async function runStdio({ input = process.stdin } = {}) {
+  const server = createMcpServer();
+  const lines = createInterface({ input, crlfDelay: Infinity, terminal: false });
+  for await (const line of lines) {
+    if (!line) continue;
+    if (line.length > MAX_LINE_LENGTH) {
+      writeMessage(protocolError(null, -32700, 'MCP message exceeds the size limit.'));
+      continue;
+    }
+    let message;
+    try { message = JSON.parse(line); } catch {
+      writeMessage(protocolError(null, -32700, 'Invalid JSON.'));
+      continue;
+    }
+    try {
+      const response = await server.handle(message);
+      if (response) writeMessage(response);
+    } catch (error) {
+      process.stderr.write(`${String(error?.stack || error)}\n`);
+      if (message?.id !== undefined) writeMessage(protocolError(message.id, -32603, 'Internal MCP server error.'));
+    }
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+  await runStdio();
+}

--- a/package.json
+++ b/package.json
@@ -8,8 +8,11 @@
   },
   "files": [
     ".codex-plugin",
+    ".mcp.json",
     ".agents",
     "skills",
+    "mcp",
+    "schemas",
     "bin",
     "scripts",
     "AI_INSTALL.md",
@@ -18,6 +21,7 @@
     "SECURITY.md",
     "llms.txt",
     "docs/llms.txt",
+    "docs/mcp.md",
     "LICENSE",
     "assets"
   ],

--- a/schemas/evidence.schema.json
+++ b/schemas/evidence.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/hogancv/coordinate-agents/schemas/evidence.schema.json",
+  "title": "Coordinate Agents Evidence",
+  "type": "object",
+  "properties": {
+    "type": { "type": "string" },
+    "id": { "type": "string" },
+    "path": { "type": "string" },
+    "relatedCommit": { "type": ["string", "null"] },
+    "details": { "type": ["string", "null"] },
+    "createdAt": { "type": "string", "format": "date-time" },
+    "messagePath": { "type": ["string", "null"] }
+  },
+  "additionalProperties": true
+}

--- a/schemas/runtime-error.schema.json
+++ b/schemas/runtime-error.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/hogancv/coordinate-agents/schemas/runtime-error.schema.json",
+  "title": "Coordinate Agents Runtime Error",
+  "type": "object",
+  "required": ["code", "message", "recoverable"],
+  "properties": {
+    "code": {
+      "type": "string",
+      "enum": [
+        "PLUGIN_RUNTIME_NOT_FOUND",
+        "EXECUTABLE_NOT_FOUND",
+        "EXECUTABLE_NOT_RUNNABLE",
+        "SPAWN_FAILED",
+        "AGENT_EXIT_NONZERO",
+        "AGENT_TIMEOUT",
+        "AGENT_RUNTIME_ERROR",
+        "AUTH_REQUIRED",
+        "INVALID_AGENT_CONFIG",
+        "INVALID_ADAPTER_CONFIG",
+        "TASK_NOT_FOUND",
+        "TASK_ALREADY_RUNNING",
+        "TASK_STATE_CONFLICT",
+        "STALE_CLAIM",
+        "DIRTY_WORKTREE",
+        "WORKTREE_CONFLICT",
+        "UNSUPPORTED_CAPABILITY"
+      ]
+    },
+    "message": { "type": "string" },
+    "recoverable": { "type": "boolean" },
+    "details": { "type": ["string", "null"] },
+    "command": { "type": ["string", "null"] },
+    "agent": { "type": ["string", "null"] },
+    "adapter": { "type": ["string", "null"] },
+    "taskId": { "type": ["string", "null"] },
+    "stage": { "type": ["string", "null"] },
+    "exitCode": { "type": ["integer", "null"] },
+    "signal": { "type": ["string", "null"] },
+    "resolvedCommand": { "type": ["string", "null"] },
+    "legacyCode": { "type": ["string", "null"] }
+  },
+  "additionalProperties": true
+}

--- a/schemas/task.schema.json
+++ b/schemas/task.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/hogancv/coordinate-agents/schemas/task.schema.json",
+  "title": "Coordinate Agents Task",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "id",
+    "title",
+    "status",
+    "round",
+    "planner",
+    "implementer",
+    "reviewer",
+    "createdAt",
+    "updatedAt",
+    "spec",
+    "evidence",
+    "lastError"
+  ],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "id": { "type": "string", "pattern": "^task-[A-Za-z0-9][A-Za-z0-9_-]{1,127}$" },
+    "title": { "type": "string", "minLength": 1 },
+    "status": {
+      "type": "string",
+      "enum": [
+        "CREATED",
+        "PLANNING",
+        "SPEC_READY",
+        "IMPLEMENTING",
+        "WAITING_IMPLEMENTER",
+        "REVIEWING",
+        "CHANGES_REQUESTED",
+        "APPROVED",
+        "ERROR",
+        "STOPPED"
+      ]
+    },
+    "round": { "type": "integer", "minimum": 1 },
+    "planner": { "type": "string", "minLength": 1 },
+    "implementer": { "type": "string", "minLength": 1 },
+    "reviewer": { "type": "string", "minLength": 1 },
+    "createdAt": { "type": "string", "format": "date-time" },
+    "updatedAt": { "type": "string", "format": "date-time" },
+    "spec": { "type": "string" },
+    "implementationCommit": { "type": ["string", "null"] },
+    "evidence": {
+      "type": "array",
+      "items": { "$ref": "evidence.schema.json" }
+    },
+    "lastError": {
+      "anyOf": [
+        { "$ref": "runtime-error.schema.json" },
+        { "type": "null" }
+      ]
+    },
+    "reviewDecision": { "type": ["string", "null"] },
+    "reviewFeedback": { "type": ["string", "null"] },
+    "reviewHistory": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+    "dispatch": { "type": ["object", "null"], "additionalProperties": true },
+    "implementationMessage": { "type": ["object", "null"], "additionalProperties": true },
+    "stopReason": { "type": ["string", "null"] }
+  },
+  "additionalProperties": true
+}

--- a/skills/coordinate-agents/SKILL.md
+++ b/skills/coordinate-agents/SKILL.md
@@ -25,22 +25,30 @@ Task API is the product surface; the Agent Bus remains the single canonical
 durable transport and persistence layer. The bundled runtime and adapters under
 this directory are the only implementation source; do not create a second Bus.
 
-## Canonical Plugin Runtime invocation
+## Canonical Plugin tool invocation
 
-Codex Plugin installation does not promise that the npm bin `coordinate-agents`
-is on `PATH`. Let `<skill-dir>` mean the absolute directory containing this
-loaded `SKILL.md`, then invoke the one bundled Runtime entry point for every
-operation:
+Use the structured Coordinate Agents MCP tools for normal Plugin operations.
+Skills decide when and why; MCP tools execute the approved operation; the
+canonical Runtime owns workflow semantics. The Agent Bus is internal durable
+infrastructure and is not a user-facing transport.
+
+The normal path is:
+
+```text
+Intent -> focused Skill -> Coordinate Agents MCP tool -> Canonical Runtime
+```
+
+Only when MCP is unavailable, or when the user explicitly requests debugging,
+use the bundled fallback. Let `<skill-dir>` mean the absolute directory
+containing this loaded `SKILL.md`:
 
 ```text
 node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs" <command> ...
 ```
 
-The resolver follows the active Plugin payload to its canonical
-`bin/coordinate-agents.mjs`; it also understands the personal marketplace,
-Git marketplace cache, and standalone npm compatibility layout. Do not replace
-this with a per-Skill path guess or a copied Runtime. JSON operations must keep
-`--json` as the machine-facing contract.
+The fallback resolves the active Plugin payload to the canonical
+`bin/coordinate-agents.mjs`; do not guess per-Skill paths, copy the Runtime, or
+silently retry between MCP and fallback.
 
 ## Codex App workflow
 
@@ -54,20 +62,20 @@ remains a fallback for hosts without direct App skill execution.
 
 ## Intent routing
 
-| User intent | Skill | Runtime surface |
+| User intent | Skill | MCP surface |
 | --- | --- | --- |
-| "Which coding CLIs are installed?" | `coordinate-setup` | `setup --json` |
-| "Configure the implementation agent." | `coordinate-setup` | `setup configure --json` transaction |
-| "Build this feature with Coordinate Agents." | `coordinate-task` | `task create`, `task dispatch` |
-| "Review the implementation." | `coordinate-review` | inspect evidence, `task review` |
-| "Continue the last task." | `coordinate-recover` | `task status`, explicit `task resume`, `task dispatch` |
+| "Which coding CLIs are installed?" | `coordinate-setup` | `coordinate_agents_setup_discover` |
+| "Configure the implementation agent." | `coordinate-setup` | `coordinate_agents_setup_configure` |
+| "Build this feature with Coordinate Agents." | `coordinate-task` | `coordinate_agents_task_create`, `coordinate_agents_task_dispatch` |
+| "Review the implementation." | `coordinate-review` | `coordinate_agents_task_inspect`, `coordinate_agents_task_review` |
+| "Continue the last task." | `coordinate-recover` | `coordinate_agents_recover_inspect`, `coordinate_agents_task_resume`, `coordinate_agents_task_dispatch` |
 
-Use `--json` for runtime facts. JSON stdout is a single document and errors
-use stable codes; explanatory prose belongs in the Skill layer. Never infer
-authentication from absence of a version; classify `AUTH_REQUIRED` only when
-the agent explicitly reports login or authentication failure. Preserve
-fail-fast behavior: a runtime error stops the current activation and never
-starts an automatic retry loop.
+MCP tool results carry the same structured Runtime contract as CLI JSON:
+`{ ok, command, ... }`, with canonical error codes inside `error`. Keep
+explanatory prose in the Skill layer. Never infer authentication from absence
+of a version; classify `AUTH_REQUIRED` only when the agent explicitly reports
+login or authentication failure. Preserve fail-fast behavior: a runtime error
+stops the current activation and never starts an automatic retry loop.
 
 For protocol details and task templates, read the relative resources
 `references/protocol.md` and `references/task-templates.md`. For direct Bus

--- a/skills/coordinate-agents/scripts/runtime-services.mjs
+++ b/skills/coordinate-agents/scripts/runtime-services.mjs
@@ -1,0 +1,36 @@
+/**
+ * Structured transport adapters for the canonical Coordinate Agents Runtime.
+ *
+ * The CLI and MCP server use the same exported operations.  This module keeps
+ * the transport-facing names independent from MCP protocol details while the
+ * existing Task Runtime and Agent Bus remain the only workflow state owners.
+ */
+
+import {
+  runtimeRecoverInspect,
+  runtimeSetupConfigure,
+  runtimeSetupDiscover,
+  runtimeTaskCreate,
+  runtimeTaskOperation,
+} from '../../../bin/coordinate-agents.mjs';
+
+export { runtimeSetupDiscover, runtimeSetupConfigure, runtimeTaskCreate, runtimeTaskOperation, runtimeRecoverInspect };
+
+export const RUNTIME_OPERATIONS = Object.freeze({
+  setupDiscover: runtimeSetupDiscover,
+  setupConfigure: runtimeSetupConfigure,
+  taskCreate: runtimeTaskCreate,
+  taskDispatch: input => runtimeTaskOperation('dispatch', input),
+  taskStatus: input => runtimeTaskOperation('status', input),
+  taskInspect: input => runtimeTaskOperation('inspect', input),
+  taskReview: input => runtimeTaskOperation('review', input),
+  taskResume: input => runtimeTaskOperation('resume', input),
+  taskStop: input => runtimeTaskOperation('stop', input),
+  recoverInspect: runtimeRecoverInspect,
+});
+
+export async function invokeRuntimeOperation(operation, input = {}) {
+  const handler = RUNTIME_OPERATIONS[operation];
+  if (!handler) throw new Error(`Unknown Coordinate Agents Runtime operation: ${operation}`);
+  return await handler(input);
+}

--- a/skills/coordinate-recover/SKILL.md
+++ b/skills/coordinate-recover/SKILL.md
@@ -8,14 +8,21 @@ description: >-
 
 # Coordinate Recover
 
-The Plugin bundles the Runtime. Let `<skill-dir>` be the absolute directory
-containing this loaded `SKILL.md`; use the same resolver for every operation:
+Use `coordinate_agents_recover_inspect`,
+`coordinate_agents_task_status`, and `coordinate_agents_task_resume` for
+normal Plugin recovery. Recovery is facts-first and never an automatic retry.
+If MCP is unavailable, or the user explicitly requests debugging, let
+`<skill-dir>` be the absolute directory containing this loaded `SKILL.md` and
+use the bundled fallback:
 
 ```text
 node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs" ...
 ```
 
-Start with machine-readable state:
+The normal Plugin path starts with `coordinate_agents_recover_inspect`, followed
+by `coordinate_agents_task_status` or `coordinate_agents_task_resume` only when
+the recovery decision requires them. The following commands are fallback/debug
+syntax only:
 
 ```text
 node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs" task status --root "<repository>" --json

--- a/skills/coordinate-review/SKILL.md
+++ b/skills/coordinate-review/SKILL.md
@@ -8,9 +8,11 @@ description: >-
 
 # Coordinate Review
 
-The Plugin bundles the Runtime and does not require a global
-`coordinate-agents` command. Let `<skill-dir>` be the absolute directory
-containing this loaded `SKILL.md`:
+Use `coordinate_agents_task_inspect` and
+`coordinate_agents_task_review` for normal Plugin review operations. The
+Plugin bundles the Runtime and does not require a global `coordinate-agents`
+command. If MCP is unavailable, or the user explicitly requests debugging,
+let `<skill-dir>` be the absolute directory containing this loaded `SKILL.md`:
 
 ```text
 node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs" ...
@@ -18,13 +20,14 @@ node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs" ...
 
 Review only observable evidence tied to the current Task and repository:
 
-1. Read `task inspect --json` and the approved specification.
+1. Read `coordinate_agents_task_inspect` and the approved specification.
 2. Verify the implementation commit exists and inspect its diff.
 3. Re-run the relevant tests and check the recorded validation evidence.
 4. Compare every acceptance criterion and negative control.
 5. Return exactly one decision: `REVIEW_APPROVED` or `CHANGES_REQUESTED`.
-6. Record that decision through the Task API; never edit a task JSON file or
-   manually send a Bus message:
+6. Record that decision through the MCP Task API; never edit a task JSON file
+or manually send a Bus message. Only when MCP is unavailable, or for explicit
+debugging, use this fallback syntax:
 
 ```text
 node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs" task review \

--- a/skills/coordinate-setup/SKILL.md
+++ b/skills/coordinate-setup/SKILL.md
@@ -8,16 +8,30 @@ description: >-
 
 # Coordinate Setup
 
-Use this skill for first-run onboarding. The Plugin bundles the Runtime; do not
-assume `coordinate-agents` is on `PATH`. Let `<skill-dir>` be the absolute
-directory containing this loaded `SKILL.md` and use this same invocation for
-all setup operations:
+Use this skill for first-run onboarding. Use the Coordinate Agents MCP tools
+for normal setup operations; do not generate a shell command for the user.
+The Plugin bundles the Runtime, but `coordinate-agents` is not guaranteed to be
+on `PATH`.
+
+Normal MCP operations:
+
+```text
+coordinate_agents_setup_discover
+coordinate_agents_setup_configure
+```
+
+Only if MCP is unavailable, or if the user explicitly requests debugging, let
+`<skill-dir>` be the absolute directory containing this loaded `SKILL.md` and
+use the bundled fallback. The following shell syntax is not the normal Plugin
+path:
 
 ```text
 node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs" ...
 ```
 
-Run the read-only discovery operation before changing configuration:
+For the normal Plugin path, call `coordinate_agents_setup_discover` with
+`{ "root": "<repository>" }` before changing configuration. The equivalent
+fallback/debug invocation is:
 
 ```text
 node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs" setup --root "<repository>" --json
@@ -28,11 +42,14 @@ actual executable. It reports unavailable commands and distinguishes
 `detected-but-not-configured` agents. Detection never writes configuration.
 
 When the user chooses an agent, inspect its native help and perform one
-high-level setup transaction. It writes the machine-specific executable to
+high-level setup transaction through `coordinate_agents_setup_configure`. It
+writes the machine-specific executable to
 `~/.coordinate-agents/config.json`, registers/updates the project Agent,
 assigns the workflow role, checks executable availability, and returns READY
 facts. Do not manually compose `config set`, `agent add`, workflow editing,
 and doctor calls:
+
+Fallback/debug syntax only:
 
 ```text
 node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs" setup configure \

--- a/skills/coordinate-task/SKILL.md
+++ b/skills/coordinate-task/SKILL.md
@@ -9,16 +9,31 @@ description: >-
 # Coordinate Task
 
 Use this skill when the user asks Coordinate Agents to implement a feature,
-fix a bug, or build an onboarding Todo web app. The Plugin bundles the Runtime;
-let `<skill-dir>` be the absolute directory containing this `SKILL.md` and use
-the one shared entry point instead of assuming a global npm bin:
+fix a bug, or build an onboarding Todo web app. Use MCP tools for the normal
+workflow and do not make the user construct shell commands:
+
+```text
+coordinate_agents_task_create
+coordinate_agents_task_dispatch
+coordinate_agents_task_status
+coordinate_agents_task_inspect
+coordinate_agents_task_resume
+coordinate_agents_task_stop
+```
+
+Only if MCP is unavailable, or if the user explicitly requests debugging, let
+`<skill-dir>` be the absolute directory containing this `SKILL.md` and use
+the bundled fallback. The following shell syntax is fallback/debug only, not
+the normal Plugin path:
 
 ```text
 node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs" ...
 ```
 
-Create a Task instead of manually composing Agent Bus `send`, `wait`, and
-`state` calls:
+The normal Plugin call is a structured `coordinate_agents_task_create` followed
+by the other Task tools above. For standalone Runtime compatibility or explicit
+debugging, use the fallback syntax below; never expose Agent Bus `send`, `wait`,
+or `state` operations to the user:
 
 ```text
 node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs" task create --root "<repository>" --title "<task>" --json

--- a/test/mcp-server.test.mjs
+++ b/test/mcp-server.test.mjs
@@ -1,0 +1,464 @@
+import assert from 'node:assert/strict';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { createInterface } from 'node:readline';
+import { spawn, spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { createMcpServer } from '../mcp/server.mjs';
+
+const root = resolve(fileURLToPath(new URL('..', import.meta.url)));
+const cli = join(root, 'bin', 'coordinate-agents.mjs');
+const serverPath = join(root, 'mcp', 'server.mjs');
+const busTool = join(root, 'skills', 'coordinate-agents', 'scripts', 'agent-bus.mjs');
+
+function tempRepository(prefix = 'coordinate-agents-mcp-') {
+  const repository = mkdtempSync(join(tmpdir(), prefix));
+  const init = spawnSync('git', ['init', repository], { encoding: 'utf8', windowsHide: true });
+  assert.equal(init.status, 0, init.stderr || init.stdout);
+  return repository;
+}
+
+function isolatedEnvironment(home, extra = {}) {
+  return {
+    ...process.env,
+    COORDINATE_AGENTS_HOME: home,
+    HOME: home,
+    USERPROFILE: home,
+    ...extra,
+  };
+}
+
+function fixtureCommand(repository, name, mode = 'success') {
+  const bin = join(repository, 'fixture bin');
+  mkdirSync(bin, { recursive: true });
+  const source = `const fs = require('node:fs');
+const cp = require('node:child_process');
+const args = process.argv.slice(2);
+if (args[0] === '--version') { console.log('fixture-implementer 1.0.0'); process.exit(0); }
+if (process.env.FIXTURE_COUNT) fs.appendFileSync(process.env.FIXTURE_COUNT, '1');
+if (process.env.FIXTURE_MODE === 'failure') { process.stderr.write('fixture runtime failure\\n'); process.exit(7); }
+const prompt = args.join(' ');
+const task = prompt.match(/Task ID:\\s*(task-[A-Za-z0-9_-]+)/)?.[1];
+if (!task) { process.stderr.write('missing Task ID\\n'); process.exit(8); }
+const result = cp.spawnSync(process.execPath, [
+  process.env.BUS_TOOL, 'send', '--root', process.env.FIXTURE_ROOT,
+  '--from', process.env.FIXTURE_AGENT, '--to', 'codex',
+  '--type', 'IMPLEMENTATION_DONE', '--subject', 'fixture implementation done',
+  '--related-commit', process.env.FIXTURE_COMMIT || 'abc1234',
+  '--body', 'Task ID: ' + task + '\\nimplementationCommit: ' + (process.env.FIXTURE_COMMIT || 'abc1234') + '\\nEvidence: fixture tests passed',
+], { encoding: 'utf8', windowsHide: true });
+if (result.status !== 0) { process.stderr.write(result.stderr || result.stdout || 'fixture send failed'); process.exit(result.status || 9); }
+process.exit(0);
+`;
+  if (process.platform === 'win32') {
+    const script = join(bin, `${name}.cjs`);
+    writeFileSync(script, source, 'utf8');
+    const command = join(bin, `${name}.cmd`);
+    writeFileSync(command, `@"${process.execPath}" "${script}" %*\r\n`, 'utf8');
+    return command;
+  }
+  const command = join(bin, name);
+  writeFileSync(command, `#!${process.execPath}\n${source}`, 'utf8');
+  chmodSync(command, 0o755);
+  return command;
+}
+
+class StdioMcpClient {
+  constructor(env) {
+    this.child = spawn(process.execPath, [serverPath, '--stdio'], {
+      cwd: root,
+      env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    this.lines = createInterface({ input: this.child.stdout, crlfDelay: Infinity, terminal: false });
+    this.responses = [];
+    this.waiters = [];
+    this.stderr = '';
+    this.child.stderr.on('data', chunk => { this.stderr += `${chunk}`; });
+    this.lines.on('line', line => {
+      if (!line) return;
+      const response = JSON.parse(line);
+      const waiter = this.waiters.shift();
+      if (waiter) waiter(response);
+      else this.responses.push(response);
+    });
+  }
+
+  request(method, params = {}) {
+    const id = (this._id = (this._id || 0) + 1);
+    const message = { jsonrpc: '2.0', id, method, params };
+    return new Promise((resolveResponse, reject) => {
+      const timer = setTimeout(() => reject(new Error(`MCP response timeout for ${method}: ${this.stderr}`)), 15_000);
+      const resolveOnce = response => {
+        clearTimeout(timer);
+        resolveResponse(response);
+      };
+      const queued = this.responses.shift();
+      if (queued) resolveOnce(queued);
+      else this.waiters.push(resolveOnce);
+      this.child.stdin.write(`${JSON.stringify(message)}\n`);
+    });
+  }
+
+  async close() {
+    this.child.stdin.end();
+    await new Promise(resolveClose => {
+      const timer = setTimeout(() => {
+        if (!this.child.killed) this.child.kill();
+        resolveClose();
+      }, 2_000);
+      this.child.once('exit', () => {
+        clearTimeout(timer);
+        resolveClose();
+      });
+    });
+  }
+}
+
+function invokeCli(args, env) {
+  return spawnSync(process.execPath, [cli, ...args], {
+    cwd: root,
+    encoding: 'utf8',
+    env,
+    windowsHide: true,
+  });
+}
+
+function taskParityFields(task) {
+  return {
+    status: task.status,
+    round: task.round,
+    planner: task.planner,
+    implementer: task.implementer,
+    reviewer: task.reviewer,
+    spec: task.spec,
+    implementationCommit: task.implementationCommit,
+    evidence: task.evidence,
+    lastError: task.lastError,
+    reviewDecision: task.reviewDecision,
+    reviewFeedback: task.reviewFeedback,
+  };
+}
+
+test('MCP server exposes the canonical lifecycle and exact P0 tool catalog', async () => {
+  const server = createMcpServer({ root });
+  const initialized = await server.handle({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} });
+  assert.equal(initialized.result.serverInfo.name, 'coordinate-agents');
+  assert.equal(initialized.result.serverInfo.version, '2.1.2');
+  const listed = await server.handle({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
+  const names = listed.result.tools.map(tool => tool.name);
+  assert.deepEqual(names, [
+    'coordinate_agents_setup_discover',
+    'coordinate_agents_setup_configure',
+    'coordinate_agents_task_create',
+    'coordinate_agents_task_dispatch',
+    'coordinate_agents_task_status',
+    'coordinate_agents_task_inspect',
+    'coordinate_agents_task_review',
+    'coordinate_agents_task_resume',
+    'coordinate_agents_task_stop',
+    'coordinate_agents_recover_inspect',
+  ]);
+  for (const tool of listed.result.tools) {
+    assert.equal(tool.inputSchema.type, 'object');
+    assert.equal(tool.inputSchema.additionalProperties, false);
+  }
+  assert.equal((await server.handle({ jsonrpc: '2.0', id: 3, method: 'ping', params: {} })).result !== undefined, true);
+});
+
+test('MCP stdio workflow uses the same Runtime state and error contract as CLI', async () => {
+  const repository = tempRepository();
+  const home = mkdtempSync(join(tmpdir(), 'coordinate-agents-mcp-home-'));
+  const count = join(repository, 'fixture-count.txt');
+  const command = fixtureCommand(repository, 'fixture-implementer');
+  const env = isolatedEnvironment(home, {
+    FIXTURE_ROOT: repository,
+    FIXTURE_AGENT: 'fixture-implementer',
+    BUS_TOOL: busTool,
+    FIXTURE_COMMIT: 'mcp1234',
+    FIXTURE_COUNT: count,
+  });
+  const client = new StdioMcpClient(env);
+  try {
+    const init = await client.request('initialize', { protocolVersion: '2025-06-18', clientInfo: { name: 'test', version: '1' }, capabilities: {} });
+    assert.equal(init.result.protocolVersion, '2025-06-18');
+
+    const cliDiscovered = invokeCli(['setup', '--root', repository, '--json'], env);
+    assert.equal(cliDiscovered.status, 0, cliDiscovered.stderr);
+    const discovered = await client.request('tools/call', {
+      name: 'coordinate_agents_setup_discover',
+      arguments: { root: repository },
+    });
+    assert.equal(discovered.result.structuredContent.ok, true);
+    assert.equal(discovered.result.structuredContent.command, 'setup');
+    assert.deepEqual(discovered.result.structuredContent, JSON.parse(cliDiscovered.stdout));
+    assert.deepEqual(Object.keys(discovered.result.structuredContent).sort(), ['agents', 'availableCommands', 'command', 'configuredAgents', 'detectedButNotConfigured', 'ok', 'projectConfigPath', 'root', 'userConfigPath'].sort());
+
+    const setupArgs = JSON.stringify(['{prompt}']);
+    const cliConfigured = invokeCli([
+      'setup', 'configure', '--root', repository, '--agent', 'fixture-implementer',
+      '--command', command, '--adapter', 'generic-cli', '--args', setupArgs,
+      '--json',
+    ], env);
+    assert.equal(cliConfigured.status, 0, cliConfigured.stderr);
+    const configured = await client.request('tools/call', {
+      name: 'coordinate_agents_setup_configure',
+      arguments: {
+        root: repository,
+        agent: 'fixture-implementer',
+        command,
+        adapter: 'generic-cli',
+        args: ['{prompt}'],
+        role: 'implementer',
+      },
+    });
+    assert.equal(configured.result.structuredContent.ok, true);
+    assert.equal(configured.result.structuredContent.command, 'setup.configure');
+    assert.equal(configured.result.structuredContent.workflow.implementer, 'fixture-implementer');
+    assert.deepEqual(configured.result.structuredContent, JSON.parse(cliConfigured.stdout));
+
+    const cliCreatedParity = invokeCli([
+      'task', 'create', '--root', repository, '--id', 'task-cli-create-parity',
+      '--title', 'Parity create task', '--json',
+    ], env);
+    assert.equal(cliCreatedParity.status, 0, cliCreatedParity.stderr);
+    const mcpCreatedParity = await client.request('tools/call', {
+      name: 'coordinate_agents_task_create',
+      arguments: { root: repository, id: 'task-mcp-create-parity', title: 'Parity create task' },
+    });
+    assert.deepEqual(
+      taskParityFields(mcpCreatedParity.result.structuredContent.task),
+      taskParityFields(JSON.parse(cliCreatedParity.stdout).task),
+    );
+
+    const created = await client.request('tools/call', {
+      name: 'coordinate_agents_task_create',
+      arguments: { root: repository, id: 'task-mcp-e2e', title: 'MCP fixture task' },
+    });
+    assert.equal(created.result.structuredContent.ok, true);
+    assert.equal(created.result.structuredContent.task.status, 'CREATED');
+
+    const inspected = await client.request('tools/call', {
+      name: 'coordinate_agents_task_inspect',
+      arguments: { root: repository, taskId: 'task-mcp-e2e' },
+    });
+    const cliInspect = invokeCli(['task', 'inspect', '--root', repository, '--id', 'task-mcp-e2e', '--json'], env);
+    assert.equal(cliInspect.status, 0, cliInspect.stderr);
+    assert.deepEqual(inspected.result.structuredContent.task, JSON.parse(cliInspect.stdout).task);
+
+    const dispatched = await client.request('tools/call', {
+      name: 'coordinate_agents_task_dispatch',
+      arguments: { root: repository, taskId: 'task-mcp-e2e', spec: 'Implement the fixture workflow.' },
+    });
+    assert.equal(dispatched.result.structuredContent.ok, true);
+    assert.equal(dispatched.result.structuredContent.command, 'task.dispatch');
+    assert.equal(dispatched.result.structuredContent.task.status, 'REVIEWING');
+    assert.equal(dispatched.result.structuredContent.task.implementationCommit, 'mcp1234');
+    assert.equal(readFileSync(count, 'utf8'), '1');
+
+    const changes = await client.request('tools/call', {
+      name: 'coordinate_agents_task_review',
+      arguments: { root: repository, taskId: 'task-mcp-e2e', decision: 'CHANGES_REQUESTED', feedback: 'Add one fixture assertion.' },
+    });
+    assert.equal(changes.result.structuredContent.ok, true);
+    assert.equal(changes.result.structuredContent.task.status, 'CHANGES_REQUESTED');
+    assert.equal(changes.result.structuredContent.task.round, 2);
+
+    const cliReviewCreated = invokeCli([
+      'task', 'create', '--root', repository, '--id', 'task-cli-review-parity',
+      '--title', 'Parity review task', '--json',
+    ], env);
+    assert.equal(cliReviewCreated.status, 0, cliReviewCreated.stderr);
+    const cliReviewDispatched = invokeCli([
+      'task', 'dispatch', '--root', repository, '--id', 'task-cli-review-parity',
+      '--spec', 'Implement the fixture workflow.', '--json',
+    ], env);
+    assert.equal(cliReviewDispatched.status, 0, cliReviewDispatched.stderr);
+    const cliChanges = invokeCli([
+      'task', 'review', '--root', repository, '--id', 'task-cli-review-parity',
+      '--decision', 'CHANGES_REQUESTED', '--feedback', 'Add one fixture assertion.', '--json',
+    ], env);
+    assert.equal(cliChanges.status, 0, cliChanges.stderr);
+    assert.deepEqual(
+      {
+        status: JSON.parse(cliChanges.stdout).task.status,
+        round: JSON.parse(cliChanges.stdout).task.round,
+        reviewDecision: JSON.parse(cliChanges.stdout).task.reviewDecision,
+        reviewFeedback: JSON.parse(cliChanges.stdout).task.reviewFeedback,
+      },
+      {
+        status: changes.result.structuredContent.task.status,
+        round: changes.result.structuredContent.task.round,
+        reviewDecision: changes.result.structuredContent.task.reviewDecision,
+        reviewFeedback: changes.result.structuredContent.task.reviewFeedback,
+      },
+    );
+
+    const redispatched = await client.request('tools/call', {
+      name: 'coordinate_agents_task_dispatch',
+      arguments: { root: repository, taskId: 'task-mcp-e2e' },
+    });
+    assert.equal(redispatched.result.structuredContent.task.status, 'REVIEWING');
+    assert.equal(redispatched.result.structuredContent.task.round, 2);
+    assert.equal(readFileSync(count, 'utf8'), '111');
+
+    const approved = await client.request('tools/call', {
+      name: 'coordinate_agents_task_review',
+      arguments: { root: repository, taskId: 'task-mcp-e2e', decision: 'REVIEW_APPROVED' },
+    });
+    assert.equal(approved.result.structuredContent.task.status, 'APPROVED');
+    assert.match(approved.result.structuredContent.review.messagePath, /IMPLEMENT|REVIEW/i);
+
+    const recovery = await client.request('tools/call', {
+      name: 'coordinate_agents_recover_inspect',
+      arguments: { root: repository, taskId: 'task-mcp-e2e' },
+    });
+    assert.equal(recovery.result.structuredContent.ok, true);
+    assert.equal(recovery.result.structuredContent.recommendedRecovery.automaticRetry, false);
+  } finally {
+    await client.close();
+    rmSync(repository, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('MCP preserves runtime failure semantics, recovery facts, and explicit resume', async () => {
+  const repository = tempRepository('coordinate-agents-mcp-recovery-');
+  const home = mkdtempSync(join(tmpdir(), 'coordinate-agents-mcp-recovery-home-'));
+  const count = join(repository, 'fixture-count.txt');
+  const command = fixtureCommand(repository, 'fixture-recoverable');
+  const failureEnv = isolatedEnvironment(home, {
+    FIXTURE_ROOT: repository,
+    FIXTURE_AGENT: 'fixture-recoverable',
+    BUS_TOOL: busTool,
+    FIXTURE_COMMIT: 'recover123',
+    FIXTURE_COUNT: count,
+    FIXTURE_MODE: 'failure',
+  });
+  const successEnv = { ...failureEnv, FIXTURE_MODE: 'success' };
+  const clients = [];
+  try {
+    const failingClient = new StdioMcpClient(failureEnv);
+    clients.push(failingClient);
+    await failingClient.request('initialize', { protocolVersion: '2025-06-18', capabilities: {} });
+    const configured = await failingClient.request('tools/call', {
+      name: 'coordinate_agents_setup_configure',
+      arguments: {
+        root: repository,
+        agent: 'fixture-recoverable',
+        command,
+        adapter: 'generic-cli',
+        args: ['{prompt}'],
+        role: 'implementer',
+      },
+    });
+    assert.equal(configured.result.structuredContent.ok, true);
+    await failingClient.request('tools/call', {
+      name: 'coordinate_agents_task_create',
+      arguments: { root: repository, id: 'task-mcp-recovery', title: 'MCP recovery task', spec: 'Recover the fixture workflow.' },
+    });
+
+    const failed = await failingClient.request('tools/call', {
+      name: 'coordinate_agents_task_dispatch',
+      arguments: { root: repository, taskId: 'task-mcp-recovery' },
+    });
+    assert.equal(failed.result.isError, true);
+    assert.equal(failed.result.structuredContent.ok, false);
+    assert.equal(failed.result.structuredContent.error.code, 'AGENT_EXIT_NONZERO');
+    assert.equal(readFileSync(count, 'utf8'), '1');
+
+    const recovery = await failingClient.request('tools/call', {
+      name: 'coordinate_agents_recover_inspect',
+      arguments: { root: repository, taskId: 'task-mcp-recovery' },
+    });
+    assert.equal(recovery.result.structuredContent.task.status, 'ERROR');
+    assert.equal(recovery.result.structuredContent.recommendedRecovery.automaticRetry, false);
+    assert.equal(recovery.result.structuredContent.recommendedRecovery.resumeRequired, true);
+
+    const blockedRetry = await failingClient.request('tools/call', {
+      name: 'coordinate_agents_task_dispatch',
+      arguments: { root: repository, taskId: 'task-mcp-recovery' },
+    });
+    assert.equal(blockedRetry.result.isError, true);
+    assert.equal(blockedRetry.result.structuredContent.error.code, 'TASK_STATE_CONFLICT');
+    assert.equal(readFileSync(count, 'utf8'), '1');
+
+    const resumed = await failingClient.request('tools/call', {
+      name: 'coordinate_agents_task_resume',
+      arguments: { root: repository, taskId: 'task-mcp-recovery' },
+    });
+    assert.equal(resumed.result.structuredContent.task.status, 'SPEC_READY');
+    await failingClient.close();
+    clients.splice(clients.indexOf(failingClient), 1);
+
+    const retryClient = new StdioMcpClient(successEnv);
+    clients.push(retryClient);
+    await retryClient.request('initialize', { protocolVersion: '2025-06-18', capabilities: {} });
+    const retried = await retryClient.request('tools/call', {
+      name: 'coordinate_agents_task_dispatch',
+      arguments: { root: repository, taskId: 'task-mcp-recovery' },
+    });
+    assert.equal(retried.result.structuredContent.task.status, 'REVIEWING');
+    assert.equal(readFileSync(count, 'utf8'), '11');
+  } finally {
+    for (const client of clients) await client.close();
+    rmSync(repository, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('MCP domain failures are structured and do not become protocol errors', async () => {
+  const repository = tempRepository('coordinate-agents-mcp-error-');
+  const home = mkdtempSync(join(tmpdir(), 'coordinate-agents-mcp-error-home-'));
+  const server = createMcpServer({ root });
+  try {
+    const created = await server.handle({
+      jsonrpc: '2.0', id: 10, method: 'tools/call',
+      params: { name: 'coordinate_agents_task_create', arguments: { root: repository, id: 'task-error', title: 'Error task', spec: 'approved' } },
+    });
+    assert.equal(created.result.structuredContent.ok, true);
+    const configPath = join(repository, '.agent-bus', 'config.json');
+    const config = JSON.parse(readFileSync(configPath, 'utf8'));
+    config.agents.find(agent => agent.id === 'antigravity').command = 'missing-coordinate-agents-mcp-executable';
+    writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+    const missing = await server.handle({
+      jsonrpc: '2.0', id: 11, method: 'tools/call',
+      params: { name: 'coordinate_agents_task_dispatch', arguments: { root: repository, taskId: 'task-error' } },
+    });
+    assert.equal(missing.result.isError, true);
+    assert.equal(missing.result.structuredContent.ok, false);
+    assert.equal(missing.result.structuredContent.command, 'task.dispatch');
+    assert.equal(missing.result.structuredContent.error.code, 'EXECUTABLE_NOT_FOUND');
+    assert.equal(missing.error, undefined);
+    const invalidTool = await server.handle({ jsonrpc: '2.0', id: 12, method: 'tools/call', params: { name: 'no_such_tool', arguments: {} } });
+    assert.equal(invalidTool.error.code, -32601);
+    assert.equal(existsSync(join(repository, '.agent-bus', 'tasks', 'task-error.json')), true);
+  } finally {
+    rmSync(repository, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('Protocol schemas and Plugin MCP packaging stay version-stable', () => {
+  const packageJson = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
+  const pluginJson = JSON.parse(readFileSync(join(root, '.codex-plugin', 'plugin.json'), 'utf8'));
+  assert.equal(packageJson.version, '2.1.2');
+  assert.equal(pluginJson.version, '2.1.2');
+  assert.equal(pluginJson.mcpServers, './.mcp.json');
+  assert.deepEqual(JSON.parse(readFileSync(join(root, '.mcp.json'), 'utf8')).mcpServers['coordinate-agents'].args, ['./mcp/server.mjs', '--stdio']);
+  for (const name of ['task.schema.json', 'runtime-error.schema.json', 'evidence.schema.json']) {
+    const schema = JSON.parse(readFileSync(join(root, 'schemas', name), 'utf8'));
+    assert.equal(schema.$schema, 'https://json-schema.org/draft/2020-12/schema');
+  }
+});


### PR DESCRIPTION
This pull request introduces the new Coordinate Agents MCP (Machine Coordination Protocol) interface as the primary structured machine path for the plugin, updates documentation to reflect this change, and adds configuration for the MCP server. The key changes clarify that Skills now use the MCP tools by default, with the previous shell command interface retained only as a fallback for debugging or compatibility. Documentation and configuration files are updated to describe and support the MCP workflow.

**MCP Server Integration and Configuration**

* Added an `.mcp.json` file specifying how to launch the local MCP server, and referenced it in `.codex-plugin/plugin.json` for plugin discovery and integration. [[1]](diffhunk://#diff-d5d3368a61f8d02e085f7a4cb666ee471cf5383690a04b64c839c6ae2080ceb9R1-R9) [[2]](diffhunk://#diff-7952afb62f76de49cd9a374265eb78a3b4d7e14a51eff6317314513ab32b436bR12)

**Documentation: MCP Workflow and Usage**

* Added a new `docs/mcp.md` file documenting the MCP tools, installation, lifecycle, tool schemas, error handling, fallback behavior, and security.
* Updated `AI_INSTALL.md`, `README.md`, and `README.zh-CN.md` to describe the MCP tools as the default machine path, clarify fallback/debugging scenarios, and explain the structured workflow. [[1]](diffhunk://#diff-e3c18f8929d8be0032f4c35a13e06a2fdd9405eb016a197da499cc62864c46a5L58-R65) [[2]](diffhunk://#diff-e3c18f8929d8be0032f4c35a13e06a2fdd9405eb016a197da499cc62864c46a5L70-R76) [[3]](diffhunk://#diff-e3c18f8929d8be0032f4c35a13e06a2fdd9405eb016a197da499cc62864c46a5L120-R128) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L62-R90) [[5]](diffhunk://#diff-13f564fa6ce92394f8423bbcea359aef7e9ebc4f79763efc0d791d9ce5b6f987L57-R84)

**Documentation Navigation and Linking**

* Added the new MCP documentation page to the sidebar navigation (`docs/_config.yml`) and linked to it from `docs/llms.txt` and `llms.txt`. [[1]](diffhunk://#diff-f64371f310bcd3bbf6ead5827d929a4eb13b7516806d6658485a996e39eb2556R14) [[2]](diffhunk://#diff-c3766b99af4d08bfc9cdf445f24886eba90f863437970d4eee791c8e6053e3d8R16) [[3]](diffhunk://#diff-c3766b99af4d08bfc9cdf445f24886eba90f863437970d4eee791c8e6053e3d8L32-R39)

These changes establish MCP as the structured, local stdio interface for all plugin Skills, improving reliability and maintainability, while maintaining compatibility with the previous CLI-based fallback path.