### PR TITLE
fix: expose bundled MCP tools in Codex

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "coordinate-agents": {
+    "coordinate_agents": {
       "command": "node",
       "args": ["./mcp/server.mjs", "--stdio"],
       "cwd": "."

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ that concrete path. The resolver starts the one canonical `bin/coordinate-agents
 payload. Do not silently retry between MCP and fallback.
 
 See [MCP tools and integration](./docs/mcp.md) for the stdio lifecycle, schemas,
-error semantics, fallback behavior, and release safety.
+error semantics, fallback behavior, and release safety. If the Plugin loads but
+the tools are not callable, use the [MCP troubleshooting guide](./docs/MCP_TROUBLESHOOTING.md).
 
 ## Advanced: standalone npm Runtime and debugging
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -81,7 +81,7 @@ node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs" <command> ...
 Plugin 载荷中启动唯一的 `bin/coordinate-agents.mjs`。不要在 MCP 与 fallback 之间静默循环重试。
 
 详见 [MCP 工具与集成文档](./docs/mcp.md)，其中包含 stdio 生命周期、schema、错误语义、fallback
-行为和 release safety。
+行为和 release safety。如果 Plugin 已加载但工具不可调用，请参阅 [MCP 排障指南](./docs/MCP_TROUBLESHOOTING.md)。
 
 ## 高级：standalone npm Runtime 与调试
 

--- a/docs/MCP_TROUBLESHOOTING.md
+++ b/docs/MCP_TROUBLESHOOTING.md
@@ -1,0 +1,199 @@
+---
+layout: default
+title: MCP troubleshooting
+description: Diagnose a loaded Coordinate Agents Plugin whose MCP tools are not callable in Codex.
+---
+
+# MCP troubleshooting
+
+Use this page when the `coordinate-agents` Skill is visible but Codex says that
+`coordinate_agents_setup_discover` (or another Coordinate Agents tool) is not a
+callable MCP tool.
+
+The checks must be made in order. A visible Skill does not prove that the
+Plugin payload was refreshed, that `.mcp.json` was ingested, or that the MCP
+server completed `initialize` and `tools/list`.
+
+## 1. Confirm the installed Plugin payload
+
+The Plugin and the MCP server are shipped together. Confirm the installed
+Plugin is the intended `2.1.2` payload and inspect its actual root, not only the
+marketplace entry:
+
+```powershell
+codex plugin list
+codex plugin list --json
+```
+
+At that installed root, verify that all of these exist:
+
+```text
+.codex-plugin/plugin.json
+.mcp.json
+mcp/server.mjs
+skills/coordinate-agents/scripts/runtime-services.mjs
+```
+
+`plugin.json` must contain `"mcpServers": "./.mcp.json"`. A cached Plugin can
+still report version `2.1.2` while pointing at an older Git revision that does
+not contain the MCP payload. The version string alone is not a cache refresh
+proof.
+
+For a Git marketplace that should track the release branch, add the exact ref
+and reinstall the Plugin. The marketplace source is separate from the Plugin
+name:
+
+```powershell
+codex plugin remove coordinate-agents@coordinate-agents
+codex plugin marketplace remove coordinate-agents
+codex plugin marketplace add hogancv/coordinate-agents --ref 2.1.2
+codex plugin add coordinate-agents@coordinate-agents
+```
+
+For local development, add the checkout itself as a local marketplace and
+reinstall the Plugin from that source:
+
+```powershell
+codex plugin marketplace add "C:\path\to\coordinate-agents"
+codex plugin add coordinate-agents@coordinate-agents
+```
+
+Do not delete the whole Codex home directory. If an existing marketplace has
+the same name, refresh or remove only that marketplace before adding the
+intended source.
+
+## 2. Confirm MCP registration
+
+Inspect the server registration separately from Plugin discovery:
+
+```powershell
+codex mcp list --json
+codex mcp get coordinate_agents --json
+codex mcp get coordinate-agents --json
+```
+
+The bundled server identifier is `coordinate_agents`. The Plugin name remains
+`coordinate-agents`, and the ten tool names remain unchanged. A missing entry
+means the failure is before MCP process startup; do not change Task Runtime or
+Agent Bus code to fix that layer.
+
+The expected registration is equivalent to:
+
+```json
+{
+  "name": "coordinate_agents",
+  "transport": {
+    "type": "stdio",
+    "command": "node",
+    "args": ["./mcp/server.mjs", "--stdio"],
+    "cwd": "<installed Plugin root>"
+  }
+}
+```
+
+The `cwd` must be the installed Plugin root, not the current project, Codex
+process directory, or the user home directory. The server resolves its own
+imports from its file location, so its runtime remains independent of the
+launching working directory.
+
+## 3. Run the standalone handshake
+
+From any working directory, run the packaged self-test:
+
+```powershell
+node "<installed Plugin root>\mcp\self-test.mjs"
+```
+
+Expected output:
+
+```text
+MCP server: OK
+Protocol: 2025-06-18
+Tools: 10
+```
+
+The self-test launches the real stdio subprocess, sends `initialize`, sends
+`notifications/initialized`, then sends `tools/list`. It also starts the
+server with an independent temporary working directory. A failure here is a
+server, Node, packaging, or path problem; a passing result does not by itself
+prove that Codex injected the tools into an active conversation.
+
+The stdio transport is newline-delimited JSON-RPC. stdout must contain only
+valid MCP messages. Diagnostics are allowed on stderr only.
+
+## 4. Collect optional stderr diagnostics
+
+Enable diagnostics without contaminating the MCP stream:
+
+```powershell
+$env:COORDINATE_AGENTS_MCP_DEBUG = "1"
+node "<installed Plugin root>\mcp\self-test.mjs"
+Remove-Item Env:COORDINATE_AGENTS_MCP_DEBUG
+```
+
+The server reports startup, server/runtime roots, negotiated protocol, tool
+count, `initialize`, and `tools/list` on stderr. Never redirect these messages
+into stdout or add startup banners to the stdio process.
+
+## 5. Complete the Codex restart
+
+MCP processes and Plugin payloads can live at the App/session boundary. After
+refreshing a Plugin or changing `.mcp.json`:
+
+1. Close Codex App completely.
+2. Confirm the related Codex process has exited.
+3. Reopen Codex App.
+4. Start a new thread with the repository as its project.
+5. Ask Codex to list the Coordinate Agents MCP tools without using shell or CLI fallback.
+
+Creating only a new thread is not a substitute for a complete App restart when
+the Plugin cache or MCP registry changed.
+
+## 6. Isolate Plugin ingestion from Codex MCP support
+
+Register the same server directly, using an absolute path to the installed
+Plugin payload:
+
+```powershell
+codex mcp add coordinate_agents -- node "<installed Plugin root>\mcp\server.mjs" --stdio
+codex mcp list --json
+```
+
+Restart Codex App and test a new thread. Remove the temporary registration when
+finished:
+
+```powershell
+codex mcp remove coordinate_agents
+```
+
+Interpret the result as follows:
+
+| Result | Boundary indicated |
+| --- | --- |
+| Direct registration works, bundled Plugin does not | Plugin payload, marketplace ref/cache, manifest, server id, or Plugin cwd |
+| Both fail, standalone handshake passes | Codex host/session MCP injection or host compatibility |
+| Direct registration and handshake fail | Server process, Node PATH, packaging, framing, or protocol implementation |
+
+Do not describe a standalone pass as proof of an in-thread tool invocation.
+
+## Expected tool catalog
+
+The server must expose exactly these high-level tools:
+
+```text
+coordinate_agents_setup_discover
+coordinate_agents_setup_configure
+coordinate_agents_task_create
+coordinate_agents_task_dispatch
+coordinate_agents_task_status
+coordinate_agents_task_inspect
+coordinate_agents_task_review
+coordinate_agents_task_resume
+coordinate_agents_task_stop
+coordinate_agents_recover_inspect
+```
+
+The CLI fallback through `runtime-entry.mjs` remains available for standalone,
+compatibility, and explicit debugging scenarios. It is not evidence that the
+Codex App MCP path is healthy and must not be silently retried as a substitute
+for a missing callable tool.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -12,6 +12,7 @@ header_pages:
   - install-with-ai.md
   - protocol.md
   - mcp.md
+  - MCP_TROUBLESHOOTING.md
   - security.md
   - troubleshooting.md
   - faq.md

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -14,6 +14,7 @@ Codex role (Reference planner/reviewer): https://hogancv.github.io/coordinate-ag
 Antigravity role (Reference implementer): https://hogancv.github.io/coordinate-agents/antigravity-cli.html
 Protocol: https://hogancv.github.io/coordinate-agents/protocol.html
 MCP tools: https://hogancv.github.io/coordinate-agents/mcp.html
+MCP troubleshooting: https://hogancv.github.io/coordinate-agents/MCP_TROUBLESHOOTING.html
 Security: https://hogancv.github.io/coordinate-agents/security.html
 Troubleshooting: https://hogancv.github.io/coordinate-agents/troubleshooting.html
 Comparison: https://hogancv.github.io/coordinate-agents/comparison.html

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -28,7 +28,7 @@ starts as a local child process:
 ```json
 {
   "mcpServers": {
-    "coordinate-agents": {
+    "coordinate_agents": {
       "command": "node",
       "args": ["./mcp/server.mjs", "--stdio"],
       "cwd": "."
@@ -83,7 +83,8 @@ block. Business failures use MCP `isError: true`; they are not converted to a
 new `MCP_ERROR_*` code. JSON-RPC protocol errors are reserved for malformed
 requests, unknown methods/tools, or invalid tool arguments.
 
-The server reads its name as `coordinate-agents` and its version from the
+The MCP server identifier is `coordinate_agents`; its product/server name remains
+`coordinate-agents`. The version is read from the
 bundled package manifest. Protocol compatibility is not represented as a
 second product version. Task records continue to use `schemaVersion: 1`.
 

--- a/llms.txt
+++ b/llms.txt
@@ -14,6 +14,7 @@ Codex role (Reference planner/reviewer): https://hogancv.github.io/coordinate-ag
 Antigravity role (Reference implementer): https://hogancv.github.io/coordinate-agents/antigravity-cli.html
 Protocol: https://hogancv.github.io/coordinate-agents/protocol.html
 MCP tools: https://hogancv.github.io/coordinate-agents/mcp.html
+MCP troubleshooting: https://hogancv.github.io/coordinate-agents/MCP_TROUBLESHOOTING.html
 Security: https://hogancv.github.io/coordinate-agents/security.html
 Troubleshooting: https://hogancv.github.io/coordinate-agents/troubleshooting.html
 Comparison: https://hogancv.github.io/coordinate-agents/comparison.html

--- a/mcp/self-test.mjs
+++ b/mcp/self-test.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const serverPath = join(root, 'mcp', 'server.mjs');
+const expectedTools = [
+  'coordinate_agents_setup_discover',
+  'coordinate_agents_setup_configure',
+  'coordinate_agents_task_create',
+  'coordinate_agents_task_dispatch',
+  'coordinate_agents_task_status',
+  'coordinate_agents_task_inspect',
+  'coordinate_agents_task_review',
+  'coordinate_agents_task_resume',
+  'coordinate_agents_task_stop',
+  'coordinate_agents_recover_inspect',
+];
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function responseFor(responses, id) {
+  return responses.find(response => response?.id === id);
+}
+
+const isolatedCwd = mkdtempSync(join(tmpdir(), 'Coordinate Agents MCP Self Test '));
+try {
+  const input = [
+    {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-06-18',
+        capabilities: {},
+        clientInfo: { name: 'coordinate-agents-self-test', version: '1.0.0' },
+      },
+    },
+    { jsonrpc: '2.0', method: 'notifications/initialized', params: {} },
+    { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} },
+  ].map(message => JSON.stringify(message)).join('\n') + '\n';
+
+  const result = spawnSync(process.execPath, [serverPath, '--stdio'], {
+    cwd: isolatedCwd,
+    env: process.env,
+    input,
+    encoding: 'utf8',
+    windowsHide: true,
+  });
+
+  const stderr = `${result.stderr || ''}`.trim();
+  assert(result.error === undefined, `failed to start MCP server: ${result.error?.message || result.error}`);
+  assert(result.status === 0, `MCP server exited with ${result.status}: ${stderr}`);
+
+  const lines = `${result.stdout || ''}`.split(/\r?\n/).filter(Boolean);
+  assert(lines.length === 2, `expected two MCP responses, received ${lines.length}`);
+  const responses = lines.map((line, index) => {
+    try {
+      return JSON.parse(line);
+    } catch (error) {
+      throw new Error(`stdout line ${index + 1} is not valid JSON: ${error.message}`);
+    }
+  });
+
+  const initialized = responseFor(responses, 1);
+  assert(initialized?.jsonrpc === '2.0' && initialized.result, 'initialize did not return a JSON-RPC result');
+  assert(initialized.result.protocolVersion === '2025-06-18', `unexpected protocol: ${initialized.result.protocolVersion}`);
+  assert(initialized.result.capabilities?.tools, 'initialize did not advertise tools capability');
+
+  const listed = responseFor(responses, 2);
+  assert(listed?.jsonrpc === '2.0' && listed.result, 'tools/list did not return a JSON-RPC result');
+  const names = listed.result.tools?.map(tool => tool.name) || [];
+  assert(names.length === expectedTools.length, `expected ${expectedTools.length} tools, received ${names.length}`);
+  assert(JSON.stringify(names) === JSON.stringify(expectedTools), 'tools/list returned an unexpected catalog');
+
+  if (stderr) process.stderr.write(`${stderr}\n`);
+  console.log('MCP server: OK');
+  console.log(`Protocol: ${initialized.result.protocolVersion}`);
+  console.log(`Tools: ${names.length}`);
+} catch (error) {
+  console.error(`MCP server: FAILED: ${error.message}`);
+  process.exitCode = 1;
+} finally {
+  rmSync(isolatedCwd, { recursive: true, force: true });
+}

--- a/mcp/server.mjs
+++ b/mcp/server.mjs
@@ -14,6 +14,9 @@ const SERVER_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const PROTOCOL_VERSION = '2025-06-18';
 const SUPPORTED_PROTOCOL_VERSIONS = new Set(['2025-03-26', '2025-06-18', '2025-11-25']);
 const MAX_LINE_LENGTH = 1024 * 1024;
+const DEBUG_ENABLED = new Set(['1', 'true', 'yes']).has(
+  `${process.env.COORDINATE_AGENTS_MCP_DEBUG || ''}`.trim().toLowerCase(),
+);
 
 function readJson(path) {
   try { return JSON.parse(readFileSync(path, 'utf8')); } catch { return null; }
@@ -24,6 +27,11 @@ function serverVersion(root = SERVER_ROOT) {
   if (packageJson?.version) return `${packageJson.version}`;
   const pluginJson = readJson(join(root, '.codex-plugin', 'plugin.json'));
   return `${pluginJson?.version || '0.0.0'}`;
+}
+
+function debugLog(enabled, message) {
+  if (!enabled) return;
+  process.stderr.write(`[coordinate-agents:mcp] ${message}\n`);
 }
 
 const stringProperty = (description, { minLength = 1 } = {}) => ({
@@ -241,7 +249,7 @@ function initializeResult(root, params = {}) {
   const requested = params.protocolVersion;
   return {
     protocolVersion: SUPPORTED_PROTOCOL_VERSIONS.has(requested) ? requested : PROTOCOL_VERSION,
-    capabilities: { tools: {} },
+    capabilities: { tools: { listChanged: false } },
     serverInfo: { name: 'coordinate-agents', version: serverVersion(root) },
     instructions: 'Use Coordinate Agents tools for setup, durable Task operations, review, and recovery facts. Agent Bus transport and release actions remain internal or user-gated.',
   };
@@ -249,14 +257,27 @@ function initializeResult(root, params = {}) {
 
 export function createMcpServer({ root = SERVER_ROOT } = {}) {
   const serverRoot = resolve(root);
+  const debug = DEBUG_ENABLED;
+  const log = message => debugLog(debug, message);
+  log('server starting');
+  log(`server root: ${serverRoot}`);
+  log(`runtime root: operation input (server root is ${serverRoot})`);
+  log(`protocol version: ${PROTOCOL_VERSION}`);
+  log(`tool count: ${TOOL_DEFINITIONS.length}`);
   return {
     async handle(message) {
       if (!isObject(message) || message.jsonrpc !== '2.0') return protocolError(message?.id, -32600, 'Invalid JSON-RPC request.');
       const { id = null, method, params = {} } = message;
       if (method === 'notifications/initialized' || method === 'notifications/cancelled' || method === '$/cancelRequest') return null;
-      if (method === 'initialize') return { jsonrpc: '2.0', id, result: initializeResult(serverRoot, params) };
+      if (method === 'initialize') {
+        log(`initialize received: protocolVersion=${params.protocolVersion || 'missing'}`);
+        return { jsonrpc: '2.0', id, result: initializeResult(serverRoot, params) };
+      }
       if (method === 'ping') return { jsonrpc: '2.0', id, result: {} };
-      if (method === 'tools/list') return { jsonrpc: '2.0', id, result: { tools: TOOL_DEFINITIONS.map(({ operation, command, ...tool }) => tool) } };
+      if (method === 'tools/list') {
+        log('tools/list received');
+        return { jsonrpc: '2.0', id, result: { tools: TOOL_DEFINITIONS.map(({ operation, command, ...tool }) => tool) } };
+      }
       if (method !== 'tools/call') return protocolError(id, -32601, `Method not found: ${method}`);
       if (!isObject(params) || typeof params.name !== 'string') return protocolError(id, -32602, 'tools/call requires a tool name.');
       const tool = TOOL_MAP.get(params.name);

--- a/mcp/server.mjs
+++ b/mcp/server.mjs
@@ -259,7 +259,7 @@ export function createMcpServer({ root = SERVER_ROOT } = {}) {
   const serverRoot = resolve(root);
   const debug = DEBUG_ENABLED;
   const log = message => debugLog(debug, message);
-  log('server starting');
+  log('MCP server starting');
   log(`server root: ${serverRoot}`);
   log(`runtime root: operation input (server root is ${serverRoot})`);
   log(`protocol version: ${PROTOCOL_VERSION}`);

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "llms.txt",
     "docs/llms.txt",
     "docs/mcp.md",
+    "docs/MCP_TROUBLESHOOTING.md",
     "LICENSE",
     "assets"
   ],
@@ -32,6 +33,7 @@
     "check": "node bin/coordinate-agents.mjs --help && npm run check:llms && npm test",
     "prepack": "npm run sync:llms && npm run check",
     "demo": "node scripts/demo.mjs",
+    "mcp:self-test": "node mcp/self-test.mjs",
     "release:check": "npm ci && npm run check && npm pack --dry-run"
   },
   "engines": {

--- a/test/mcp-server.test.mjs
+++ b/test/mcp-server.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import {
   chmodSync,
+  cpSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -19,6 +20,7 @@ import { createMcpServer } from '../mcp/server.mjs';
 const root = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const cli = join(root, 'bin', 'coordinate-agents.mjs');
 const serverPath = join(root, 'mcp', 'server.mjs');
+const selfTestPath = join(root, 'mcp', 'self-test.mjs');
 const busTool = join(root, 'skills', 'coordinate-agents', 'scripts', 'agent-bus.mjs');
 
 function tempRepository(prefix = 'coordinate-agents-mcp-') {
@@ -74,9 +76,9 @@ process.exit(0);
 }
 
 class StdioMcpClient {
-  constructor(env) {
+  constructor(env, cwd = root) {
     this.child = spawn(process.execPath, [serverPath, '--stdio'], {
-      cwd: root,
+      cwd,
       env,
       stdio: ['pipe', 'pipe', 'pipe'],
       windowsHide: true,
@@ -156,6 +158,7 @@ test('MCP server exposes the canonical lifecycle and exact P0 tool catalog', asy
   const initialized = await server.handle({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} });
   assert.equal(initialized.result.serverInfo.name, 'coordinate-agents');
   assert.equal(initialized.result.serverInfo.version, '2.1.2');
+  assert.equal(initialized.result.capabilities.tools.listChanged, false);
   const listed = await server.handle({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
   const names = listed.result.tools.map(tool => tool.name);
   assert.deepEqual(names, [
@@ -171,10 +174,81 @@ test('MCP server exposes the canonical lifecycle and exact P0 tool catalog', asy
     'coordinate_agents_recover_inspect',
   ]);
   for (const tool of listed.result.tools) {
+    assert.equal(typeof tool.name, 'string');
+    assert.equal(typeof tool.description, 'string');
     assert.equal(tool.inputSchema.type, 'object');
     assert.equal(tool.inputSchema.additionalProperties, false);
+    assert.ok(Array.isArray(tool.inputSchema.required));
+    assert.ok(tool.inputSchema.properties && typeof tool.inputSchema.properties === 'object');
+    for (const required of tool.inputSchema.required) assert.ok(required in tool.inputSchema.properties);
+    assert.doesNotMatch(JSON.stringify(tool), /undefined/);
   }
   assert.equal((await server.handle({ jsonrpc: '2.0', id: 3, method: 'ping', params: {} })).result !== undefined, true);
+});
+
+test('MCP stdio is protocol-pure, debuggable on stderr, cwd-independent, and path-safe', async () => {
+  const independentCwd = mkdtempSync(join(tmpdir(), 'Coordinate Agents MCP cwd '));
+  const debugClient = new StdioMcpClient(isolatedEnvironment(independentCwd, {
+    COORDINATE_AGENTS_MCP_DEBUG: '1',
+  }), independentCwd);
+  try {
+    const initialized = await debugClient.request('initialize', {
+      protocolVersion: '2025-06-18',
+      capabilities: {},
+      clientInfo: { name: 'debug-test', version: '1' },
+    });
+    assert.equal(initialized.result.protocolVersion, '2025-06-18');
+    const listed = await debugClient.request('tools/list');
+    assert.equal(listed.result.tools.length, 10);
+  } finally {
+    await debugClient.close();
+  }
+  assert.match(debugClient.stderr, /server starting/);
+  assert.match(debugClient.stderr, /server root:/);
+  assert.match(debugClient.stderr, /runtime root:/);
+  assert.match(debugClient.stderr, /protocol version: 2025-06-18/);
+  assert.match(debugClient.stderr, /tool count: 10/);
+  assert.match(debugClient.stderr, /initialize received/);
+  assert.match(debugClient.stderr, /tools\/list received/);
+  const selfTest = spawnSync(process.execPath, [selfTestPath], {
+    cwd: independentCwd,
+    encoding: 'utf8',
+    env: isolatedEnvironment(independentCwd),
+    windowsHide: true,
+  });
+  assert.equal(selfTest.status, 0, selfTest.stderr || selfTest.stdout);
+  assert.match(selfTest.stdout, /MCP server: OK/);
+  assert.match(selfTest.stdout, /Protocol: 2025-06-18/);
+  assert.match(selfTest.stdout, /Tools: 10/);
+  rmSync(independentCwd, { recursive: true, force: true });
+
+  const pluginRoot = mkdtempSync(join(tmpdir(), 'Coordinate Agents Plugin Fixture '));
+  try {
+    for (const entry of ['mcp', 'skills', 'bin', '.codex-plugin']) {
+      cpSync(join(root, entry), join(pluginRoot, entry), { recursive: true });
+    }
+    cpSync(join(root, 'package.json'), join(pluginRoot, 'package.json'));
+    const handshake = [
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18', capabilities: {} } },
+      { jsonrpc: '2.0', method: 'notifications/initialized', params: {} },
+      { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} },
+    ].map(message => JSON.stringify(message)).join('\n') + '\n';
+    const launched = spawnSync(process.execPath, ['./mcp/server.mjs', '--stdio'], {
+      cwd: pluginRoot,
+      encoding: 'utf8',
+      env: isolatedEnvironment(pluginRoot),
+      input: handshake,
+      windowsHide: true,
+    });
+    assert.equal(launched.status, 0, launched.stderr || launched.stdout);
+    assert.equal(launched.stderr, '');
+    const responses = launched.stdout.trim().split(/\r?\n/).map(line => JSON.parse(line));
+    assert.equal(responses.length, 2);
+    assert.equal(responses[0].result.protocolVersion, '2025-06-18');
+    assert.equal(responses[1].result.tools.length, 10);
+  } finally {
+    rmSync(pluginRoot, { recursive: true, force: true });
+  }
 });
 
 test('MCP stdio workflow uses the same Runtime state and error contract as CLI', async () => {
@@ -456,7 +530,15 @@ test('Protocol schemas and Plugin MCP packaging stay version-stable', () => {
   assert.equal(packageJson.version, '2.1.2');
   assert.equal(pluginJson.version, '2.1.2');
   assert.equal(pluginJson.mcpServers, './.mcp.json');
-  assert.deepEqual(JSON.parse(readFileSync(join(root, '.mcp.json'), 'utf8')).mcpServers['coordinate-agents'].args, ['./mcp/server.mjs', '--stdio']);
+  const mcpConfig = JSON.parse(readFileSync(join(root, '.mcp.json'), 'utf8'));
+  const serverIds = Object.keys(mcpConfig.mcpServers);
+  assert.deepEqual(serverIds, ['coordinate_agents']);
+  assert.equal(serverIds.some(id => id.includes('-')), false);
+  assert.deepEqual(mcpConfig.mcpServers.coordinate_agents.args, ['./mcp/server.mjs', '--stdio']);
+  assert.equal(mcpConfig.mcpServers.coordinate_agents.cwd, '.');
+  assert.equal(existsSync(join(root, 'mcp', 'self-test.mjs')), true);
+  assert.equal(packageJson.scripts['mcp:self-test'], 'node mcp/self-test.mjs');
+  assert.equal(packageJson.files.includes('docs/MCP_TROUBLESHOOTING.md'), true);
   for (const name of ['task.schema.json', 'runtime-error.schema.json', 'evidence.schema.json']) {
     const schema = JSON.parse(readFileSync(join(root, 'schemas', name), 'utf8'));
     assert.equal(schema.$schema, 'https://json-schema.org/draft/2020-12/schema');

--- a/test/mcp-server.test.mjs
+++ b/test/mcp-server.test.mjs
@@ -203,7 +203,7 @@ test('MCP stdio is protocol-pure, debuggable on stderr, cwd-independent, and pat
   } finally {
     await debugClient.close();
   }
-  assert.match(debugClient.stderr, /server starting/);
+  assert.match(debugClient.stderr, /MCP server starting/);
   assert.match(debugClient.stderr, /server root:/);
   assert.match(debugClient.stderr, /runtime root:/);
   assert.match(debugClient.stderr, /protocol version: 2025-06-18/);


### PR DESCRIPTION
## Summary
- register the bundled MCP server under the Codex-safe `coordinate_agents` identifier
- add stderr-only MCP diagnostics and a real stdio self-test
- add regression coverage and troubleshooting docs for stale marketplace/plugin caches

## Root cause
Codex was using the `main` marketplace snapshot at commit `402337e`. That cached payload reported version `2.1.2` but lacked `.mcp.json`, `mcp/server.mjs`, and the plugin `mcpServers` declaration, so Skills loaded while no MCP server was registered.

## Verification
- `npm ci`
- `npm run check` (107 tests)
- `npm run demo`
- `npm pack --dry-run`
- Skill/plugin validators
- installed-cache MCP self-test: Protocol `2025-06-18`, Tools `10`

Version remains `2.1.2`. No Task Runtime or Agent Bus changes.