### PR TITLE
Codex/fix windows event journal lock

### DIFF
--- a/test/inspector.test.mjs
+++ b/test/inspector.test.mjs
@@ -306,7 +306,7 @@ test('Inspector metadata is included in the package payload and CLI help', () =>
   const packageJson = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
   assert.ok(packageJson.files.includes('inspector'));
   assert.ok(packageJson.files.includes('docs/inspector.md'));
-  const help = spawnSync(process.execPath, [cli, '--help'], { cwd: root, encoding: 'utf8', windowsHide: true });
+  const help = spawnSync(process.execPath, [cli, 'help', '--lang', 'en'], { cwd: root, encoding: 'utf8', windowsHide: true });
   assert.equal(help.status, 0);
   assert.match(help.stdout, /inspector\s+Start the local read-only Web UI Inspector/);
   assert.match(help.stdout, /--port <port>/);

--- a/test/mcp-server.test.mjs
+++ b/test/mcp-server.test.mjs
@@ -589,7 +589,7 @@ test('MCP exposes the bounded persistent Session lifecycle through the canonical
   const repository = tempRepository('coordinate-agents-mcp-session-');
   const home = mkdtempSync(join(canonicalTmpdir, 'coordinate-agents-mcp-session-home-'));
   const client = new StdioMcpClient(isolatedEnvironment(home));
-  const source = "console.log('session-ready'); process.stdin.setEncoding('utf8'); process.stdin.on('data', chunk => console.log('received:' + chunk)); setInterval(() => {}, 10000);";
+  const source = "console.log('session-ready'); process.stdin.setEncoding('utf8'); process.stdin.on('data', chunk => console.log('received:' + chunk)); setInterval(() => {}, 120_000);";
   try {
     await client.request('initialize', { protocolVersion: '2025-06-18', capabilities: {} });
     const configured = await client.request('tools/call', {


### PR DESCRIPTION
This pull request makes minor adjustments to test files to improve test reliability and output consistency. The changes include modifying how the CLI help is invoked in one test and increasing a timer interval in another to reduce test flakiness.

Test improvements:

* Updated the CLI help invocation in `inspector.test.mjs` to use the explicit `help` command with English language output, ensuring consistent test results regardless of environment defaults.
* Increased the `setInterval` duration in a test script within `mcp-server.test.mjs` from 10 seconds to 2 minutes, reducing the likelihood of the test process exiting prematurely during longer-running tests.