### PR TITLE
feat: integrate completed task graph commits (#26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,14 +77,22 @@ Codex turns that into a durable task, selects the configured Implementer adapter
 ## Key Capabilities
 
 - Durable local tasks, messages, review decisions, and runtime events.
-- Additive Task Graph v1 validation, deterministic read-only scheduling, bounded parallel execution, and facts-first recovery across isolated worktrees and Sessions.
+- Additive Task Graph v1 validation, deterministic read-only scheduling, bounded parallel execution, isolated aggregate integration/review, and facts-first recovery across worktrees and Sessions.
 - Explicit Planner, Implementer, and Reviewer role boundaries.
 - Adapter-based execution for exact configured CLI commands.
 - Persistent, bounded, and inspectable execution sessions.
 - Review rework that reuses healthy context without infinite retry loops.
 - Recovery, explicit resume, bounded stop, and ownership-safe cleanup for interrupted graph execution; no filename/prose success inference or automatic retry loop.
+- Explicit graph integration verifies completed subtask refs and applies them in sorted order in a separate review worktree; review refuses stale source facts or uncommitted aggregate changes, while conflicts remain inspectable and never modify the user checkout.
 - A local Inspector timeline for tasks, sessions, and events.
 - Separate review and release gates with exact authorization semantics.
+
+Task Graph users can explicitly run `task graph-integrate` after all required
+subtasks succeed, then use `task graph-review` or the matching MCP tools to
+inspect and record the aggregate decision. The integration worktree, source
+refs, applied commits, conflict facts, and review evidence are durable; a
+`REVIEW_APPROVED` result never authorizes merge, push, tag, publish, deploy,
+or release.
 
 ## Supported Agents and Adapters
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -143,7 +143,7 @@ npx @hogancv/coordinate-agents@latest --help
 - 开始使用：[AI 安装契约](./AI_INSTALL.md)、[快速入门](./docs/getting-started.md)、[让 AI 安装](./docs/install-with-ai.md)、[常见问题](./docs/faq.md)、[变更记录](./CHANGELOG.md)
 - 核心 Runtime：[协议](./docs/protocol.md)、[Execution Session](./docs/session-runtime.md)、[Event Journal](./docs/event-journal.md)、[MCP](./docs/mcp.md)
 - Task Graph：[Task Graph v1 契约](./docs/task-graph-v1.md)
-- 聚合集成审查输出：[集成 schema](./schemas/task-graph-v1-integration.schema.json)、[审查 schema](./schemas/task-graph-v1-review.schema.json)
+- 聚合集成审查输出：[集成 schema](./schemas/task-graph-v1-integrate.schema.json)、[审查 schema](./schemas/task-graph-v1-review.schema.json)
 - 运维与安全：[Inspector](./docs/inspector.md)、[故障排查](./docs/troubleshooting.md)、[MCP 故障排查](./docs/MCP_TROUBLESHOOTING.md)、[安全](./docs/security.md)
 - 代理与选型：[Codex CLI](./docs/codex-cli.md)、[Antigravity CLI](./docs/antigravity-cli.md)、[方案对比](./docs/comparison.md)
 - Adapter 作者：[作者指南](./docs/adapter-author-guide.md)、[最小外部 Adapter 示例](./examples/minimal-external-adapter/README.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -85,6 +85,7 @@ Codex 会把要求转成持久任务，选择已配置的 Implementer 适配器�
 - 使用规范本地事实恢复中断的图执行，显式 resume、有限 stop 与所有权安全 cleanup；不从文件名/描述推断成功，也不自动重试。
 - 通过本地 Inspector 查看任务、Session 与事件时间线。
 - 严格区分审查门禁和发布门禁。
+- 所有必需子任务成功后，可在独立 Runtime-owned 聚合 worktree 中按确定性顺序执行 graph-integrate，再通过 graph-review 记录 REVIEW_APPROVED 或 CHANGES_REQUESTED；来源事实过期或聚合 worktree 有未提交改动时拒绝审查，冲突可检查且不会修改用户 checkout。
 
 ## 支持的代理与适配器
 
@@ -142,6 +143,7 @@ npx @hogancv/coordinate-agents@latest --help
 - 开始使用：[AI 安装契约](./AI_INSTALL.md)、[快速入门](./docs/getting-started.md)、[让 AI 安装](./docs/install-with-ai.md)、[常见问题](./docs/faq.md)、[变更记录](./CHANGELOG.md)
 - 核心 Runtime：[协议](./docs/protocol.md)、[Execution Session](./docs/session-runtime.md)、[Event Journal](./docs/event-journal.md)、[MCP](./docs/mcp.md)
 - Task Graph：[Task Graph v1 契约](./docs/task-graph-v1.md)
+- 聚合集成审查输出：[集成 schema](./schemas/task-graph-v1-integration.schema.json)、[审查 schema](./schemas/task-graph-v1-review.schema.json)
 - 运维与安全：[Inspector](./docs/inspector.md)、[故障排查](./docs/troubleshooting.md)、[MCP 故障排查](./docs/MCP_TROUBLESHOOTING.md)、[安全](./docs/security.md)
 - 代理与选型：[Codex CLI](./docs/codex-cli.md)、[Antigravity CLI](./docs/antigravity-cli.md)、[方案对比](./docs/comparison.md)
 - Adapter 作者：[作者指南](./docs/adapter-author-guide.md)、[最小外部 Adapter 示例](./examples/minimal-external-adapter/README.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -78,6 +78,14 @@ it before sharing diagnostics.
   cleanup failures remain durable bounded errors, while user worktrees, refs, commits, and evidence
   are preserved. Repeating these operations is idempotent.
 
+- Task Graph integration and aggregate review use a distinct Runtime-owned
+  `.agent-bus/worktrees/<parentTaskId>/__integration__` worktree and exact
+  `coordinate-agents/<parentTaskId>/__integration__` ref. All required source
+  refs and commits are verified before application; source worktrees and the
+  current checkout remain unchanged. Conflicts preserve inspectable Git state
+  and durable applied/source facts, while review decisions remain separate from
+  the human `RELEASE_APPROVED` gate.
+
 - Adapter Contract v1 validates metadata and launch-result shapes; it does not sandbox adapter code.
   A module registered with `coordinate-agents adapter register <local-file>` executes with the current
   Node.js process permissions and must be treated as trusted local code.

--- a/bin/coordinate-agents.mjs
+++ b/bin/coordinate-agents.mjs
@@ -91,14 +91,19 @@ import {
 } from '../skills/coordinate-agents/scripts/task-graph-contract.mjs';
 import {
   captureGraphBaseCommit,
+  cleanupTaskGraphIntegrationWorktree,
   cleanupTaskGraphWorktree,
   createTaskGraph,
   ensureSubtaskWorktree,
   ensureSubtaskWorktreeBus,
   hasTaskGraph,
+  inspectTaskGraphIntegration,
   inspectTaskGraphRecovery,
+  integrateTaskGraph,
   listTaskGraphs,
   readTaskGraph,
+  setTaskGraphIntegration,
+  setTaskGraphReview,
   setTaskGraphState,
   setTaskGraphSubtaskState,
   taskGraphBranchName,
@@ -108,6 +113,7 @@ import {
   taskGraphWorktreePath,
   verifyDurableImplementationCommit,
   verifyGraphImplementationCommit,
+  verifyTaskGraphIntegrationSources,
   validateSubtaskId,
 } from '../skills/coordinate-agents/scripts/task-graph-runtime.mjs';
 import {
@@ -151,7 +157,7 @@ Commands:
   launch        Start one CLI with its generated collaboration prompt
   setup         Discover coding CLIs and show configuration guidance
   status        Show the project Agent Bus and Task status
-  task          Manage durable tasks and Task Graphs (create, graph-validate, graph-create, graph-plan, graph-run, graph-recover, graph-resume, graph-stop, graph-cleanup, graph-dispatch, graph-status, graph-inspect, dispatch, status, list, inspect, resume, stop, review, error)
+  task          Manage durable tasks and Task Graphs (create, graph-validate, graph-create, graph-plan, graph-run, graph-recover, graph-resume, graph-stop, graph-cleanup, graph-dispatch, graph-integrate, graph-review, graph-status, graph-inspect, dispatch, status, list, inspect, resume, stop, review, error)
   agent         Manage registered agents (add, list, doctor)
   adapter       Manage trusted local Contract v1 adapters (register, list, remove)
   inspector     Start the local read-only Web UI Inspector
@@ -1683,12 +1689,14 @@ function taskGraphOperation(options) {
   if (['graph-resume', 'resume-graph'].includes(subcommand)) return 'resume';
   if (['graph-stop', 'stop-graph'].includes(subcommand)) return 'stop';
   if (['graph-cleanup', 'cleanup-graph'].includes(subcommand)) return 'cleanup';
+  if (['graph-integrate', 'integrate-graph'].includes(subcommand)) return 'integrate';
+  if (['graph-review', 'review-graph'].includes(subcommand)) return 'review';
   if (['graph-status', 'status-graph'].includes(subcommand)) return 'status';
   if (['graph-inspect', 'inspect-graph'].includes(subcommand)) return 'inspect';
   if (['graph-dispatch', 'dispatch-graph'].includes(subcommand)) return 'dispatch';
   if (subcommand !== 'graph') return null;
   const nested = options.positionals?.[0];
-  return ['create', 'plan', 'run', 'recover', 'resume', 'stop', 'cleanup', 'status', 'inspect', 'dispatch'].includes(nested) ? nested : null;
+  return ['create', 'plan', 'run', 'recover', 'resume', 'stop', 'cleanup', 'integrate', 'review', 'status', 'inspect', 'dispatch'].includes(nested) ? nested : null;
 }
 
 function graphInput(options) {
@@ -1738,7 +1746,7 @@ function graphTaskId(options, root) {
   if (direct) return direct;
   const isGraphSubcommand = options.subcommand === 'graph';
   const nestedPos0 = options.positionals?.[0];
-  const nested = isGraphSubcommand && ['status', 'inspect', 'dispatch', 'create', 'validate', 'plan', 'run', 'recover', 'resume', 'stop', 'cleanup'].includes(nestedPos0)
+  const nested = isGraphSubcommand && ['status', 'inspect', 'dispatch', 'create', 'validate', 'plan', 'run', 'recover', 'resume', 'stop', 'cleanup', 'integrate', 'review'].includes(nestedPos0)
     ? options.positionals?.[1]
     : options.positionals?.[0];
   if (nested) return nested;
@@ -2391,6 +2399,221 @@ function graphCleanupSummary(repository, graph) {
   }));
 }
 
+function integrationCleanupFactsChanged(previous, current) {
+  const worktree = value => value && {
+    path: value.path || null,
+    recordedPath: value.recordedPath || null,
+    branch: value.branch || null,
+    ref: value.ref || null,
+    recordedBranch: value.recordedBranch || null,
+    recordedRef: value.recordedRef || null,
+    matchesRecord: value.matchesRecord ?? null,
+    exists: Boolean(value.exists),
+    safe: Boolean(value.safe),
+    registered: Boolean(value.registered),
+    owned: Boolean(value.owned),
+    ownershipKnown: Boolean(value.ownershipKnown),
+    head: value.head || null,
+    registeredBranch: value.registeredBranch || null,
+    error: value.error || null,
+  };
+  // After a successful removal the next inspection has no directory to
+  // describe. Treat that stable absence as the same terminal cleanup fact.
+  if (previous?.status === 'CLEANED' && current?.worktree
+    && !current.worktree.exists && !current.worktree.registered && !current.worktree.error) return false;
+  return JSON.stringify(worktree(previous?.worktree) || null) !== JSON.stringify(worktree(current?.worktree) || null);
+}
+
+function graphIntegrationCleanup(repository, graph, { timeoutMs = 2_000, allowRunning = false } = {}) {
+  const integration = graph.integration;
+  if (!integration) return null;
+  const current = inspectTaskGraphIntegration(repository, graph, { probeGit: true, timeoutMs });
+  const prior = integration.cleanup;
+  if (prior?.status === 'CLEANED' && !integrationCleanupFactsChanged(prior, current)) {
+    return {
+      root: repository,
+      parentTaskId: graph.parentTaskId,
+      status: 'CLEANED',
+      idempotent: true,
+      integrationState: integration.state,
+      worktree: current?.worktree || prior.worktree || null,
+      error: null,
+    };
+  }
+  if (integration.state === 'RUNNING' && !allowRunning) {
+    const error = runtimeError('TASK_STATE_CONFLICT', 'Task Graph integration for ' + graph.parentTaskId + ' is RUNNING; stop or reconcile it before cleanup.', {
+      recoverable: true,
+      taskId: graph.parentTaskId,
+      root: repository,
+      stage: 'integration-cleanup',
+      details: { integration: current || integration },
+    });
+    const cleanup = {
+      status: 'SKIPPED',
+      attemptedAt: prior?.attemptedAt || new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      worktree: current?.worktree || null,
+      error: serializeRuntimeError(error, { includeLegacy: true }),
+    };
+    try {
+      setTaskGraphIntegration(repository, graph.parentTaskId, integration.state, {
+        expectedState: integration.state,
+        cleanup,
+        operation: 'graph-cleanup',
+      });
+    } catch {
+      // Preserve the primary non-destructive cleanup decision.
+    }
+    return {
+      root: repository,
+      parentTaskId: graph.parentTaskId,
+      status: 'SKIPPED',
+      idempotent: false,
+      integrationState: integration.state,
+      worktree: current?.worktree || null,
+      error: cleanup.error,
+    };
+  }
+  const worktreeResult = cleanupTaskGraphIntegrationWorktree(repository, graph.parentTaskId, {
+    recordedPath: integration.worktreePath || null,
+    recordedBranch: integration.branch || null,
+    recordedRef: integration.ref || null,
+    timeoutMs,
+  });
+  const cleanup = {
+    status: worktreeResult.status,
+    attemptedAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    worktree: worktreeResult.worktree || current?.worktree || null,
+    error: worktreeResult.error || null,
+  };
+  let persistenceError = null;
+  try {
+    setTaskGraphIntegration(repository, graph.parentTaskId, integration.state, {
+      expectedState: integration.state,
+      cleanup,
+      operation: 'graph-cleanup',
+    });
+  } catch (error) {
+    persistenceError = serializeRuntimeError(error, { includeLegacy: true });
+  }
+  return {
+    root: repository,
+    parentTaskId: graph.parentTaskId,
+    status: persistenceError ? 'FAILED' : worktreeResult.status,
+    idempotent: persistenceError ? false : Boolean(worktreeResult.idempotent),
+    integrationState: integration.state,
+    worktree: worktreeResult.worktree || current?.worktree || null,
+    error: persistenceError || worktreeResult.error || null,
+  };
+}
+
+async function taskGraphIntegrateCommand(options, { json = false } = {}) {
+  const repository = assertGitRepository(options.root, messages.en);
+  const parentTaskId = graphTaskId(options, repository);
+  const result = integrateTaskGraph(repository, parentTaskId, { timeoutMs: cleanupTimeout(options) });
+  const latestGraph = readTaskGraph(repository, parentTaskId);
+  const payload = jsonSuccess('task.graph-integrate', {
+    root: repository,
+    graphId: parentTaskId,
+    parentTaskId,
+    baseCommit: result.integration?.baseCommit || null,
+    sources: result.sources || [],
+    integration: result.integration || inspectTaskGraphIntegration(repository, latestGraph, { probeGit: true }),
+    graph: latestGraph,
+    idempotent: Boolean(result.idempotent),
+    release: { authorized: false, required: 'explicit user release authorization' },
+  });
+  if (!json) console.log(JSON.stringify(payload, null, 2));
+  return payload;
+}
+
+async function taskGraphReviewCommand(options, { json = false } = {}) {
+  const repository = assertGitRepository(options.root, messages.en);
+  const parentTaskId = graphTaskId(options, repository);
+  const graph = readTaskGraph(repository, parentTaskId);
+  // Re-verify source facts at the review boundary so a reviewer never
+  // approves an aggregate whose required subtask evidence or refs changed.
+  const verified = verifyTaskGraphIntegrationSources(repository, graph);
+  const integration = inspectTaskGraphIntegration(repository, graph, { probeGit: true, timeoutMs: cleanupTimeout(options) });
+  const expectedAppliedRefs = verified.sources.map(source => ({
+    subtaskId: source.subtaskId,
+    ref: source.ref,
+    commit: source.commit,
+  }));
+  const actualAppliedRefs = (integration?.appliedRefs || []).map(source => ({
+    subtaskId: source.subtaskId,
+    ref: source.ref,
+    commit: source.commit,
+  }));
+  if (integration?.state !== 'SUCCEEDED'
+    || integration.sourceFingerprint !== verified.sourceFingerprint
+    || integration.baseCommit?.toLowerCase() !== verified.baseCommit.toLowerCase()
+    || JSON.stringify(actualAppliedRefs) !== JSON.stringify(expectedAppliedRefs)) {
+    throw runtimeError('TASK_STATE_CONFLICT', 'Task Graph ' + parentTaskId + ' integration does not match the currently verified source commits.', {
+      recoverable: true,
+      taskId: parentTaskId,
+      root: repository,
+      stage: 'graph-review',
+      details: {
+        integrationState: integration?.state || null,
+        expectedBaseCommit: verified.baseCommit,
+        integrationBaseCommit: integration?.baseCommit || null,
+        expectedSourceFingerprint: verified.sourceFingerprint,
+        integrationSourceFingerprint: integration?.sourceFingerprint || null,
+        expectedAppliedRefs,
+        actualAppliedRefs,
+      },
+    });
+  }
+  if (!integration?.worktree?.owned || !integration.worktree.safe || !integration.worktree.exists) {
+    throw runtimeError('TASK_STATE_CONFLICT', 'Task Graph ' + parentTaskId + ' integration worktree is not Runtime-owned and inspectable.', {
+      recoverable: true,
+      taskId: parentTaskId,
+      root: repository,
+      stage: 'graph-review',
+      details: { integration },
+    });
+  }
+  if (!integration.aggregateCommit || integration.worktree.head?.toLowerCase() !== integration.aggregateCommit.toLowerCase()) {
+    throw runtimeError('TASK_STATE_CONFLICT', 'Task Graph ' + parentTaskId + ' integration aggregate commit is not stable for review.', {
+      recoverable: true,
+      taskId: parentTaskId,
+      root: repository,
+      stage: 'graph-review',
+      details: { aggregateCommit: integration.aggregateCommit, worktreeHead: integration.worktree.head || null },
+    });
+  }
+  if (integration.clean !== true) {
+    throw runtimeError('WORKTREE_CONFLICT', 'Task Graph ' + parentTaskId + ' integration worktree has uncommitted changes and cannot be approved.', {
+      recoverable: true,
+      taskId: parentTaskId,
+      root: repository,
+      stage: 'graph-review',
+      details: { worktree: integration.worktree, diff: integration.diff },
+    });
+  }
+  const result = setTaskGraphReview(repository, parentTaskId, options.decision, {
+    feedback: options.feedback || options.reason || '',
+    evidence: options.evidence,
+  });
+  const latestGraph = result.graph || readTaskGraph(repository, parentTaskId);
+  const payload = jsonSuccess('task.graph-review', {
+    root: repository,
+    graphId: parentTaskId,
+    parentTaskId,
+    decision: result.review?.decision || options.decision,
+    review: result.review,
+    graph: latestGraph,
+    integration: inspectTaskGraphIntegration(repository, latestGraph, { probeGit: true, timeoutMs: cleanupTimeout(options) }),
+    changed: Boolean(result.changed),
+    event: result.event || null,
+    release: { authorized: false, required: 'explicit user release authorization' },
+  });
+  if (!json) console.log(JSON.stringify(payload, null, 2));
+  return payload;
+}
+
 async function cleanupGraphSubtask(repository, graph, subtask, {
   timeoutMs = 2_000,
   allowRunning = false,
@@ -2591,6 +2814,7 @@ async function taskGraphCleanupCommand(options, { json = false } = {}) {
   const repository = assertGitRepository(options.root, messages.en);
   const parentTaskId = graphTaskId(options, repository);
   const graph = readTaskGraph(repository, parentTaskId);
+  const scopedSubtask = Boolean(graphSubtaskOption(options));
   const selected = graphSubtaskSelection(options, graph, { includeTerminal: true });
   const outcomes = [];
   for (const subtask of selected) {
@@ -2600,7 +2824,11 @@ async function taskGraphCleanupCommand(options, { json = false } = {}) {
       parentStateOverride: currentGraph.state,
     }));
   }
-  const latestGraph = readTaskGraph(repository, parentTaskId);
+  let latestGraph = readTaskGraph(repository, parentTaskId);
+  const integrationCleanup = !scopedSubtask
+    ? graphIntegrationCleanup(repository, latestGraph, { timeoutMs: cleanupTimeout(options) })
+    : null;
+  latestGraph = readTaskGraph(repository, parentTaskId);
   const payload = jsonSuccess('task.graph-cleanup', {
     root: repository,
     graphId: parentTaskId,
@@ -2608,6 +2836,7 @@ async function taskGraphCleanupCommand(options, { json = false } = {}) {
     graph: latestGraph,
     outcomes,
     cleanup: graphCleanupSummary(repository, latestGraph),
+    integrationCleanup,
   });
   if (!json) console.log(JSON.stringify(payload, null, 2));
   return payload;
@@ -2661,6 +2890,29 @@ async function taskGraphStopCommand(options, { json = false } = {}) {
   if (!scopedSubtask && graph.state !== 'STOPPED') {
     graph = setTaskGraphState(repository, parentTaskId, 'STOPPED', { operation: 'graph-stop', reason: options.reason || 'Task Graph explicitly stopped.' }).graph;
   }
+  let integrationCleanup = null;
+  if (!scopedSubtask) {
+    graph = readTaskGraph(repository, parentTaskId);
+    if (graph.integration?.state === 'RUNNING') {
+      const stoppedIntegration = runtimeError('TASK_STATE_CONFLICT', 'Task Graph integration was interrupted by an explicit graph stop.', {
+        recoverable: true,
+        taskId: parentTaskId,
+        root: repository,
+        stage: 'graph-stop',
+      });
+      graph = setTaskGraphIntegration(repository, parentTaskId, 'FAILED', {
+        expectedState: 'RUNNING',
+        reason: stoppedIntegration.message,
+        lastError: serializeRuntimeError(stoppedIntegration, { includeLegacy: true }),
+        operation: 'graph-stop',
+      }).graph;
+    }
+    integrationCleanup = graphIntegrationCleanup(repository, readTaskGraph(repository, parentTaskId), {
+      timeoutMs: cleanupTimeout(options),
+      allowRunning: true,
+    });
+    graph = readTaskGraph(repository, parentTaskId);
+  }
   const payload = jsonSuccess('task.graph-stop', {
     root: repository,
     graphId: parentTaskId,
@@ -2668,6 +2920,7 @@ async function taskGraphStopCommand(options, { json = false } = {}) {
     graph,
     outcomes,
     cleanup: graphCleanupSummary(repository, graph),
+    integrationCleanup,
   });
   if (!json) console.log(JSON.stringify(payload, null, 2));
   return payload;
@@ -3215,6 +3468,8 @@ async function taskCommand(options, { json = false } = {}) {
   if (graphOperation === 'resume') return await taskGraphResumeCommand(options, { json });
   if (graphOperation === 'stop') return await taskGraphStopCommand(options, { json });
   if (graphOperation === 'cleanup') return await taskGraphCleanupCommand(options, { json });
+  if (graphOperation === 'integrate') return await taskGraphIntegrateCommand(options, { json });
+  if (graphOperation === 'review') return await taskGraphReviewCommand(options, { json });
   if (graphOperation === 'dispatch') return await taskGraphDispatchCommand(options, { json });
   if (graphOperation === 'status' || graphOperation === 'inspect') {
     return taskGraphViewCommand(options, graphOperation, { json });
@@ -3238,6 +3493,12 @@ async function taskCommand(options, { json = false } = {}) {
       } catch {
         // Preserve the existing single-Task error when no graph store exists.
       }
+    }
+  }
+  if (subcommand === 'review') {
+    const requestedId = options.taskId || options.positionals?.[0] || null;
+    if (requestedId && hasTaskGraph(resolve(options.root), requestedId)) {
+      return await taskGraphReviewCommand({ ...options, taskId: requestedId }, { json });
     }
   }
   const adapterRegistry = await loadConfiguredAdaptersForRuntime();
@@ -5000,6 +5261,31 @@ export async function runtimeTaskGraphCleanup(input = {}) {
     subcommand: 'graph-cleanup',
     taskId: input.taskId || input.parentTaskId || input.id || null,
     subtaskId: input.subtaskId || input.subtask || null,
+    timeoutMs: input.timeoutMs ?? null,
+    positionals: [],
+  }), { json: true });
+}
+
+export async function runtimeTaskGraphIntegrate(input = {}) {
+  return taskCommand(serviceOptions({
+    ...input,
+    command: 'task',
+    subcommand: 'graph-integrate',
+    taskId: input.taskId || input.parentTaskId || input.id || null,
+    timeoutMs: input.timeoutMs ?? null,
+    positionals: [],
+  }), { json: true });
+}
+
+export async function runtimeTaskGraphReview(input = {}) {
+  return taskCommand(serviceOptions({
+    ...input,
+    command: 'task',
+    subcommand: 'graph-review',
+    taskId: input.taskId || input.parentTaskId || input.id || null,
+    decision: input.decision || null,
+    feedback: input.feedback || input.reason || '',
+    evidence: input.evidence === undefined ? null : input.evidence,
     timeoutMs: input.timeoutMs ?? null,
     positionals: [],
   }), { json: true });

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -107,7 +107,7 @@ aggregate HEAD, Runtime ownership, and worktree cleanliness before recording
 `REVIEW_APPROVED` or `CHANGES_REQUESTED` through the existing reviewer
 boundary. Stale or dirty aggregates are refused. Review approval is not release
 authorization. The output contracts
-are `schemas/task-graph-v1-integration.schema.json` and
+are `schemas/task-graph-v1-integrate.schema.json` and
 `schemas/task-graph-v1-review.schema.json`.
 
 Use this project for structured multi-agent software engineering where workflow roles (such as planner, implementer, and reviewer) coordinate across distinct CLI or adapter-extended agents via durable local messaging, explicit leases, and human release authorization. The default reference workflow pairs Codex as planner/reviewer with Antigravity as exclusive implementer. Do not use it for single-agent coding tasks or concurrent conflicting worktree writes.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -93,6 +93,22 @@ remove only their exact worktrees after bounded cleanup, preserving user files,
 refs, commits, and evidence. Failures are durable and repeated recovery,
 resume, stop, and cleanup calls are idempotent. Their shared output shape is
 `schemas/task-graph-v1-recovery.schema.json`.
+`coordinate_agents_task_graph_integrate` is an explicit post-completion
+boundary: it verifies every required subtask evidence/ref and applies the
+source commits in sorted subtask-id order to a separate Runtime-owned
+`.agent-bus/worktrees/<parentTaskId>/__integration__` review worktree. The
+current checkout and source worktrees stay unchanged. Durable integration
+facts include base, source fingerprint, ordered source refs, applied commits,
+aggregate commit, cleanup, and bounded conflict status. A conflict is not
+automatically resolved, retried, reset, merged, pushed, tagged, published,
+deployed, or released.
+`coordinate_agents_task_graph_review` rechecks the exact source fingerprint,
+aggregate HEAD, Runtime ownership, and worktree cleanliness before recording
+`REVIEW_APPROVED` or `CHANGES_REQUESTED` through the existing reviewer
+boundary. Stale or dirty aggregates are refused. Review approval is not release
+authorization. The output contracts
+are `schemas/task-graph-v1-integration.schema.json` and
+`schemas/task-graph-v1-review.schema.json`.
 
 Use this project for structured multi-agent software engineering where workflow roles (such as planner, implementer, and reviewer) coordinate across distinct CLI or adapter-extended agents via durable local messaging, explicit leases, and human release authorization. The default reference workflow pairs Codex as planner/reviewer with Antigravity as exclusive implementer. Do not use it for single-agent coding tasks or concurrent conflicting worktree writes.
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -240,7 +240,7 @@ The stable Task, Task Graph v1 input, Runtime error, and evidence shapes are doc
 - `schemas/task-graph-v1-plan.schema.json`
 - `schemas/task-graph-v1-run.schema.json`
 - `schemas/task-graph-v1-recovery.schema.json`
-- `schemas/task-graph-v1-integration.schema.json`
+- `schemas/task-graph-v1-integrate.schema.json`
 - `schemas/task-graph-v1-review.schema.json`
 - `schemas/runtime-error.schema.json`
 - `schemas/evidence.schema.json`

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -61,6 +61,8 @@ Agent Bus transport is not Codex App Terminal UI automation.
 | `coordinate_agents_task_graph_stop` | `root`, `taskId` | `subtaskId`, `reason`, `timeoutMs` | `task.graph-stop` |
 | `coordinate_agents_task_graph_cleanup` | `root`, `taskId` | `subtaskId`, `timeoutMs` | `task.graph-cleanup` |
 | `coordinate_agents_task_graph_dispatch` | `root`, `taskId`, `subtaskId` | `spec`, `sessionWaitMs` | `task.graph-dispatch` |
+| `coordinate_agents_task_graph_integrate` | `root`, `taskId` | `timeoutMs` | `task.graph-integrate` |
+| `coordinate_agents_task_graph_review` | `root`, `taskId`, `decision` | `feedback`, `evidence`, `timeoutMs` | `task.graph-review` |
 | `coordinate_agents_task_dispatch` | `root`, `taskId` | `spec` | `task.dispatch` |
 | `coordinate_agents_task_status` | `root`, `taskId` | — | `task.status` |
 | `coordinate_agents_task_inspect` | `root`, `taskId` | — | `task.inspect` |
@@ -119,6 +121,22 @@ uncommitted files in the user repository or mutating sibling subtasks. It captur
 the graph base commit, provisions a dedicated worktree and branch, resolves the
 configured Implementer, runs an isolated persistent Session, and updates the
 subtask and frontier state upon completion.
+
+`coordinate_agents_task_graph_integrate` is the explicit aggregate step after
+all required subtasks succeed. It verifies each exact Runtime branch/ref and
+completion commit, then applies source commits in sorted subtask-id order to
+`.agent-bus/worktrees/<parentTaskId>/__integration__`. The aggregate worktree
+and its durable base/source/applied/conflict facts are separate from every
+subtask worktree and from the current checkout. A conflict is returned as a
+bounded business failure with the in-progress Git state preserved for inspection.
+
+`coordinate_agents_task_graph_review` sends that aggregate through the existing
+review boundary. It rechecks source evidence, the exact integration source
+fingerprint, aggregate ownership, aggregate HEAD, and worktree cleanliness before
+recording `REVIEW_APPROVED` or `CHANGES_REQUESTED`; review never merges, pushes,
+tags, publishes, deploys, or releases. `graph-cleanup` and unscoped
+`graph-stop` clean only the Runtime-owned aggregate worktree and retain its
+branch, commits, conflict facts, and review evidence.
 
 `coordinate_agents_task_graph_recover` is the facts-first interruption path. It
 reads the durable graph, Session, worktree, and Event Journal records, verifies
@@ -222,6 +240,8 @@ The stable Task, Task Graph v1 input, Runtime error, and evidence shapes are doc
 - `schemas/task-graph-v1-plan.schema.json`
 - `schemas/task-graph-v1-run.schema.json`
 - `schemas/task-graph-v1-recovery.schema.json`
+- `schemas/task-graph-v1-integration.schema.json`
+- `schemas/task-graph-v1-review.schema.json`
 - `schemas/runtime-error.schema.json`
 - `schemas/evidence.schema.json`
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -35,6 +35,10 @@ Typical workflow:
 2. Implementer (default: Antigravity) claims it, implements, tests, commits, and sends `IMPLEMENTATION_DONE` with evidence.
 3. Reviewer (default: Codex) validates the commit and evidence, then sends `CHANGES_REQUESTED` or `REVIEW_APPROVED`.
 4. Release work remains blocked until the user separately enters `RELEASE_APPROVED`.
+5. For a Task Graph, the Runtime then integrates verified subtask commits in a
+   separate aggregate worktree and sends that aggregate through the existing
+   reviewer boundary; integration and review never change the current checkout
+   or authorize release actions.
 
 Messages and state survive terminal restarts. Reinvoke the Skill and inspect `status` to resume. Recover a stale claim only after confirming no matching implementation, commit, or reply exists, because recovery may make the work eligible for delivery again.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -41,6 +41,14 @@ close only matching Runtime-owned Sessions and remove only the exact Runtime-own
 a bounded timeout. Ownership mismatches, symlinks, path escapes, and cleanup failures are
 preserved as durable bounded errors; branches, refs, commits, evidence, and the user's worktree
 remain intact.
+Graph integration is a separate, explicit boundary. It runs only after every required subtask has
+verified completion evidence, checks the exact Runtime source refs and captured base commit, and
+applies commits in deterministic order inside a distinct Runtime-owned aggregate worktree. It
+never changes the current checkout or source worktrees. A cherry-pick conflict remains in place
+with bounded source, applied-ref, Git-status, and conflict facts for inspection; no automatic
+resolution, reset, retry, merge, push, tag, publish, deploy, or release occurs. Aggregate review
+rechecks those facts before recording `REVIEW_APPROVED` or `CHANGES_REQUESTED`, and cleanup
+retains the aggregate branch, commits, conflict facts, and evidence.
 
 Local Git exclusion prevents ordinary commits but does not block administrators, same-user processes, backups, cloud sync, or malware. Inspect and redact bus data before sharing diagnostics. Use the explicit `clean --confirm DELETE_AGENT_BUS` operation after audit retention is no longer needed.
 

--- a/docs/task-graph-v1.md
+++ b/docs/task-graph-v1.md
@@ -230,6 +230,58 @@ cleanup calls are idempotent and do not duplicate messages, input, commits, or
 worktrees. The shared output shape is
 `schemas/task-graph-v1-recovery.schema.json`.
 
+## Deterministic integration and aggregate review
+
+After every required subtask is SUCCEEDED, integrate the verified
+IMPLEMENTATION_DONE commits explicitly:
+
+```sh
+coordinate-agents task graph-integrate --root <repository> --id <parentTaskId> --json
+# equivalent nested form:
+coordinate-agents task graph integrate <parentTaskId> --root <repository> --json
+```
+
+The MCP equivalent is coordinate_agents_task_graph_integrate. Integration
+refuses any graph with an unresolved, failed, stopped, or unverified subtask.
+It captures one base commit, sorts source subtasks by identifier, verifies the
+exact Runtime branch/ref and commit reachability, then cherry-picks the
+verified commits into the separate Runtime-owned
+.agent-bus/worktrees/<parentTaskId>/__integration__ worktree and
+coordinate-agents/<parentTaskId>/__integration__ branch. The current user
+checkout, subtask worktrees, source branches, and source commits are not
+modified.
+
+The integration record is part of the atomic graph record and retains the
+base, source fingerprint, ordered source refs, applied refs and aggregate
+commit. A conflict is a bounded structured failure that leaves the aggregate
+worktree and Git conflict state inspectable; it never silently resolves,
+retries, resets, or deletes source work. graph-status reports the durable
+integration record, while graph-inspect additionally probes the aggregate
+worktree and aggregate diff. The result contract is
+schemas/task-graph-v1-integration.schema.json.
+
+Send the aggregate through the existing reviewer boundary explicitly:
+
+```sh
+coordinate-agents task graph-review --root <repository> --id <parentTaskId> \
+  --decision REVIEW_APPROVED --json
+# or:
+coordinate-agents task graph-review --root <repository> --id <parentTaskId> \
+  --decision CHANGES_REQUESTED --feedback "Bounded review notes" --json
+```
+
+The MCP equivalent is coordinate_agents_task_graph_review; task review also
+recognizes a persisted graph parent ID. The reviewer rechecks the subtask
+evidence/refs, exact integration source fingerprint, aggregate HEAD, and the
+Runtime-owned aggregate worktree before recording REVIEW_APPROVED or
+CHANGES_REQUESTED with bounded evidence. A stale-source or dirty aggregate is
+refused.
+REVIEW_APPROVED changes only the durable graph/review state: it is not merge,
+push, tag, release, deploy, or publish authorization. Integration cleanup is
+explicit through graph-cleanup or an unscoped graph-stop; it removes only the
+Runtime-owned aggregate worktree and retains the integration branch, commits,
+conflict facts, and review evidence.
+
 ## Subtask dispatch in an isolated Git worktree
 
 To execute one approved, dependency-ready subtask from a persisted graph, use

--- a/docs/task-graph-v1.md
+++ b/docs/task-graph-v1.md
@@ -258,7 +258,7 @@ worktree and Git conflict state inspectable; it never silently resolves,
 retries, resets, or deletes source work. graph-status reports the durable
 integration record, while graph-inspect additionally probes the aggregate
 worktree and aggregate diff. The result contract is
-schemas/task-graph-v1-integration.schema.json.
+schemas/task-graph-v1-integrate.schema.json.
 
 Send the aggregate through the existing reviewer boundary explicitly:
 

--- a/llms.txt
+++ b/llms.txt
@@ -107,7 +107,7 @@ aggregate HEAD, Runtime ownership, and worktree cleanliness before recording
 `REVIEW_APPROVED` or `CHANGES_REQUESTED` through the existing reviewer
 boundary. Stale or dirty aggregates are refused. Review approval is not release
 authorization. The output contracts
-are `schemas/task-graph-v1-integration.schema.json` and
+are `schemas/task-graph-v1-integrate.schema.json` and
 `schemas/task-graph-v1-review.schema.json`.
 
 Use this project for structured multi-agent software engineering where workflow roles (such as planner, implementer, and reviewer) coordinate across distinct CLI or adapter-extended agents via durable local messaging, explicit leases, and human release authorization. The default reference workflow pairs Codex as planner/reviewer with Antigravity as exclusive implementer. Do not use it for single-agent coding tasks or concurrent conflicting worktree writes.

--- a/llms.txt
+++ b/llms.txt
@@ -93,6 +93,22 @@ remove only their exact worktrees after bounded cleanup, preserving user files,
 refs, commits, and evidence. Failures are durable and repeated recovery,
 resume, stop, and cleanup calls are idempotent. Their shared output shape is
 `schemas/task-graph-v1-recovery.schema.json`.
+`coordinate_agents_task_graph_integrate` is an explicit post-completion
+boundary: it verifies every required subtask evidence/ref and applies the
+source commits in sorted subtask-id order to a separate Runtime-owned
+`.agent-bus/worktrees/<parentTaskId>/__integration__` review worktree. The
+current checkout and source worktrees stay unchanged. Durable integration
+facts include base, source fingerprint, ordered source refs, applied commits,
+aggregate commit, cleanup, and bounded conflict status. A conflict is not
+automatically resolved, retried, reset, merged, pushed, tagged, published,
+deployed, or released.
+`coordinate_agents_task_graph_review` rechecks the exact source fingerprint,
+aggregate HEAD, Runtime ownership, and worktree cleanliness before recording
+`REVIEW_APPROVED` or `CHANGES_REQUESTED` through the existing reviewer
+boundary. Stale or dirty aggregates are refused. Review approval is not release
+authorization. The output contracts
+are `schemas/task-graph-v1-integration.schema.json` and
+`schemas/task-graph-v1-review.schema.json`.
 
 Use this project for structured multi-agent software engineering where workflow roles (such as planner, implementer, and reviewer) coordinate across distinct CLI or adapter-extended agents via durable local messaging, explicit leases, and human release authorization. The default reference workflow pairs Codex as planner/reviewer with Antigravity as exclusive implementer. Do not use it for single-agent coding tasks or concurrent conflicting worktree writes.
 

--- a/mcp/self-test.mjs
+++ b/mcp/self-test.mjs
@@ -21,6 +21,8 @@ const expectedTools = [
   'coordinate_agents_task_graph_stop',
   'coordinate_agents_task_graph_cleanup',
   'coordinate_agents_task_graph_dispatch',
+  'coordinate_agents_task_graph_integrate',
+  'coordinate_agents_task_graph_review',
   'coordinate_agents_task_dispatch',
   'coordinate_agents_task_status',
   'coordinate_agents_task_inspect',

--- a/mcp/server.mjs
+++ b/mcp/server.mjs
@@ -343,6 +343,41 @@ const TOOL_DEFINITIONS = Object.freeze([
     },
   },
   {
+    name: 'coordinate_agents_task_graph_integrate',
+    description: 'Verify every required subtask completion, apply its commits in deterministic order to a Runtime-owned aggregate review worktree, and preserve conflict facts without changing the current checkout.',
+    operation: 'taskGraphIntegrate',
+    command: 'task.graph-integrate',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        root: rootProperty,
+        taskId: stringProperty('Existing Task Graph parent identifier.'),
+        timeoutMs: integerProperty('Bounded Git integration command timeout.', { minimum: 100, maximum: 10_000 }),
+      },
+      required: ['root', 'taskId'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'coordinate_agents_task_graph_review',
+    description: 'Inspect the Runtime-owned aggregate integration worktree and record REVIEW_APPROVED or CHANGES_REQUESTED without merging, pushing, tagging, releasing, deploying, or publishing.',
+    operation: 'taskGraphReview',
+    command: 'task.graph-review',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        root: rootProperty,
+        taskId: stringProperty('Existing Task Graph parent identifier.'),
+        decision: { type: 'string', enum: ['REVIEW_APPROVED', 'CHANGES_REQUESTED'] },
+        feedback: { type: 'string', description: 'Required when decision is CHANGES_REQUESTED.' },
+        evidence: { type: 'object', description: 'Optional bounded review evidence reference.' },
+        timeoutMs: integerProperty('Bounded Git inspection timeout.', { minimum: 100, maximum: 10_000 }),
+      },
+      required: ['root', 'taskId', 'decision'],
+      additionalProperties: false,
+    },
+  },
+  {
     name: 'coordinate_agents_task_dispatch',
     description: 'Validate and explicitly dispatch an approved Task to the configured Implementer.',
     operation: 'taskDispatch',

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "examples"
   ],
   "scripts": {
-    "test": "node --test",
+    "test": "node --test --test-concurrency=1",
     "sync:llms": "node scripts/sync-llms.mjs",
     "check:llms": "node scripts/sync-llms.mjs --check",
     "check": "node bin/coordinate-agents.mjs --help && npm run check:llms && npm test",

--- a/schemas/task-graph-v1-integrate.schema.json
+++ b/schemas/task-graph-v1-integrate.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/hogancv/coordinate-agents/schemas/task-graph-v1-integration.schema.json",
+  "$id": "https://github.com/hogancv/coordinate-agents/schemas/task-graph-v1-integrate.schema.json",
   "title": "Coordinate Agents Task Graph v1 integration result",
   "description": "Deterministic, isolated application of verified subtask commits to a Runtime-owned review worktree.",
   "type": "object",

--- a/schemas/task-graph-v1-integration.schema.json
+++ b/schemas/task-graph-v1-integration.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/hogancv/coordinate-agents/schemas/task-graph-v1-integration.schema.json",
+  "title": "Coordinate Agents Task Graph v1 integration result",
+  "description": "Deterministic, isolated application of verified subtask commits to a Runtime-owned review worktree.",
+  "type": "object",
+  "required": ["ok", "command", "root", "graphId", "parentTaskId", "baseCommit", "sources", "integration", "graph"],
+  "properties": {
+    "ok": { "const": true },
+    "command": { "const": "task.graph-integrate" },
+    "root": { "type": "string", "minLength": 1 },
+    "graphId": { "type": "string", "pattern": "^task-[A-Za-z0-9][A-Za-z0-9_-]{1,127}$" },
+    "parentTaskId": { "type": "string", "pattern": "^task-[A-Za-z0-9][A-Za-z0-9_-]{1,127}$" },
+    "baseCommit": { "type": ["string", "null"], "pattern": "^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$" },
+    "sources": { "type": "array", "maxItems": 256, "items": { "$ref": "#/$defs/source" } },
+    "integration": { "$ref": "#/$defs/integration" },
+    "graph": { "$ref": "./task-graph-v1-record.schema.json" },
+    "idempotent": { "type": "boolean" },
+    "release": {
+      "type": "object",
+      "required": ["authorized"],
+      "properties": {
+        "authorized": { "const": false },
+        "required": { "type": "string" }
+      },
+      "additionalProperties": true
+    }
+  },
+  "$defs": {
+    "source": {
+      "type": "object",
+      "required": ["order", "subtaskId", "implementer", "branch", "ref", "commit", "refCommit"],
+      "properties": {
+        "order": { "type": "integer", "minimum": 0 },
+        "subtaskId": { "type": "string", "pattern": "^[a-z][a-z0-9_-]{0,63}$" },
+        "implementer": { "type": "string" },
+        "branch": { "type": "string" },
+        "ref": { "type": "string" },
+        "commit": { "type": "string", "pattern": "^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$" },
+        "refCommit": { "type": "string", "pattern": "^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$" },
+        "evidence": { "type": "array", "maxItems": 64 }
+      },
+      "additionalProperties": true
+    },
+    "integration": {
+      "type": "object",
+      "required": ["schemaVersion", "kind", "parentTaskId", "state", "status", "baseCommit", "worktreePath", "branch", "ref", "sourceRefs", "appliedRefs", "createdAt", "updatedAt"],
+      "properties": {
+        "schemaVersion": { "const": 1 },
+        "kind": { "const": "task-graph-integration" },
+        "parentTaskId": { "type": "string" },
+        "state": { "type": "string", "enum": ["PENDING", "RUNNING", "SUCCEEDED", "FAILED"] },
+        "status": { "type": "string", "enum": ["PENDING", "RUNNING", "SUCCEEDED", "FAILED"] },
+        "baseCommit": { "type": ["string", "null"], "pattern": "^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$" },
+        "worktreePath": { "type": ["string", "null"] },
+        "branch": { "type": ["string", "null"] },
+        "ref": { "type": ["string", "null"] },
+        "worktreeHead": { "type": ["string", "null"], "pattern": "^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$" },
+        "aggregateCommit": { "type": ["string", "null"], "pattern": "^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$" },
+        "sourceFingerprint": { "type": ["string", "null"] },
+        "sourceRefs": { "type": "array", "maxItems": 256 },
+        "appliedRefs": { "type": "array", "maxItems": 256 },
+        "appliedCommits": { "type": "array", "maxItems": 256 },
+        "appliedSubtasks": { "type": "array", "maxItems": 256 },
+        "conflict": { "type": ["object", "null"] },
+        "cleanup": { "type": ["object", "null"] },
+        "evidence": { "type": "array", "maxItems": 64 },
+        "reason": { "type": ["string", "null"] },
+        "lastError": { "type": ["object", "string", "null"] },
+        "createdAt": { "type": "string", "format": "date-time" },
+        "updatedAt": { "type": "string", "format": "date-time" }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/task-graph-v1-record.schema.json
+++ b/schemas/task-graph-v1-record.schema.json
@@ -34,7 +34,10 @@
     "createdAt": { "type": "string", "format": "date-time" },
     "updatedAt": { "type": "string", "format": "date-time" },
     "subtasks": { "type": "array", "minItems": 1, "maxItems": 256, "items": { "$ref": "#/$defs/subtask" } },
-    "frontier": { "$ref": "#/$defs/frontier" }
+    "frontier": { "$ref": "#/$defs/frontier" },
+    "integration": { "anyOf": [{ "$ref": "#/$defs/integration" }, { "type": "null" }] },
+    "review": { "anyOf": [{ "$ref": "#/$defs/review" }, { "type": "null" }] },
+    "reviewHistory": { "type": "array", "maxItems": 64, "items": { "$ref": "#/$defs/review" } }
   },
   "$defs": {
     "parentTask": {
@@ -115,6 +118,60 @@
         "reasons": { "type": "object", "additionalProperties": { "type": ["string", "null"] } }
       },
       "additionalProperties": false
+    },
+    "integration": {
+      "type": "object",
+      "required": ["schemaVersion", "kind", "parentTaskId", "state", "status", "createdAt", "updatedAt"],
+      "properties": {
+        "schemaVersion": { "const": 1 },
+        "kind": { "const": "task-graph-integration" },
+        "parentTaskId": { "type": "string", "pattern": "^task-[A-Za-z0-9][A-Za-z0-9_-]{1,127}$" },
+        "state": { "type": "string", "enum": ["PENDING", "RUNNING", "SUCCEEDED", "FAILED"] },
+        "status": { "type": "string", "enum": ["PENDING", "RUNNING", "SUCCEEDED", "FAILED"] },
+        "reason": { "type": ["string", "null"], "maxLength": 8192 },
+        "lastError": {
+          "anyOf": [
+            { "type": "object" },
+            { "type": "string" },
+            { "type": "null" }
+          ]
+        },
+        "baseCommit": { "type": ["string", "null"], "pattern": "^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$" },
+        "worktreePath": { "type": ["string", "null"] },
+        "branch": { "type": ["string", "null"] },
+        "ref": { "type": ["string", "null"] },
+        "worktreeHead": { "type": ["string", "null"], "pattern": "^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$" },
+        "aggregateCommit": { "type": ["string", "null"], "pattern": "^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$" },
+        "sourceFingerprint": { "type": ["string", "null"] },
+        "sourceRefs": { "type": "array", "maxItems": 256, "items": { "type": "object" } },
+        "appliedRefs": { "type": "array", "maxItems": 256, "items": { "type": "object" } },
+        "appliedCommits": { "type": "array", "maxItems": 256, "items": { "type": "string" } },
+        "appliedSubtasks": { "type": "array", "maxItems": 256, "items": { "type": "string" } },
+        "conflict": { "type": ["object", "null"] },
+        "cleanup": { "type": ["object", "null"] },
+        "evidence": { "type": "array", "maxItems": 64 },
+        "createdAt": { "type": "string", "format": "date-time" },
+        "updatedAt": { "type": "string", "format": "date-time" }
+      },
+      "additionalProperties": true
+    },
+    "review": {
+      "type": "object",
+      "required": ["schemaVersion", "kind", "decision", "reviewer", "feedback", "decidedAt"],
+      "properties": {
+        "schemaVersion": { "const": 1 },
+        "kind": { "const": "task-graph-review" },
+        "decision": { "type": "string", "enum": ["REVIEW_APPROVED", "CHANGES_REQUESTED"] },
+        "reviewer": { "type": "string" },
+        "feedback": { "type": "string", "maxLength": 8192 },
+        "integrationCommit": { "type": ["string", "null"] },
+        "integrationWorktreePath": { "type": ["string", "null"] },
+        "integrationBranch": { "type": ["string", "null"] },
+        "integrationRef": { "type": ["string", "null"] },
+        "evidence": { "type": "array", "maxItems": 64 },
+        "decidedAt": { "type": "string", "format": "date-time" }
+      },
+      "additionalProperties": true
     }
   },
   "additionalProperties": false

--- a/schemas/task-graph-v1-recovery.schema.json
+++ b/schemas/task-graph-v1-recovery.schema.json
@@ -15,6 +15,12 @@
     "before": { "type": "array", "items": { "$ref": "#/$defs/recoveryFact" } },
     "recovery": { "type": "array", "items": { "$ref": "#/$defs/recoveryFact" } },
     "cleanup": { "type": "array", "items": { "$ref": "#/$defs/cleanupFact" } },
+    "integrationCleanup": {
+      "anyOf": [
+        { "$ref": "#/$defs/integrationCleanupFact" },
+        { "type": "null" }
+      ]
+    },
     "outcomes": { "type": "array", "maxItems": 256, "items": { "$ref": "#/$defs/outcome" } },
     "dispatchRequired": { "type": "boolean" },
     "automaticRetry": { "const": false }
@@ -98,6 +104,25 @@
         "worktree": { "$ref": "#/$defs/worktree" },
         "session": { "$ref": "#/$defs/session" },
         "status": { "type": ["string", "null"] }
+      },
+      "additionalProperties": true
+    },
+    "integrationCleanupFact": {
+      "type": "object",
+      "required": ["parentTaskId", "status", "integrationState", "worktree"],
+      "properties": {
+        "root": { "type": "string", "minLength": 1 },
+        "parentTaskId": { "type": "string", "pattern": "^task-[A-Za-z0-9][A-Za-z0-9_-]{1,127}$" },
+        "status": { "type": "string", "enum": ["CLEANED", "FAILED", "SKIPPED"] },
+        "idempotent": { "type": "boolean" },
+        "integrationState": { "type": "string", "enum": ["PENDING", "RUNNING", "SUCCEEDED", "FAILED"] },
+        "worktree": { "$ref": "#/$defs/worktree" },
+        "error": {
+          "anyOf": [
+            { "$ref": "#/$defs/error" },
+            { "type": "null" }
+          ]
+        }
       },
       "additionalProperties": true
     },

--- a/schemas/task-graph-v1-review.schema.json
+++ b/schemas/task-graph-v1-review.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/hogancv/coordinate-agents/schemas/task-graph-v1-review.schema.json",
+  "title": "Coordinate Agents Task Graph v1 aggregate review result",
+  "description": "Existing reviewer boundary for an isolated, successfully integrated Task Graph.",
+  "type": "object",
+  "required": ["ok", "command", "root", "graphId", "parentTaskId", "decision", "review", "integration", "graph"],
+  "properties": {
+    "ok": { "const": true },
+    "command": { "const": "task.graph-review" },
+    "root": { "type": "string", "minLength": 1 },
+    "graphId": { "type": "string", "pattern": "^task-[A-Za-z0-9][A-Za-z0-9_-]{1,127}$" },
+    "parentTaskId": { "type": "string", "pattern": "^task-[A-Za-z0-9][A-Za-z0-9_-]{1,127}$" },
+    "decision": { "type": "string", "enum": ["REVIEW_APPROVED", "CHANGES_REQUESTED"] },
+    "review": { "$ref": "#/$defs/review" },
+    "integration": { "type": ["object", "null"] },
+    "graph": { "$ref": "./task-graph-v1-record.schema.json" },
+    "changed": { "type": "boolean" },
+    "event": { "type": ["object", "null"] },
+    "release": {
+      "type": "object",
+      "required": ["authorized"],
+      "properties": {
+        "authorized": { "const": false },
+        "required": { "type": "string" }
+      },
+      "additionalProperties": true
+    }
+  },
+  "$defs": {
+    "review": {
+      "type": "object",
+      "required": ["schemaVersion", "kind", "decision", "reviewer", "feedback", "integrationCommit", "decidedAt"],
+      "properties": {
+        "schemaVersion": { "const": 1 },
+        "kind": { "const": "task-graph-review" },
+        "decision": { "type": "string", "enum": ["REVIEW_APPROVED", "CHANGES_REQUESTED"] },
+        "reviewer": { "type": "string" },
+        "feedback": { "type": "string" },
+        "integrationCommit": { "type": ["string", "null"], "pattern": "^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$" },
+        "integrationWorktreePath": { "type": ["string", "null"] },
+        "integrationBranch": { "type": ["string", "null"] },
+        "integrationRef": { "type": ["string", "null"] },
+        "evidence": { "type": "array", "maxItems": 64 },
+        "decidedAt": { "type": "string", "format": "date-time" }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/skills/coordinate-agents/SKILL.md
+++ b/skills/coordinate-agents/SKILL.md
@@ -75,7 +75,8 @@ remains a fallback for hosts without direct App skill execution.
 | "Which coding CLIs are installed?" | `coordinate-setup` | `coordinate_agents_setup_discover` |
 | "Configure the implementation agent." | `coordinate-setup` | `coordinate_agents_setup_configure` |
 | "Build this feature with Coordinate Agents." | `coordinate-task` | `coordinate_agents_task_create`, `coordinate_agents_task_dispatch` |
-| "Validate, persist, plan, run, recover, resume, stop, or clean up subtasks in a Task Graph." | `coordinate-task` / `coordinate-recover` | `coordinate_agents_task_graph_validate`, `coordinate_agents_task_graph_create`, `coordinate_agents_task_graph_plan`, `coordinate_agents_task_graph_run`, `coordinate_agents_task_graph_dispatch`, `coordinate_agents_task_graph_recover`, `coordinate_agents_task_graph_resume`, `coordinate_agents_task_graph_stop`, `coordinate_agents_task_graph_cleanup` |
+| "Validate, persist, plan, run, recover, resume, stop, clean up, or integrate subtasks in a Task Graph." | `coordinate-task` / `coordinate-recover` | `coordinate_agents_task_graph_validate`, `coordinate_agents_task_graph_create`, `coordinate_agents_task_graph_plan`, `coordinate_agents_task_graph_run`, `coordinate_agents_task_graph_dispatch`, `coordinate_agents_task_graph_recover`, `coordinate_agents_task_graph_resume`, `coordinate_agents_task_graph_stop`, `coordinate_agents_task_graph_cleanup`, `coordinate_agents_task_graph_integrate` |
+| "Review an integrated Task Graph aggregate." | `coordinate-review` | `coordinate_agents_task_graph_review` |
 | "Review the implementation." | `coordinate-review` | `coordinate_agents_task_inspect`, `coordinate_agents_task_review` |
 | "Continue the last task." | `coordinate-recover` | `coordinate_agents_recover_inspect`, `coordinate_agents_task_resume`, `coordinate_agents_task_dispatch` |
 | "Inspect or control the Implementer session." | `coordinate-task` / `coordinate-recover` | `coordinate_agents_session_open`, `coordinate_agents_session_status`, `coordinate_agents_session_inspect`, `coordinate_agents_session_write`, `coordinate_agents_session_read`, `coordinate_agents_session_close` |
@@ -119,6 +120,14 @@ exited/failed Sessions are returned to READY for a separate dispatch. Call
 cleanup. These operations preserve user worktrees, refs, commits, and
 evidence and are idempotent. Existing Task status and inspect tools recognize
 a graph parent ID and return its durable graph view.
+
+After every required subtask succeeds, call
+`coordinate_agents_task_graph_integrate` to verify exact source refs and
+apply commits in sorted subtask-id order to a separate Runtime-owned aggregate
+worktree. Inspect the aggregate through `coordinate_agents_task_graph_review`
+and record `REVIEW_APPROVED` or `CHANGES_REQUESTED`; neither integration nor
+review authorizes merge, push, tag, publish, deploy, or release. Conflicts
+remain inspectable and require explicit cleanup or resolution.
 
 Session operations are explicit and bounded: `session_open` resolves the
 configured executable and starts or reuses one Session; `status` and `inspect`

--- a/skills/coordinate-agents/scripts/runtime-services.mjs
+++ b/skills/coordinate-agents/scripts/runtime-services.mjs
@@ -24,6 +24,8 @@ import {
   runtimeTaskGraphResume,
   runtimeTaskGraphStop,
   runtimeTaskGraphCleanup,
+  runtimeTaskGraphIntegrate,
+  runtimeTaskGraphReview,
   runtimeTaskGraphDispatch,
   runtimeTaskOperation,
 } from '../../../bin/coordinate-agents.mjs';
@@ -57,6 +59,8 @@ export {
   runtimeTaskGraphResume,
   runtimeTaskGraphStop,
   runtimeTaskGraphCleanup,
+  runtimeTaskGraphIntegrate,
+  runtimeTaskGraphReview,
   runtimeRecoverInspect,
 };
 export {
@@ -85,6 +89,8 @@ export const RUNTIME_OPERATIONS = Object.freeze({
   taskGraphResume: runtimeTaskGraphResume,
   taskGraphStop: runtimeTaskGraphStop,
   taskGraphCleanup: runtimeTaskGraphCleanup,
+  taskGraphIntegrate: runtimeTaskGraphIntegrate,
+  taskGraphReview: runtimeTaskGraphReview,
   taskGraphDispatch: runtimeTaskGraphDispatch,
   taskDispatch: input => runtimeTaskOperation('dispatch', input),
   taskStatus: input => runtimeTaskOperation('status', input),

--- a/skills/coordinate-agents/scripts/task-graph-runtime.mjs
+++ b/skills/coordinate-agents/scripts/task-graph-runtime.mjs
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { existsSync, lstatSync, mkdirSync, readdirSync, realpathSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { dirname, join, resolve } from 'node:path';
@@ -23,7 +24,7 @@ import {
   taskGraphDurableFacts,
   validateTaskGraphV1,
 } from './task-graph-contract.mjs';
-import { runtimeError } from './runtime-contract.mjs';
+import { runtimeError, serializeRuntimeError } from './runtime-contract.mjs';
 import {
   appendRuntimeEvent,
   readRuntimeEvents,
@@ -34,6 +35,8 @@ import { EXECUTION_SESSION_STATES } from './session-manager.mjs';
 
 export const TASK_GRAPH_STORE_DIRECTORY = 'task-graphs';
 export const TASK_GRAPH_WORKTREES_DIRECTORY = 'worktrees';
+export const TASK_GRAPH_INTEGRATION_DIRECTORY = '__integration__';
+export const TASK_GRAPH_INTEGRATION_STATES = Object.freeze(['PENDING', 'RUNNING', 'SUCCEEDED', 'FAILED']);
 export const TASK_GRAPH_MAX_REASON_BYTES = 8 * 1024;
 export const TASK_GRAPH_MAX_EVIDENCE_ITEMS = 64;
 export const TASK_GRAPH_EVENT_LIMIT = 100;
@@ -42,6 +45,7 @@ const COMMIT_SHA_PATTERN = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
 
 const GRAPH_STATE_SET = new Set(TASK_GRAPH_STATES);
 const SUBTASK_STATE_SET = new Set(TASK_GRAPH_SUBTASK_STATES);
+const INTEGRATION_STATE_SET = new Set(TASK_GRAPH_INTEGRATION_STATES);
 const TERMINAL_SUBTASK_STATES = new Set(['SUCCEEDED', 'FAILED', 'STOPPED']);
 const FAILED_SUBTASK_STATES = new Set(['FAILED', 'BLOCKED', 'STOPPED']);
 // PENDING/READY/WAITING are frontier states derived from dependency facts.
@@ -206,6 +210,44 @@ export function taskGraphBranchName(parentTaskId, subtaskId) {
 
 export function taskGraphBranchRef(parentTaskId, subtaskId) {
   return `refs/heads/${taskGraphBranchName(parentTaskId, subtaskId)}`;
+}
+
+function graphParentIdentifier(parentTaskId) {
+  try {
+    return validateTaskId(parentTaskId);
+  } catch {
+    throw runtimeError('TASK_GRAPH_INVALID', `Invalid Task Graph parent Task identifier: ${parentTaskId || '(empty)'}.`, {
+      recoverable: false,
+      stage: 'graph-validation',
+      taskId: parentTaskId || null,
+    });
+  }
+}
+
+/**
+ * Integration has a path component that cannot be a valid subtask id. This
+ * keeps the aggregate review worktree separate even when a graph contains a
+ * subtask whose title happens to mention integration.
+ */
+export function taskGraphIntegrationWorktreePath(root, parentTaskId) {
+  const repository = repositoryRoot(root);
+  const worktrees = taskGraphWorktreesRoot(repository);
+  const validParentId = graphParentIdentifier(parentTaskId);
+  const parentWorktrees = join(worktrees, validParentId);
+  assertContained(worktrees, parentWorktrees);
+  assertSafePath(repository, parentWorktrees);
+  const path = join(parentWorktrees, TASK_GRAPH_INTEGRATION_DIRECTORY);
+  assertContained(parentWorktrees, path);
+  if (existsSync(path)) assertSafePath(repository, path);
+  return path;
+}
+
+export function taskGraphIntegrationBranchName(parentTaskId) {
+  return `coordinate-agents/${graphParentIdentifier(parentTaskId)}/${TASK_GRAPH_INTEGRATION_DIRECTORY}`;
+}
+
+export function taskGraphIntegrationBranchRef(parentTaskId) {
+  return `refs/heads/${taskGraphIntegrationBranchName(parentTaskId)}`;
 }
 
 export function captureGraphBaseCommit(root) {
@@ -440,6 +482,91 @@ function inspectGraphWorktree(root, parentTaskId, subtaskId, {
     // until the explicit Git probe used by recovery/cleanup verifies the
     // exact Runtime branch and path.
     worktree.owned = false;
+  }
+  return worktree;
+}
+
+function inspectGraphIntegrationWorktree(root, parentTaskId, {
+  probeGit = false,
+  recordedPath = null,
+  recordedBranch = null,
+  recordedRef = null,
+  timeoutMs = null,
+} = {}) {
+  const repository = repositoryRoot(root);
+  const expectedBranch = taskGraphIntegrationBranchName(parentTaskId);
+  const expectedRef = taskGraphIntegrationBranchRef(parentTaskId);
+  let expectedPath;
+  let pathError = null;
+  try {
+    expectedPath = taskGraphIntegrationWorktreePath(repository, parentTaskId);
+  } catch (error) {
+    pathError = error;
+    expectedPath = join(repository, '.agent-bus', TASK_GRAPH_WORKTREES_DIRECTORY, parentTaskId, TASK_GRAPH_INTEGRATION_DIRECTORY);
+  }
+  let matchesRecord = null;
+  if (recordedPath || recordedBranch || recordedRef) {
+    try {
+      matchesRecord = (!recordedPath || pathMatches(recordedPath, expectedPath))
+        && (!recordedBranch || recordedBranch === expectedBranch)
+        && (!recordedRef || recordedRef === expectedRef);
+    } catch {
+      matchesRecord = false;
+    }
+  }
+  const worktree = {
+    path: expectedPath,
+    branch: expectedBranch,
+    ref: expectedRef,
+    recordedPath: recordedPath || null,
+    recordedBranch: recordedBranch || null,
+    recordedRef: recordedRef || null,
+    matchesRecord,
+    exists: false,
+    safe: false,
+    registered: false,
+    owned: false,
+    ownershipKnown: Boolean(probeGit && !pathError),
+    head: null,
+    registeredBranch: null,
+    error: pathError ? boundedText(pathError.message || pathError) : null,
+  };
+  if (pathError) return worktree;
+  try {
+    const metadata = lstatSync(expectedPath);
+    if (metadata.isSymbolicLink()) throw new Error('symbolic link or junction');
+    assertSafePath(repository, expectedPath);
+    worktree.exists = metadata.isDirectory();
+    worktree.safe = worktree.exists;
+    if (!worktree.exists) worktree.error = 'path is not a directory';
+  } catch (error) {
+    if (error?.code !== 'ENOENT') worktree.error = boundedText(error.message || error);
+  }
+  if (!probeGit) return worktree;
+
+  const listed = runGit(['worktree', 'list', '--porcelain'], repository, { timeoutMs });
+  if (listed.error || listed.status !== 0) {
+    worktree.ownershipKnown = false;
+    worktree.error = boundedText(listed.stderr || listed.stdout || listed.error?.message || 'unable to inspect Git worktrees');
+    return worktree;
+  }
+  const entry = gitWorktreeEntries(listed.stdout).find(candidate => pathMatches(candidate.path || '', expectedPath));
+  if (!entry) {
+    worktree.owned = false;
+    if (worktree.safe && !worktree.error) worktree.error = 'worktree path is not registered with Git';
+    return worktree;
+  }
+  worktree.registered = true;
+  worktree.head = entry.head || null;
+  worktree.registeredBranch = entry.branch || null;
+  const missingSafePath = !worktree.exists && !worktree.error;
+  worktree.owned = matchesRecord !== false
+    && entry.branch === expectedRef
+    && (worktree.safe || missingSafePath);
+  if (matchesRecord === false) {
+    worktree.error = 'recorded integration worktree identity does not match the canonical Runtime path';
+  } else if (entry.branch !== expectedRef) {
+    worktree.error = `unexpected registered branch: ${entry.branch || '(detached)'}`;
   }
   return worktree;
 }
@@ -726,6 +853,150 @@ export function ensureSubtaskWorktree(root, parentTaskId, subtaskId, baseCommit)
   return { worktreePath, branch: branchName, ref: branchRef, reused: false };
 }
 
+/**
+ * Create the Runtime-owned aggregate worktree from the captured graph base.
+ * Unlike a subtask worktree, the integration worktree is deliberately not
+ * addressable by a user-provided subtask identifier.
+ */
+export function ensureTaskGraphIntegrationWorktree(root, parentTaskId, baseCommit) {
+  const repository = repositoryRoot(root);
+  const worktreePath = taskGraphIntegrationWorktreePath(repository, parentTaskId);
+  const branchName = taskGraphIntegrationBranchName(parentTaskId);
+  const branchRef = taskGraphIntegrationBranchRef(parentTaskId);
+  const expectedHead = normalizeCommitSha(baseCommit, 'graph base commit');
+  const worktreesRoot = taskGraphWorktreesRoot(repository);
+  const parentWorktrees = dirname(worktreePath);
+  assertSafePath(repository, worktreesRoot);
+  assertSafePath(repository, parentWorktrees);
+
+  let targetMetadata = null;
+  try { targetMetadata = lstatSync(worktreePath); } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
+  if (targetMetadata?.isSymbolicLink()) {
+    throw graphWorktreeConflict(`Refusing symbolic link or junction at Task Graph integration worktree path: ${worktreePath}`, {
+      taskId: parentTaskId,
+      root: repository,
+      stage: 'integration-worktree',
+    });
+  }
+
+  const listWorktrees = () => {
+    const result = runGit(['worktree', 'list', '--porcelain'], repository);
+    if (result.error || result.status !== 0) {
+      throw graphWorktreeConflict(`Unable to inspect existing Git worktrees for ${worktreePath}.`, {
+        taskId: parentTaskId,
+        root: repository,
+        stage: 'integration-worktree',
+        details: (result.stderr || result.stdout || result.error?.message || '').trim(),
+      });
+    }
+    return gitWorktreeEntries(result.stdout);
+  };
+
+  if (targetMetadata) {
+    assertSafePath(repository, worktreePath);
+    if (!targetMetadata.isDirectory()) {
+      throw graphWorktreeConflict(`Task Graph integration worktree path is not a directory: ${worktreePath}`, {
+        taskId: parentTaskId,
+        root: repository,
+        stage: 'integration-worktree',
+      });
+    }
+    const registered = listWorktrees().find(entry => pathMatches(entry.path || '', worktreePath));
+    if (!registered) {
+      throw graphWorktreeConflict(`Refusing to replace an existing non-Runtime integration worktree path: ${worktreePath}`, {
+        taskId: parentTaskId,
+        root: repository,
+        stage: 'integration-worktree',
+      });
+    }
+    if (registered.branch !== branchRef) {
+      throw graphWorktreeConflict(`Existing Task Graph integration worktree is attached to unexpected branch ${registered.branch || '(detached)'}.`, {
+        taskId: parentTaskId,
+        root: repository,
+        stage: 'integration-worktree',
+        details: { expectedBranch: branchRef, actualBranch: registered.branch || null },
+      });
+    }
+    if (registered.head?.toLowerCase() !== expectedHead) {
+      throw graphWorktreeConflict(`Existing Task Graph integration worktree does not point at the captured base commit: ${worktreePath}`, {
+        taskId: parentTaskId,
+        root: repository,
+        stage: 'integration-worktree',
+        details: { expectedHead, actualHead: registered.head || null },
+      });
+    }
+    return { worktreePath, branch: branchName, ref: branchRef, reused: true };
+  }
+
+  const registeredTarget = listWorktrees().find(entry => pathMatches(entry.path || '', worktreePath));
+  if (registeredTarget) {
+    throw graphWorktreeConflict(`Git still registers the Runtime integration worktree path and requires explicit cleanup: ${worktreePath}`, {
+      taskId: parentTaskId,
+      root: repository,
+      stage: 'integration-worktree',
+      details: { registeredHead: registeredTarget.head || null, registeredBranch: registeredTarget.branch || null },
+    });
+  }
+  assertSafePath(repository, parentWorktrees);
+  mkdirSync(parentWorktrees, { recursive: true });
+  assertSafePath(repository, parentWorktrees);
+
+  const branchCheck = runGit(['rev-parse', '--verify', branchRef], repository);
+  if (branchCheck.error) {
+    throw graphWorktreeConflict(`Unable to inspect Task Graph integration branch ${branchRef}.`, {
+      taskId: parentTaskId,
+      root: repository,
+      stage: 'integration-worktree',
+      details: branchCheck.error.message || String(branchCheck.error),
+    });
+  }
+  const branchExists = branchCheck.status === 0;
+  if (branchExists && branchCheck.stdout.trim().toLowerCase() !== expectedHead) {
+    throw graphWorktreeConflict(`Existing Task Graph integration branch ${branchRef} does not point at the captured base commit.`, {
+      taskId: parentTaskId,
+      root: repository,
+      stage: 'integration-worktree',
+      details: { expectedHead, actualHead: branchCheck.stdout.trim().toLowerCase() },
+    });
+  }
+
+  const addArgs = branchExists
+    ? ['worktree', 'add', worktreePath, branchRef]
+    : ['worktree', 'add', '-b', branchName, worktreePath, baseCommit];
+  const added = runGit(addArgs, repository);
+  if (added.error || added.status !== 0) {
+    const errorDetails = (added.stderr || added.stdout || added.error?.message || '').trim();
+    throw runtimeError('TASK_STATE_CONFLICT', `Failed to create Git integration worktree: ${errorDetails}`, {
+      recoverable: true,
+      taskId: parentTaskId,
+      root: repository,
+      stage: 'integration-worktree',
+    });
+  }
+
+  assertSafePath(repository, worktreePath);
+  const createdResult = runGit(['worktree', 'list', '--porcelain'], repository);
+  const created = !createdResult.error && createdResult.status === 0
+    ? gitWorktreeEntries(createdResult.stdout).find(entry => pathMatches(entry.path || '', worktreePath))
+    : null;
+  if (!created || created.branch !== branchRef || created.head?.toLowerCase() !== expectedHead) {
+    throw graphWorktreeConflict(`Created Git integration worktree failed Runtime ownership verification: ${worktreePath}`, {
+      taskId: parentTaskId,
+      root: repository,
+      stage: 'integration-worktree',
+      details: { expectedBranch: branchRef, actualBranch: created?.branch || null, expectedHead, actualHead: created?.head || null },
+    });
+  }
+  return { worktreePath, branch: branchName, ref: branchRef, reused: false };
+}
+
+// Descriptive aliases keep the aggregate worktree helpers discoverable to
+// transports and downstream Runtime consumers.
+export const ensureGraphIntegrationWorktree = ensureTaskGraphIntegrationWorktree;
+export const taskGraphIntegrationPath = taskGraphIntegrationWorktreePath;
+
 function ensureGraphStore(root, { create = false } = {}) {
   const repository = repositoryRoot(root);
   const bus = graphBusPath(repository);
@@ -918,7 +1189,86 @@ function graphRecordFromValidated(validated) {
     updatedAt: timestamp,
     subtasks: reconciled,
     frontier: frontierFor(reconciled, validated.maxConcurrency),
+    integration: null,
+    review: null,
+    reviewHistory: [],
   };
+}
+
+function validateStoredIntegration(integration, parentTaskId) {
+  if (!plainObject(integration)) {
+    throw runtimeError('TASK_STATE_CONFLICT', `Task Graph ${parentTaskId} has a malformed integration record.`, { recoverable: false, taskId: parentTaskId });
+  }
+  if (integration.schemaVersion !== TASK_GRAPH_SCHEMA_VERSION || integration.kind !== 'task-graph-integration') {
+    throw runtimeError('TASK_STATE_CONFLICT', `Task Graph ${parentTaskId} has an unsupported integration schema.`, { recoverable: false, taskId: parentTaskId });
+  }
+  if (integration.parentTaskId !== parentTaskId || !INTEGRATION_STATE_SET.has(integration.state) || integration.status !== integration.state) {
+    throw runtimeError('TASK_STATE_CONFLICT', `Task Graph ${parentTaskId} has an invalid integration state.`, { recoverable: false, taskId: parentTaskId });
+  }
+  for (const [label, value] of [
+    ['integration base commit', integration.baseCommit],
+    ['aggregate commit', integration.aggregateCommit],
+    ['worktree head', integration.worktreeHead],
+  ]) {
+    if (value !== undefined && value !== null && !COMMIT_SHA_PATTERN.test(`${value}`)) {
+      throw runtimeError('TASK_STATE_CONFLICT', `Task Graph ${parentTaskId} has an invalid ${label}.`, { recoverable: false, taskId: parentTaskId });
+    }
+  }
+  for (const [label, value] of [
+    ['worktreePath', integration.worktreePath],
+    ['branch', integration.branch],
+    ['ref', integration.ref],
+    ['sourceFingerprint', integration.sourceFingerprint],
+  ]) {
+    if (value !== undefined && value !== null && typeof value !== 'string') {
+      throw runtimeError('TASK_STATE_CONFLICT', `Task Graph ${parentTaskId} has an invalid integration ${label}.`, { recoverable: false, taskId: parentTaskId });
+    }
+  }
+  for (const [label, value] of [
+    ['appliedRefs', integration.appliedRefs],
+    ['sourceRefs', integration.sourceRefs],
+    ['appliedCommits', integration.appliedCommits],
+    ['appliedSubtasks', integration.appliedSubtasks],
+  ]) {
+    if (value !== undefined && value !== null && (!Array.isArray(value) || value.length > TASK_GRAPH_MAX_SUBTASKS)) {
+      throw runtimeError('TASK_STATE_CONFLICT', `Task Graph ${parentTaskId} has invalid integration ${label}.`, { recoverable: false, taskId: parentTaskId });
+    }
+  }
+  if (integration.evidence !== undefined && integration.evidence !== null
+    && (!Array.isArray(integration.evidence) || integration.evidence.length > TASK_GRAPH_MAX_EVIDENCE_ITEMS)) {
+    throw runtimeError('TASK_STATE_CONFLICT', `Task Graph ${parentTaskId} has invalid integration evidence.`, { recoverable: false, taskId: parentTaskId });
+  }
+  if (integration.conflict !== undefined && integration.conflict !== null && !plainObject(integration.conflict)) {
+    throw runtimeError('TASK_STATE_CONFLICT', `Task Graph ${parentTaskId} has an invalid integration conflict record.`, { recoverable: false, taskId: parentTaskId });
+  }
+  if (integration.cleanup !== undefined && integration.cleanup !== null && !plainObject(integration.cleanup)) {
+    throw runtimeError('TASK_STATE_CONFLICT', `Task Graph ${parentTaskId} has an invalid integration cleanup record.`, { recoverable: false, taskId: parentTaskId });
+  }
+  return integration;
+}
+
+function validateStoredReview(review, parentTaskId) {
+  if (review === undefined || review === null) return;
+  if (!plainObject(review)
+    || review.schemaVersion !== TASK_GRAPH_SCHEMA_VERSION
+    || review.kind !== 'task-graph-review'
+    || !['REVIEW_APPROVED', 'CHANGES_REQUESTED'].includes(review.decision)) {
+    throw runtimeError('TASK_STATE_CONFLICT', `Task Graph ${parentTaskId} has an invalid review record.`, { recoverable: false, taskId: parentTaskId });
+  }
+  if (typeof review.reviewer !== 'string' || !review.reviewer) {
+    throw runtimeError('TASK_STATE_CONFLICT', `Task Graph ${parentTaskId} has an invalid review reviewer.`, { recoverable: false, taskId: parentTaskId });
+  }
+  if (review.feedback !== undefined && typeof review.feedback !== 'string') {
+    throw runtimeError('TASK_STATE_CONFLICT', `Task Graph ${parentTaskId} has invalid review feedback.`, { recoverable: false, taskId: parentTaskId });
+  }
+  if (review.integrationCommit !== undefined && review.integrationCommit !== null
+    && !COMMIT_SHA_PATTERN.test(`${review.integrationCommit}`)) {
+    throw runtimeError('TASK_STATE_CONFLICT', `Task Graph ${parentTaskId} has an invalid review integration commit.`, { recoverable: false, taskId: parentTaskId });
+  }
+  if (review.evidence !== undefined && review.evidence !== null
+    && (!Array.isArray(review.evidence) || review.evidence.length > TASK_GRAPH_MAX_EVIDENCE_ITEMS)) {
+    throw runtimeError('TASK_STATE_CONFLICT', `Task Graph ${parentTaskId} has invalid review evidence.`, { recoverable: false, taskId: parentTaskId });
+  }
 }
 
 function validateStoredGraph(record, parentTaskId = null) {
@@ -952,6 +1302,12 @@ function validateStoredGraph(record, parentTaskId = null) {
   if (record.baseCommit && record.parentTask?.baseCommit && `${record.baseCommit}`.toLowerCase() !== `${record.parentTask.baseCommit}`.toLowerCase()) {
     throw runtimeError('TASK_STATE_CONFLICT', `Task Graph ${id} has conflicting base commit facts.`, { recoverable: false, taskId: id });
   }
+  if (record.integration !== undefined && record.integration !== null) validateStoredIntegration(record.integration, id);
+  validateStoredReview(record.review, id);
+  if (record.reviewHistory !== undefined && (!Array.isArray(record.reviewHistory) || record.reviewHistory.length > TASK_GRAPH_MAX_EVIDENCE_ITEMS)) {
+    throw runtimeError('TASK_STATE_CONFLICT', `Task Graph ${id} has invalid review history.`, { recoverable: false, taskId: id });
+  }
+  for (const review of record.reviewHistory || []) validateStoredReview(review, id);
   if (!plainObject(record.parentTask) || record.parentTask.id !== id) {
     throw runtimeError('TASK_STATE_CONFLICT', `Task Graph ${id} has an invalid parent Task record.`, { recoverable: false, taskId: id });
   }
@@ -1207,6 +1563,77 @@ export function cleanupTaskGraphWorktree(root, parentTaskId, subtaskId, {
   return { status: 'CLEANED', idempotent: false, worktree: after };
 }
 
+/** Remove only the exact Runtime-owned aggregate integration worktree. */
+export function cleanupTaskGraphIntegrationWorktree(root, parentTaskId, {
+  recordedPath = null,
+  recordedBranch = null,
+  recordedRef = null,
+  timeoutMs = 2_000,
+} = {}) {
+  const repository = repositoryRoot(root);
+  const boundedTimeoutMs = Math.max(100, Math.min(10_000, Number.isFinite(timeoutMs) ? Math.floor(timeoutMs) : 2_000));
+  const recorded = inspectGraphIntegrationWorktree(repository, parentTaskId, {
+    probeGit: true,
+    recordedPath,
+    recordedBranch,
+    recordedRef,
+    timeoutMs: boundedTimeoutMs,
+  });
+  const expectedPath = recorded.path || join(repository, '.agent-bus', TASK_GRAPH_WORKTREES_DIRECTORY, parentTaskId, TASK_GRAPH_INTEGRATION_DIRECTORY);
+  const failure = message => {
+    const error = runtimeError('TASK_STATE_CONFLICT', message, {
+      recoverable: true,
+      taskId: parentTaskId,
+      root: repository,
+      stage: 'integration-cleanup',
+      details: {
+        path: expectedPath,
+        registered: recorded.registered,
+        branch: recorded.registeredBranch || null,
+        matchesRecord: recorded.matchesRecord,
+      },
+    });
+    return { status: 'FAILED', idempotent: false, worktree: recorded, error: serializeCleanupError(error) };
+  };
+  if (recorded.matchesRecord === false) return failure(`Refusing to remove non-Runtime Task Graph integration worktree: ${expectedPath}`);
+  if (!recorded.exists && !recorded.registered && !recorded.error) {
+    return { status: 'CLEANED', idempotent: true, worktree: recorded };
+  }
+  if (!recorded.owned) return failure(`Refusing to remove non-Runtime Task Graph integration worktree: ${expectedPath}`);
+
+  const removed = runGit(['worktree', 'remove', '--force', expectedPath], repository, { timeoutMs: boundedTimeoutMs });
+  if (removed.error || removed.status !== 0) {
+    const error = runtimeError('TASK_STATE_CONFLICT', `Failed to remove Runtime-owned Task Graph integration worktree: ${expectedPath}`, {
+      recoverable: true,
+      taskId: parentTaskId,
+      root: repository,
+      stage: 'integration-cleanup',
+      details: (removed.stderr || removed.stdout || removed.error?.message || '').trim(),
+    });
+    return { status: 'FAILED', idempotent: false, worktree: recorded, error: serializeCleanupError(error) };
+  }
+  const after = inspectGraphIntegrationWorktree(repository, parentTaskId, {
+    probeGit: true,
+    recordedPath,
+    recordedBranch,
+    recordedRef,
+    timeoutMs: boundedTimeoutMs,
+  });
+  if (after.exists || after.registered) {
+    const error = runtimeError('TASK_STATE_CONFLICT', `Runtime-owned Task Graph integration cleanup remains incomplete: ${expectedPath}`, {
+      recoverable: true,
+      taskId: parentTaskId,
+      root: repository,
+      stage: 'integration-cleanup',
+      details: { path: expectedPath, exists: after.exists, registered: after.registered },
+    });
+    return { status: 'FAILED', idempotent: false, worktree: after, error: serializeCleanupError(error) };
+  }
+  return { status: 'CLEANED', idempotent: false, worktree: after };
+}
+
+export const cleanupGraphIntegrationWorktree = cleanupTaskGraphIntegrationWorktree;
+
 function serializeCleanupError(error) {
   return {
     code: error.code,
@@ -1365,6 +1792,9 @@ function graphFacts(record) {
         evidence: boundedEvidence(subtask?.evidence),
       };
     }),
+    integration: record.integration || null,
+    review: record.review || null,
+    reviewHistory: Array.isArray(record.reviewHistory) ? record.reviewHistory : [],
   };
 }
 
@@ -1398,6 +1828,7 @@ export function taskGraphStatusPayload(root, record, { inspect = false, eventLim
   const events = inspect
     ? readRuntimeEvents(root, { taskId: record.parentTaskId, limit: eventLimit })
     : undefined;
+  const integration = inspectTaskGraphIntegration(root, record, { probeGit: inspect });
   return {
     root: resolve(root),
     graphId: record.parentTaskId,
@@ -1412,9 +1843,694 @@ export function taskGraphStatusPayload(root, record, { inspect = false, eventLim
     frontier: record.frontier,
     facts: graphFacts(record),
     recovery: inspectTaskGraphRecovery(root, record),
+    integration: record.integration || null,
+    integrationFacts: integration,
+    review: record.review || null,
+    reviewHistory: Array.isArray(record.reviewHistory) ? record.reviewHistory : [],
     ...(inspect ? { events } : {}),
   };
 }
+
+function integrationRecordTemplate(parentTaskId, timestamp = now()) {
+  return {
+    schemaVersion: TASK_GRAPH_SCHEMA_VERSION,
+    kind: 'task-graph-integration',
+    parentTaskId,
+    state: 'PENDING',
+    status: 'PENDING',
+    reason: null,
+    lastError: null,
+    baseCommit: null,
+    worktreePath: null,
+    branch: null,
+    ref: null,
+    worktreeHead: null,
+    aggregateCommit: null,
+    sourceFingerprint: null,
+    sourceRefs: [],
+    appliedRefs: [],
+    appliedCommits: [],
+    appliedSubtasks: [],
+    conflict: null,
+    cleanup: null,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+}
+
+function normalizeIntegrationArray(value, limit = TASK_GRAPH_MAX_SUBTASKS) {
+  if (!Array.isArray(value)) return [];
+  return value.slice(0, limit).map(item => typeof item === 'string'
+    ? boundedText(item, '')
+    : sanitizeRuntimeEventData(item));
+}
+
+function integrationErrorDetails(error) {
+  return serializeRuntimeError(error, { includeLegacy: true });
+}
+
+/**
+ * Update the durable integration state without changing the graph lifecycle
+ * state. The graph lock serializes each applied commit so a coordinator
+ * restart can inspect exactly how far the aggregate worktree progressed.
+ */
+export function setTaskGraphIntegration(root, parentTaskId, nextState, details = {}) {
+  if (!INTEGRATION_STATE_SET.has(nextState)) {
+    throw runtimeError('TASK_STATE_CONFLICT', `Unsupported Task Graph integration state: ${nextState}`, {
+      recoverable: false,
+      taskId: parentTaskId,
+      stage: 'graph-integration',
+    });
+  }
+  const { repository, bus, tmp } = ensureGraphStore(root);
+  const path = taskGraphPath(repository, parentTaskId);
+  const release = acquireConfigLock(bus);
+  try {
+    const current = readStoredGraph(repository, parentTaskId);
+    const previous = current.integration;
+    if (details.expectedState !== undefined && (previous?.state || 'PENDING') !== details.expectedState) {
+      throw runtimeError('TASK_STATE_CONFLICT', `Task Graph integration for ${parentTaskId} is ${previous?.state || 'PENDING'}; expected ${details.expectedState}.`, {
+        recoverable: true,
+        taskId: parentTaskId,
+        stage: 'graph-integration',
+        details: { expectedState: details.expectedState, actualState: previous?.state || 'PENDING' },
+      });
+    }
+    const timestamp = now();
+    const base = previous || integrationRecordTemplate(parentTaskId, timestamp);
+    const candidate = {
+      ...base,
+      ...Object.fromEntries(Object.entries(details).filter(([key]) => ![
+        'expectedState', 'operation', 'reason', 'evidence', 'sourceRefs', 'appliedRefs',
+        'appliedCommits', 'appliedSubtasks', 'conflict', 'cleanup', 'lastError',
+      ].includes(key))),
+      schemaVersion: TASK_GRAPH_SCHEMA_VERSION,
+      kind: 'task-graph-integration',
+      parentTaskId,
+      state: nextState,
+      status: nextState,
+      reason: details.reason === undefined ? (base.reason || null) : boundedText(details.reason),
+      lastError: details.lastError === undefined
+        ? (base.lastError || null)
+        : (details.lastError ? sanitizeRuntimeEventData(details.lastError) : null),
+      sourceRefs: details.sourceRefs === undefined ? normalizeIntegrationArray(base.sourceRefs) : normalizeIntegrationArray(details.sourceRefs),
+      appliedRefs: details.appliedRefs === undefined ? normalizeIntegrationArray(base.appliedRefs) : normalizeIntegrationArray(details.appliedRefs),
+      appliedCommits: details.appliedCommits === undefined ? normalizeIntegrationArray(base.appliedCommits) : normalizeIntegrationArray(details.appliedCommits),
+      appliedSubtasks: details.appliedSubtasks === undefined ? normalizeIntegrationArray(base.appliedSubtasks) : normalizeIntegrationArray(details.appliedSubtasks),
+      conflict: details.conflict === undefined ? (base.conflict || null) : (details.conflict ? sanitizeRuntimeEventData(details.conflict) : null),
+      cleanup: details.cleanup === undefined ? (base.cleanup || null) : (details.cleanup ? sanitizeRuntimeEventData(details.cleanup) : null),
+      evidence: details.evidence === undefined ? normalizeIntegrationArray(base.evidence, TASK_GRAPH_MAX_EVIDENCE_ITEMS) : normalizeIntegrationArray(details.evidence, TASK_GRAPH_MAX_EVIDENCE_ITEMS),
+    };
+    const withoutTimestamps = value => ({ ...value, updatedAt: null, createdAt: null });
+    const changed = !sameJson(withoutTimestamps(base), withoutTimestamps(candidate));
+    if (!changed) return { graph: current, integration: previous || null, changed: false, event: null };
+    const next = {
+      ...current,
+      integration: { ...candidate, updatedAt: timestamp },
+      updatedAt: timestamp,
+    };
+    atomicWrite(path, `${JSON.stringify(next, null, 2)}\n`, tmp);
+    const event = appendRuntimeEvent(repository, {
+      type: 'TASK_GRAPH_INTEGRATION_STATE_CHANGED',
+      taskId: parentTaskId,
+      agentId: current.parentTask.planner,
+      role: 'planner',
+      data: {
+        from: previous?.state || null,
+        to: nextState,
+        operation: details.operation || null,
+        baseCommit: candidate.baseCommit || null,
+        worktreePath: candidate.worktreePath || null,
+        branch: candidate.branch || null,
+        ref: candidate.ref || null,
+        aggregateCommit: candidate.aggregateCommit || null,
+        sourceFingerprint: candidate.sourceFingerprint || null,
+        appliedRefs: candidate.appliedRefs,
+        conflict: candidate.conflict,
+        cleanup: candidate.cleanup,
+        lastError: candidate.lastError,
+      },
+    });
+    return { graph: next, integration: next.integration, changed: true, event };
+  } finally {
+    release();
+  }
+}
+
+function reviewRecordEqual(left, right) {
+  return Boolean(left && right)
+    && left.decision === right.decision
+    && left.feedback === right.feedback
+    && left.integrationCommit === right.integrationCommit
+    && sameJson(left.evidence || [], right.evidence || []);
+}
+
+/** Persist graph review decisions at the same boundary as single-Task review. */
+export function setTaskGraphReview(root, parentTaskId, decision, details = {}) {
+  const normalizedDecision = `${decision || ''}`.trim().toUpperCase();
+  if (!['REVIEW_APPROVED', 'CHANGES_REQUESTED'].includes(normalizedDecision)) {
+    throw runtimeError('TASK_STATE_CONFLICT', `Unsupported Task Graph review decision: ${decision || '(empty)'}`, {
+      recoverable: false,
+      taskId: parentTaskId,
+      stage: 'graph-review',
+    });
+  }
+  const feedback = details.feedback === undefined ? '' : boundedText(details.feedback, '');
+  if (normalizedDecision === 'CHANGES_REQUESTED' && !feedback) {
+    throw runtimeError('TASK_STATE_CONFLICT', 'CHANGES_REQUESTED requires review feedback.', {
+      recoverable: false,
+      taskId: parentTaskId,
+      stage: 'graph-review',
+    });
+  }
+  const { repository, bus, tmp } = ensureGraphStore(root);
+  const path = taskGraphPath(repository, parentTaskId);
+  const release = acquireConfigLock(bus);
+  try {
+    const current = readStoredGraph(repository, parentTaskId);
+    const integration = current.integration;
+    if (!integration || integration.state !== 'SUCCEEDED') {
+      throw runtimeError('TASK_STATE_CONFLICT', `Task Graph ${parentTaskId} must have a successful integration before review.`, {
+        recoverable: true,
+        taskId: parentTaskId,
+        stage: 'graph-review',
+        details: { integrationState: integration?.state || null },
+      });
+    }
+    if (current.state === 'STOPPED' || (current.state === 'APPROVED' && current.review?.decision !== normalizedDecision)) {
+      throw runtimeError('TASK_STATE_CONFLICT', `Task Graph ${parentTaskId} is ${current.state} and cannot record this review decision.`, {
+        recoverable: false,
+        taskId: parentTaskId,
+        stage: 'graph-review',
+      });
+    }
+    const timestamp = now();
+    const review = {
+      schemaVersion: TASK_GRAPH_SCHEMA_VERSION,
+      kind: 'task-graph-review',
+      decision: normalizedDecision,
+      reviewer: current.parentTask.reviewer,
+      feedback,
+      integrationCommit: integration.aggregateCommit || null,
+      integrationWorktreePath: integration.worktreePath || null,
+      integrationBranch: integration.branch || null,
+      integrationRef: integration.ref || null,
+      evidence: details.evidence === undefined || details.evidence === null
+        ? [{ type: 'TASK_GRAPH_INTEGRATION', integrationCommit: integration.aggregateCommit || null, appliedRefs: integration.appliedRefs || [] }]
+        : normalizeIntegrationArray(
+          Array.isArray(details.evidence) ? details.evidence : [details.evidence],
+          TASK_GRAPH_MAX_EVIDENCE_ITEMS,
+        ),
+      decidedAt: timestamp,
+    };
+    const nextState = normalizedDecision === 'REVIEW_APPROVED' ? 'APPROVED' : 'REVIEWING';
+    const sameDecision = reviewRecordEqual(current.review, review) && current.state === nextState;
+    if (sameDecision) return { graph: current, review: current.review, changed: false, event: null };
+    const history = [...(Array.isArray(current.reviewHistory) ? current.reviewHistory : []), review]
+      .slice(-TASK_GRAPH_MAX_EVIDENCE_ITEMS);
+    const next = {
+      ...current,
+      state: nextState,
+      status: nextState,
+      review,
+      reviewHistory: history,
+      parentTask: {
+        ...current.parentTask,
+        state: nextState,
+        status: nextState,
+      },
+      updatedAt: timestamp,
+    };
+    atomicWrite(path, `${JSON.stringify(next, null, 2)}\n`, tmp);
+    const event = appendRuntimeEvent(repository, {
+      type: normalizedDecision,
+      taskId: parentTaskId,
+      agentId: current.parentTask.reviewer,
+      role: 'reviewer',
+      data: {
+        graph: true,
+        decision: normalizedDecision,
+        feedback,
+        integrationCommit: review.integrationCommit,
+        appliedRefs: integration.appliedRefs || [],
+        evidence: review.evidence,
+      },
+    });
+    return { graph: next, review, changed: true, event };
+  } finally {
+    release();
+  }
+}
+
+function integrationSourceBaseCommit(graph) {
+  const values = [
+    graph.baseCommit,
+    graph.parentTask?.baseCommit,
+    ...graph.subtasks.map(subtask => subtask.baseCommit),
+  ].filter(value => value !== undefined && value !== null && `${value}`.trim());
+  if (values.length === 0) return null;
+  const normalized = values.map(value => normalizeCommitSha(value, 'graph base commit'));
+  const first = normalized[0];
+  if (normalized.some(value => value !== first)) {
+    throw runtimeError('TASK_STATE_CONFLICT', `Task Graph ${graph.parentTaskId} has conflicting base commit facts for integration.`, {
+      recoverable: true,
+      taskId: graph.parentTaskId,
+      stage: 'graph-integration',
+      details: { baseCommits: normalized },
+    });
+  }
+  return first;
+}
+
+/**
+ * Verify every required source before creating the aggregate worktree. The
+ * source ref must be the exact Runtime branch for that subtask and must still
+ * reach the recorded IMPLEMENTATION_DONE commit.
+ */
+export function verifyTaskGraphIntegrationSources(root, graph) {
+  const record = validateStoredGraph(graph);
+  const repository = repositoryRoot(root);
+  const baseCommit = integrationSourceBaseCommit(record);
+  if (!baseCommit) {
+    throw runtimeError('TASK_STATE_CONFLICT', `Task Graph ${record.parentTaskId} has no captured base commit for integration.`, {
+      recoverable: true,
+      taskId: record.parentTaskId,
+      root: repository,
+      stage: 'graph-integration',
+      details: { requiredFact: 'baseCommit' },
+    });
+  }
+  const unresolved = record.subtasks
+    .filter(subtask => subtask.state !== 'SUCCEEDED')
+    .map(subtask => ({ id: subtask.id, state: subtask.state, reason: boundedText(subtask.reason) }));
+  if (unresolved.length > 0) {
+    throw runtimeError('TASK_STATE_CONFLICT', `Task Graph ${record.parentTaskId} cannot integrate until every required subtask succeeds.`, {
+      recoverable: true,
+      taskId: record.parentTaskId,
+      root: repository,
+      stage: 'graph-integration',
+      details: { baseCommit, unresolved },
+    });
+  }
+
+  const sources = [];
+  for (const subtask of [...record.subtasks].sort((left, right) => compareIds(left.id, right.id))) {
+    const expectedBranch = taskGraphBranchName(record.parentTaskId, subtask.id);
+    const expectedRef = taskGraphBranchRef(record.parentTaskId, subtask.id);
+    const evidence = Array.isArray(subtask.evidence) && subtask.evidence.some(item => item?.type === 'IMPLEMENTATION_DONE'
+      && typeof item.relatedCommit === 'string'
+      && item.relatedCommit.toLowerCase() === `${subtask.implementationCommit || ''}`.toLowerCase());
+    if (!evidence) {
+      throw runtimeError('TASK_STATE_CONFLICT', `Subtask ${record.parentTaskId}/${subtask.id} lacks verified IMPLEMENTATION_DONE evidence.`, {
+        recoverable: true,
+        taskId: record.parentTaskId,
+        subtaskId: subtask.id,
+        root: repository,
+        stage: 'graph-integration',
+        details: { state: subtask.state, implementationCommit: subtask.implementationCommit || null, expectedRef },
+      });
+    }
+    if (subtask.branch !== expectedBranch || subtask.ref !== expectedRef) {
+      throw runtimeError('TASK_STATE_CONFLICT', `Subtask ${record.parentTaskId}/${subtask.id} does not have the exact Runtime source ref required for integration.`, {
+        recoverable: true,
+        taskId: record.parentTaskId,
+        subtaskId: subtask.id,
+        root: repository,
+        stage: 'graph-integration',
+        details: { expectedBranch, actualBranch: subtask.branch || null, expectedRef, actualRef: subtask.ref || null },
+      });
+    }
+    const commit = `${subtask.implementationCommit || ''}`.trim();
+    if (!COMMIT_SHA_PATTERN.test(commit)) {
+      throw runtimeError('TASK_STATE_CONFLICT', `Subtask ${record.parentTaskId}/${subtask.id} has no valid implementation commit for integration.`, {
+        recoverable: true,
+        taskId: record.parentTaskId,
+        subtaskId: subtask.id,
+        root: repository,
+        stage: 'graph-integration',
+        details: { implementationCommit: subtask.implementationCommit || null, expectedRef },
+      });
+    }
+    const refResult = runGit(['rev-parse', '--verify', `${expectedRef}^{commit}`], repository);
+    if (refResult.error || refResult.status !== 0) {
+      throw runtimeError('TASK_STATE_CONFLICT', `Subtask ${record.parentTaskId}/${subtask.id} source ref is missing: ${expectedRef}`, {
+        recoverable: true,
+        taskId: record.parentTaskId,
+        subtaskId: subtask.id,
+        root: repository,
+        stage: 'graph-integration',
+        details: (refResult.stderr || refResult.stdout || refResult.error?.message || '').trim(),
+      });
+    }
+    const refCommit = normalizeCommitSha(refResult.stdout, `source ref for ${subtask.id}`);
+    const candidate = normalizeCommitSha(commit, `implementation commit for ${subtask.id}`);
+    if (candidate === baseCommit) {
+      throw runtimeError('TASK_STATE_CONFLICT', `Subtask ${record.parentTaskId}/${subtask.id} implementation commit is the graph base commit.`, {
+        recoverable: true,
+        taskId: record.parentTaskId,
+        subtaskId: subtask.id,
+        root: repository,
+        stage: 'graph-integration',
+        details: { baseCommit, implementationCommit: candidate, expectedRef },
+      });
+    }
+    for (const [label, args] of [
+      ['base commit', ['merge-base', '--is-ancestor', baseCommit, candidate]],
+      ['source ref', ['merge-base', '--is-ancestor', candidate, refCommit]],
+    ]) {
+      const result = runGit(args, repository);
+      if (result.error || result.status !== 0) {
+        throw runtimeError('TASK_STATE_CONFLICT', `Subtask ${record.parentTaskId}/${subtask.id} implementation commit is not reachable from its verified ${label}.`, {
+          recoverable: true,
+          taskId: record.parentTaskId,
+          subtaskId: subtask.id,
+          root: repository,
+          stage: 'graph-integration',
+          details: { baseCommit, implementationCommit: candidate, expectedRef, refCommit, git: (result.stderr || result.stdout || result.error?.message || '').trim() },
+        });
+      }
+    }
+    sources.push({
+      order: sources.length,
+      subtaskId: subtask.id,
+      implementer: subtask.implementer,
+      branch: expectedBranch,
+      ref: expectedRef,
+      commit: candidate,
+      refCommit,
+      evidence: boundedEvidence(subtask.evidence),
+    });
+  }
+  const sourceFingerprint = createHash('sha256')
+    .update(JSON.stringify(sources.map(source => ({ subtaskId: source.subtaskId, ref: source.ref, commit: source.commit }))))
+    .digest('hex');
+  return { repository, parentTaskId: record.parentTaskId, baseCommit, sources, sourceFingerprint };
+}
+
+export function inspectTaskGraphIntegration(root, graph, { probeGit = false, timeoutMs = null } = {}) {
+  const record = validateStoredGraph(graph);
+  if (!record.integration) return null;
+  const integration = validateStoredIntegration(record.integration, record.parentTaskId);
+  const worktree = inspectGraphIntegrationWorktree(repositoryRoot(root), record.parentTaskId, {
+    probeGit,
+    recordedPath: integration.worktreePath || null,
+    recordedBranch: integration.branch || null,
+    recordedRef: integration.ref || null,
+    timeoutMs,
+  });
+  let clean = null;
+  let files = [];
+  let diffStat = null;
+  const head = integration.aggregateCommit || integration.worktreeHead || worktree.head || null;
+  const baseCommit = integration.baseCommit || record.baseCommit || record.parentTask?.baseCommit || null;
+  if (probeGit && worktree.safe && worktree.exists) {
+    const status = runGit(['status', '--porcelain=v1', '--untracked-files=all'], worktree.path, { timeoutMs });
+    clean = !status.error && status.status === 0 && !status.stdout.trim();
+  }
+  if (probeGit && worktree.safe && worktree.exists && baseCommit && head && COMMIT_SHA_PATTERN.test(`${baseCommit}`) && COMMIT_SHA_PATTERN.test(`${head}`)) {
+    const changed = runGit(['diff', '--name-only', `${baseCommit}..${head}`], worktree.path, { timeoutMs });
+    if (!changed.error && changed.status === 0) {
+      files = changed.stdout.split(/\r?\n/).map(value => boundedText(value)).filter(Boolean).slice(0, TASK_GRAPH_MAX_EVIDENCE_ITEMS);
+    }
+    const stat = runGit(['diff', '--stat', `${baseCommit}..${head}`], worktree.path, { timeoutMs });
+    if (!stat.error && stat.status === 0) diffStat = boundedText(stat.stdout);
+  }
+  return {
+    root: repositoryRoot(root),
+    parentTaskId: record.parentTaskId,
+    state: integration.state,
+    status: integration.status,
+    baseCommit: integration.baseCommit || null,
+    worktreePath: integration.worktreePath || worktree.path,
+    branch: integration.branch || worktree.branch,
+    ref: integration.ref || worktree.ref,
+    worktreeHead: integration.worktreeHead || worktree.head || null,
+    aggregateCommit: integration.aggregateCommit || null,
+    sourceFingerprint: integration.sourceFingerprint || null,
+    sourceRefs: integration.sourceRefs || [],
+    appliedRefs: integration.appliedRefs || [],
+    appliedCommits: integration.appliedCommits || [],
+    appliedSubtasks: integration.appliedSubtasks || [],
+    conflict: integration.conflict || null,
+    cleanup: integration.cleanup || null,
+    lastError: integration.lastError || null,
+    evidence: integration.evidence || [],
+    worktree,
+    clean,
+    diff: { baseCommit, head, files, stat: diffStat },
+  };
+}
+
+function gitConflictFacts(worktreePath, source, result, appliedRefs) {
+  const status = runGit(['status', '--porcelain=v1', '--untracked-files=all'], worktreePath);
+  const unmerged = runGit(['diff', '--name-only', '--diff-filter=U'], worktreePath);
+  const cherryPickHead = runGit(['rev-parse', '--verify', 'CHERRY_PICK_HEAD'], worktreePath);
+  const lines = `${unmerged.status === 0 ? unmerged.stdout : status.stdout || ''}`
+    .split(/\r?\n/)
+    .map(value => value.trim())
+    .filter(Boolean)
+    .map(value => value.replace(/^[ MARC?!U][ MARC?!U]\s+/, ''))
+    .map(value => boundedText(value, 1024))
+    .filter(Boolean);
+  return {
+    state: 'CONFLICTED',
+    inProgress: cherryPickHead.status === 0,
+    subtaskId: source.subtaskId,
+    order: source.order,
+    ref: source.ref,
+    branch: source.branch,
+    commit: source.commit,
+    appliedRefs: normalizeIntegrationArray(appliedRefs),
+    files: [...new Set(lines)].slice(0, TASK_GRAPH_MAX_EVIDENCE_ITEMS),
+    status: boundedText(status.stdout),
+    stdout: boundedText(result.stdout),
+    stderr: boundedText(result.stderr || result.error?.message),
+    detectedAt: now(),
+  };
+}
+
+function integrationErrorWithFacts(code, message, parentTaskId, root, details = {}) {
+  return runtimeError(code, message, {
+    recoverable: true,
+    taskId: parentTaskId,
+    root,
+    stage: 'graph-integration',
+    details,
+  });
+}
+
+/**
+ * Apply all verified subtask commits to a fresh aggregate worktree. Every
+ * successful cherry-pick is persisted before the next one starts; a conflict
+ * deliberately leaves Git's in-progress state in place for inspection.
+ */
+export function integrateTaskGraph(root, parentTaskId, { timeoutMs = 2_000 } = {}) {
+  const repository = repositoryRoot(root);
+  let graph = readTaskGraph(repository, parentTaskId);
+  const prepared = verifyTaskGraphIntegrationSources(repository, graph);
+  const prior = graph.integration;
+  if (prior?.state === 'SUCCEEDED') {
+    if (prior.sourceFingerprint === prepared.sourceFingerprint && prior.baseCommit?.toLowerCase() === prepared.baseCommit.toLowerCase()) {
+      return {
+        repository,
+        parentTaskId,
+        graph,
+        integration: inspectTaskGraphIntegration(repository, graph, { probeGit: true, timeoutMs }),
+        sources: prepared.sources,
+        idempotent: true,
+      };
+    }
+    throw integrationErrorWithFacts('TASK_STATE_CONFLICT', `Task Graph ${parentTaskId} already has a successful integration for different source commits.`, parentTaskId, repository, {
+      integration: prior,
+      requestedSourceFingerprint: prepared.sourceFingerprint,
+    });
+  }
+  if (prior?.state === 'RUNNING') {
+    throw integrationErrorWithFacts('TASK_STATE_CONFLICT', `Task Graph ${parentTaskId} integration is already RUNNING; inspect or reconcile it before retrying.`, parentTaskId, repository, {
+      integration: prior,
+    });
+  }
+  if (prior?.state === 'FAILED' && (prior.conflict || prior.appliedRefs?.length || prior.worktreePath)) {
+    throw integrationErrorWithFacts('WORKTREE_CONFLICT', `Task Graph ${parentTaskId} has a failed integration that requires explicit cleanup or conflict resolution.`, parentTaskId, repository, {
+      integration: prior,
+    });
+  }
+  if (['STOPPED', 'APPROVED'].includes(graph.state)) {
+    throw integrationErrorWithFacts('TASK_STATE_CONFLICT', `Task Graph ${parentTaskId} is ${graph.state} and cannot start integration.`, parentTaskId, repository, {
+      graphState: graph.state,
+    });
+  }
+
+  const identity = {
+    worktreePath: taskGraphIntegrationWorktreePath(repository, parentTaskId),
+    branch: taskGraphIntegrationBranchName(parentTaskId),
+    ref: taskGraphIntegrationBranchRef(parentTaskId),
+  };
+  setTaskGraphIntegration(repository, parentTaskId, 'RUNNING', {
+    expectedState: prior?.state || 'PENDING',
+    baseCommit: prepared.baseCommit,
+    worktreePath: identity.worktreePath,
+    branch: identity.branch,
+    ref: identity.ref,
+    sourceFingerprint: prepared.sourceFingerprint,
+    sourceRefs: prepared.sources.map(source => ({
+      order: source.order,
+      subtaskId: source.subtaskId,
+      branch: source.branch,
+      ref: source.ref,
+      commit: source.commit,
+      refCommit: source.refCommit,
+    })),
+    appliedRefs: [],
+    appliedCommits: [],
+    appliedSubtasks: [],
+    aggregateCommit: null,
+    worktreeHead: prepared.baseCommit,
+    conflict: null,
+    cleanup: null,
+    lastError: null,
+    reason: `Integrating ${prepared.sources.length} verified subtask commit(s).`,
+    operation: 'graph-integrate',
+  });
+
+  let worktreeInfo = null;
+  let applied = [];
+  const boundedTimeoutMs = Math.max(100, Math.min(10_000, Number.isFinite(timeoutMs) ? Math.floor(timeoutMs) : 2_000));
+  try {
+    worktreeInfo = ensureTaskGraphIntegrationWorktree(repository, parentTaskId, prepared.baseCommit);
+    const worktree = inspectGraphIntegrationWorktree(repository, parentTaskId, {
+      probeGit: true,
+      recordedPath: identity.worktreePath,
+      recordedBranch: identity.branch,
+      recordedRef: identity.ref,
+      timeoutMs: boundedTimeoutMs,
+    });
+    if (!worktree.owned || !worktree.safe || !worktree.exists) {
+      throw integrationErrorWithFacts('TASK_STATE_CONFLICT', `Runtime integration worktree failed ownership verification: ${identity.worktreePath}`, parentTaskId, repository, {
+        worktree,
+      });
+    }
+    setTaskGraphIntegration(repository, parentTaskId, 'RUNNING', {
+      expectedState: 'RUNNING',
+      worktreePath: worktreeInfo.worktreePath,
+      branch: worktreeInfo.branch,
+      ref: worktreeInfo.ref,
+      worktreeHead: worktree.head || prepared.baseCommit,
+      operation: 'graph-integrate',
+    });
+
+    for (const source of prepared.sources) {
+      const result = runGit(['cherry-pick', '--no-edit', source.commit], worktreeInfo.worktreePath, { timeoutMs: boundedTimeoutMs });
+      if (result.error || result.status !== 0) {
+        const conflict = gitConflictFacts(worktreeInfo.worktreePath, source, result, applied);
+        const error = integrationErrorWithFacts('WORKTREE_CONFLICT', `Failed to apply subtask ${source.subtaskId} commit in the integration worktree.`, parentTaskId, repository, {
+          worktreePath: worktreeInfo.worktreePath,
+          branch: worktreeInfo.branch,
+          ref: worktreeInfo.ref,
+          source,
+          appliedRefs: applied,
+          conflict,
+        });
+        setTaskGraphIntegration(repository, parentTaskId, 'FAILED', {
+          expectedState: 'RUNNING',
+          aggregateCommit: applied.length > 0 ? applied.at(-1).aggregateCommit : prepared.baseCommit,
+          worktreeHead: captureGraphBaseCommit(worktreeInfo.worktreePath),
+          conflict,
+          lastError: integrationErrorDetails(error),
+          reason: error.message,
+          operation: 'graph-integrate',
+        });
+        throw error;
+      }
+      const aggregateCommit = captureGraphBaseCommit(worktreeInfo.worktreePath);
+      const appliedRef = {
+        order: source.order,
+        subtaskId: source.subtaskId,
+        branch: source.branch,
+        ref: source.ref,
+        commit: source.commit,
+        aggregateCommit,
+        appliedAt: now(),
+      };
+      applied = [...applied, appliedRef];
+      setTaskGraphIntegration(repository, parentTaskId, 'RUNNING', {
+        expectedState: 'RUNNING',
+        appliedRefs: applied,
+        appliedCommits: applied.map(item => item.commit),
+        appliedSubtasks: applied.map(item => item.subtaskId),
+        aggregateCommit,
+        worktreeHead: aggregateCommit,
+        reason: `Applied ${applied.length} of ${prepared.sources.length} verified subtask commit(s).`,
+        operation: 'graph-integrate',
+      });
+    }
+
+    const aggregateCommit = captureGraphBaseCommit(worktreeInfo.worktreePath);
+    const integrationRef = runGit(['rev-parse', '--verify', `${worktreeInfo.ref}^{commit}`], repository);
+    if (integrationRef.error || integrationRef.status !== 0 || integrationRef.stdout.trim().toLowerCase() !== aggregateCommit.toLowerCase()) {
+      throw integrationErrorWithFacts('TASK_STATE_CONFLICT', `Integration branch did not retain the aggregate commit for ${parentTaskId}.`, parentTaskId, repository, {
+        ref: worktreeInfo.ref,
+        expected: aggregateCommit,
+        actual: integrationRef.stdout.trim() || null,
+      });
+    }
+    const completed = setTaskGraphIntegration(repository, parentTaskId, 'SUCCEEDED', {
+      expectedState: 'RUNNING',
+      appliedRefs: applied,
+      appliedCommits: applied.map(item => item.commit),
+      appliedSubtasks: applied.map(item => item.subtaskId),
+      aggregateCommit,
+      worktreeHead: aggregateCommit,
+      conflict: null,
+      lastError: null,
+      reason: `Integrated ${applied.length} verified subtask commit(s) in deterministic order.`,
+      evidence: [{
+        type: 'TASK_GRAPH_INTEGRATION',
+        baseCommit: prepared.baseCommit,
+        aggregateCommit,
+        appliedRefs: applied,
+      }],
+      operation: 'graph-integrate',
+    });
+    graph = completed.graph;
+    return {
+      repository,
+      parentTaskId,
+      graph,
+      integration: inspectTaskGraphIntegration(repository, graph, { probeGit: true, timeoutMs: boundedTimeoutMs }),
+      sources: prepared.sources,
+      idempotent: false,
+    };
+  } catch (error) {
+    const normalized = error?.code ? error : integrationErrorWithFacts('AGENT_RUNTIME_ERROR', error?.message || String(error), parentTaskId, repository, {
+      worktreePath: worktreeInfo?.worktreePath || identity.worktreePath,
+      branch: worktreeInfo?.branch || identity.branch,
+      ref: worktreeInfo?.ref || identity.ref,
+    });
+    try {
+      const latest = readTaskGraph(repository, parentTaskId);
+      if (latest.integration?.state === 'RUNNING') {
+        setTaskGraphIntegration(repository, parentTaskId, 'FAILED', {
+          expectedState: 'RUNNING',
+          worktreePath: worktreeInfo?.worktreePath || identity.worktreePath,
+          branch: worktreeInfo?.branch || identity.branch,
+          ref: worktreeInfo?.ref || identity.ref,
+          aggregateCommit: applied.at(-1)?.aggregateCommit || latest.integration.aggregateCommit || null,
+          worktreeHead: applied.at(-1)?.aggregateCommit || latest.integration.worktreeHead || prepared.baseCommit,
+          lastError: integrationErrorDetails(normalized),
+          reason: normalized.message,
+          operation: 'graph-integrate',
+        });
+      }
+    } catch {
+      // Preserve the primary integration error. The durable state write is
+      // retried by an explicit inspect/reconcile operation if it failed too.
+    }
+    throw normalized;
+  }
+}
+
+export const integrateTaskGraphCommits = integrateTaskGraph;
 
 /** Update only the explicit parent graph lifecycle state under the graph lock. */
 export function setTaskGraphState(root, parentTaskId, nextState, details = {}) {

--- a/skills/coordinate-task/SKILL.md
+++ b/skills/coordinate-task/SKILL.md
@@ -23,6 +23,8 @@ coordinate_agents_task_graph_recover
 coordinate_agents_task_graph_resume
 coordinate_agents_task_graph_stop
 coordinate_agents_task_graph_cleanup
+coordinate_agents_task_graph_integrate
+coordinate_agents_task_graph_review
 coordinate_agents_task_dispatch
 coordinate_agents_task_status
 coordinate_agents_task_inspect
@@ -65,6 +67,8 @@ node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs" task graph-rec
 node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs" task graph-resume --root "<repository>" --id task-... --subtask <subtaskId> --json
 node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs" task graph-stop --root "<repository>" --id task-... --json
 node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs" task graph-cleanup --root "<repository>" --id task-... --json
+node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs" task graph-integrate --root "<repository>" --id task-... --json
+node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs" task graph-review --root "<repository>" --id task-... --decision REVIEW_APPROVED --json
 node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs" task create --root "<repository>" --title "<task>" --json
 node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs" task dispatch --root "<repository>" --id task-... --spec "<approved specification>" --json
 node "<skill-dir>/../coordinate-agents/scripts/runtime-entry.mjs" task status --root "<repository>" --id task-... --json
@@ -146,5 +150,13 @@ Use `coordinate_agents_task_graph_stop` and
 `coordinate_agents_task_graph_cleanup` for bounded ownership-checked cleanup.
 They preserve user worktrees, refs, commits, and evidence, record cleanup
 failures, and are idempotent.
+After all required subtasks are verified successful, use
+`coordinate_agents_task_graph_integrate` (or `task graph-integrate`) to
+create the separate aggregate review worktree and apply source commits in
+deterministic subtask-id order. Use
+`coordinate_agents_task_graph_review` (or `task graph-review`) to inspect
+that aggregate and record `REVIEW_APPROVED` or `CHANGES_REQUESTED`.
+Integration conflicts are durable and bounded; they do not modify the user
+checkout or source worktrees and do not authorize release actions.
 See `../../docs/task-graph-v1.md` for the input shape and parent/subtask
 identity facts.

--- a/test/mcp-server.test.mjs
+++ b/test/mcp-server.test.mjs
@@ -251,6 +251,8 @@ test('MCP server exposes the canonical lifecycle and exact P0 tool catalog', asy
     'coordinate_agents_task_graph_stop',
     'coordinate_agents_task_graph_cleanup',
     'coordinate_agents_task_graph_dispatch',
+    'coordinate_agents_task_graph_integrate',
+    'coordinate_agents_task_graph_review',
     'coordinate_agents_task_dispatch',
     'coordinate_agents_task_status',
     'coordinate_agents_task_inspect',
@@ -291,7 +293,7 @@ test('MCP stdio is protocol-pure, debuggable on stderr, cwd-independent, and pat
     });
     assert.equal(initialized.result.protocolVersion, '2025-06-18');
     const listed = await debugClient.request('tools/list');
-    assert.equal(listed.result.tools.length, 25);
+    assert.equal(listed.result.tools.length, 27);
   } finally {
     await debugClient.close();
   }
@@ -299,7 +301,7 @@ test('MCP stdio is protocol-pure, debuggable on stderr, cwd-independent, and pat
   assert.match(debugClient.stderr, /server root:/);
   assert.match(debugClient.stderr, /runtime root:/);
   assert.match(debugClient.stderr, /protocol version: 2025-06-18/);
-  assert.match(debugClient.stderr, /tool count: 25/);
+  assert.match(debugClient.stderr, /tool count: 27/);
   assert.match(debugClient.stderr, /initialize received/);
   assert.match(debugClient.stderr, /tools\/list received/);
   const selfTest = spawnSync(process.execPath, [selfTestPath], {
@@ -311,7 +313,7 @@ test('MCP stdio is protocol-pure, debuggable on stderr, cwd-independent, and pat
   assert.equal(selfTest.status, 0, selfTest.stderr || selfTest.stdout);
   assert.match(selfTest.stdout, /MCP server: OK/);
   assert.match(selfTest.stdout, /Protocol: 2025-06-18/);
-  assert.match(selfTest.stdout, /Tools: 25/);
+  assert.match(selfTest.stdout, /Tools: 27/);
   rmSync(independentCwd, { recursive: true, force: true });
 
   const pluginRoot = mkdtempSync(join(canonicalTmpdir, 'Coordinate Agents Plugin Fixture '));
@@ -337,7 +339,7 @@ test('MCP stdio is protocol-pure, debuggable on stderr, cwd-independent, and pat
     const responses = launched.stdout.trim().split(/\r?\n/).map(line => JSON.parse(line));
     assert.equal(responses.length, 2);
     assert.equal(responses[0].result.protocolVersion, '2025-06-18');
-    assert.equal(responses[1].result.tools.length, 25);
+    assert.equal(responses[1].result.tools.length, 27);
   } finally {
     rmSync(pluginRoot, { recursive: true, force: true });
   }

--- a/test/task-graph-integration.test.mjs
+++ b/test/task-graph-integration.test.mjs
@@ -1,0 +1,302 @@
+import assert from 'node:assert/strict';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import test from 'node:test';
+
+import { createMcpServer } from '../mcp/server.mjs';
+import {
+  runtimeTaskGraphCleanup,
+  runtimeTaskGraphCreate,
+  runtimeTaskGraphIntegrate,
+} from '../bin/coordinate-agents.mjs';
+import {
+  captureGraphBaseCommit,
+  ensureSubtaskWorktree,
+  readTaskGraph,
+  setTaskGraphSubtaskState,
+  taskGraphBranchRef,
+  taskGraphIntegrationBranchRef,
+  taskGraphIntegrationWorktreePath,
+} from '../skills/coordinate-agents/scripts/task-graph-runtime.mjs';
+
+function git(root, args) {
+  return execFileSync('git', args, {
+    cwd: root,
+    encoding: 'utf8',
+    windowsHide: true,
+  }).trim();
+}
+
+function repository(prefix) {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  execFileSync('git', ['init', root], { stdio: 'ignore', windowsHide: true });
+  execFileSync('git', ['config', 'user.name', 'Coordinate Test'], { cwd: root, stdio: 'ignore', windowsHide: true });
+  execFileSync('git', ['config', 'user.email', 'test@example.invalid'], { cwd: root, stdio: 'ignore', windowsHide: true });
+  writeFileSync(join(root, 'README.md'), '# Integration fixture\n', 'utf8');
+  execFileSync('git', ['add', 'README.md'], { cwd: root, stdio: 'ignore', windowsHide: true });
+  execFileSync('git', ['commit', '-m', 'Initial integration fixture'], { cwd: root, stdio: 'ignore', windowsHide: true });
+  return root;
+}
+
+function graph(parentTaskId, subtasks = [
+  { id: 'alpha', implementer: 'antigravity', spec: 'Implement alpha.' },
+  { id: 'zeta', implementer: 'antigravity', spec: 'Implement zeta.' },
+]) {
+  return {
+    schemaVersion: 1,
+    parentTask: {
+      id: parentTaskId,
+      title: 'Integrate completed subtasks',
+      planner: 'codex',
+      reviewer: 'codex',
+    },
+    subtasks: subtasks.map(item => ({
+      id: item.id,
+      implementer: item.implementer,
+      spec: item.spec,
+      ...(item.title === undefined ? {} : { title: item.title }),
+      ...(item.dependsOn === undefined ? {} : { dependsOn: item.dependsOn }),
+    })),
+    maxConcurrency: 2,
+  };
+}
+
+function seedSubtask(root, parentTaskId, subtaskId, baseCommit, relativeFile, contents) {
+  const info = ensureSubtaskWorktree(root, parentTaskId, subtaskId, baseCommit);
+  writeFileSync(join(info.worktreePath, relativeFile), contents, 'utf8');
+  execFileSync('git', ['add', relativeFile], { cwd: info.worktreePath, stdio: 'ignore', windowsHide: true });
+  execFileSync('git', ['commit', '-m', 'Implement ' + subtaskId], { cwd: info.worktreePath, stdio: 'ignore', windowsHide: true });
+  const commit = git(info.worktreePath, ['rev-parse', 'HEAD']);
+  setTaskGraphSubtaskState(root, parentTaskId, subtaskId, 'SUCCEEDED', {
+    expectedState: 'READY',
+    baseCommit,
+    worktreePath: info.worktreePath,
+    branch: info.branch,
+    ref: info.ref,
+    implementationCommit: commit,
+    evidence: [{
+      type: 'IMPLEMENTATION_DONE',
+      relatedCommit: commit,
+      source: 'isolated fixture',
+    }],
+  });
+  return { ...info, commit };
+}
+
+async function seedGraph(root, parentTaskId, subtaskDefinitions, { only = null } = {}) {
+  await runtimeTaskGraphCreate({ root, graph: graph(parentTaskId, subtaskDefinitions) });
+  const baseCommit = captureGraphBaseCommit(root);
+  const seeded = [];
+  for (const item of subtaskDefinitions) {
+    if (only && !only.includes(item.id)) continue;
+    seeded.push(seedSubtask(
+      root,
+      parentTaskId,
+      item.id,
+      baseCommit,
+      item.file || (item.id + '.txt'),
+      item.contents || (item.id + '\n'),
+    ));
+  }
+  return { baseCommit, seeded };
+}
+
+test('Task Graph integration verifies sources, uses a separate deterministic aggregate worktree, and routes review without touching checkout', async () => {
+  const root = repository('coordinate-graph-integration-happy-');
+  const parentTaskId = 'task-integration-happy';
+  try {
+    const definitions = [
+      { id: 'zeta', implementer: 'antigravity', spec: 'Implement zeta.', file: 'zeta.txt', contents: 'zeta\n' },
+      { id: 'alpha', implementer: 'antigravity', spec: 'Implement alpha.', file: 'alpha.txt', contents: 'alpha\n' },
+    ];
+    const { baseCommit, seeded } = await seedGraph(root, parentTaskId, definitions);
+    writeFileSync(join(root, 'user-uncommitted.txt'), 'must remain in checkout\n', 'utf8');
+    const beforeStatus = git(root, ['status', '--porcelain']);
+    const beforeHead = git(root, ['rev-parse', 'HEAD']);
+
+    const integrated = await runtimeTaskGraphIntegrate({ root, taskId: parentTaskId });
+    assert.equal(integrated.ok, true);
+    assert.equal(integrated.command, 'task.graph-integrate');
+    assert.equal(integrated.integration.state, 'SUCCEEDED');
+    assert.equal(integrated.integration.baseCommit, baseCommit.toLowerCase());
+    assert.deepEqual(integrated.integration.appliedSubtasks, ['alpha', 'zeta']);
+    assert.deepEqual(integrated.integration.sourceRefs.map(item => item.subtaskId), ['alpha', 'zeta']);
+    assert.ok(integrated.integration.aggregateCommit);
+    assert.notEqual(integrated.integration.aggregateCommit, baseCommit.toLowerCase());
+    assert.equal(integrated.integration.worktree.branch, 'coordinate-agents/' + parentTaskId + '/__integration__');
+    assert.equal(integrated.integration.worktree.ref, taskGraphIntegrationBranchRef(parentTaskId));
+    assert.ok(integrated.integration.worktree.path.endsWith(join(parentTaskId, '__integration__')));
+    assert.notEqual(integrated.integration.worktree.path, seeded[0].worktreePath);
+    assert.deepEqual(integrated.integration.diff.files, ['alpha.txt', 'zeta.txt']);
+    assert.equal(git(root, ['rev-parse', taskGraphIntegrationBranchRef(parentTaskId)]), integrated.integration.aggregateCommit);
+    assert.equal(git(root, ['rev-parse', 'HEAD']), beforeHead);
+    assert.equal(git(root, ['status', '--porcelain']), beforeStatus);
+    assert.equal(readFileSync(join(root, 'user-uncommitted.txt'), 'utf8'), 'must remain in checkout\n');
+    for (const item of seeded) {
+      assert.equal(git(root, ['rev-parse', taskGraphBranchRef(parentTaskId, item.branch.split('/').at(-1))]), item.commit);
+    }
+
+    const second = await runtimeTaskGraphIntegrate({ root, taskId: parentTaskId });
+    assert.equal(second.ok, true);
+    assert.equal(second.idempotent, true);
+    assert.equal(second.integration.aggregateCommit, integrated.integration.aggregateCommit);
+
+    const server = createMcpServer({ root });
+    const listed = await server.handle({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+    const toolNames = listed.result.tools.map(tool => tool.name);
+    assert.ok(toolNames.includes('coordinate_agents_task_graph_integrate'));
+    assert.ok(toolNames.includes('coordinate_agents_task_graph_review'));
+    const dirtyFile = join(integrated.integration.worktree.path, 'unreviewed-change.txt');
+    writeFileSync(dirtyFile, 'must not be included in approval\n', 'utf8');
+    const dirtyReview = await server.handle({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: {
+        name: 'coordinate_agents_task_graph_review',
+        arguments: { root, taskId: parentTaskId, decision: 'REVIEW_APPROVED' },
+      },
+    });
+    assert.equal(dirtyReview.result.isError, true);
+    assert.equal(dirtyReview.result.structuredContent.error.code, 'WORKTREE_CONFLICT');
+    unlinkSync(dirtyFile);
+    const reviewed = await server.handle({
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'tools/call',
+      params: {
+        name: 'coordinate_agents_task_graph_review',
+        arguments: {
+          root,
+          taskId: parentTaskId,
+          decision: 'REVIEW_APPROVED',
+          evidence: { checks: ['aggregate diff inspected'] },
+        },
+      },
+    });
+    assert.equal(reviewed.result.isError, false);
+    assert.equal(reviewed.result.structuredContent.command, 'task.graph-review');
+    assert.equal(reviewed.result.structuredContent.review.decision, 'REVIEW_APPROVED');
+    assert.equal(reviewed.result.structuredContent.graph.state, 'APPROVED');
+    assert.equal(git(root, ['rev-parse', 'HEAD']), beforeHead);
+    assert.equal(git(root, ['status', '--porcelain']), beforeStatus);
+
+    const cleaned = await runtimeTaskGraphCleanup({ root, taskId: parentTaskId });
+    assert.equal(cleaned.ok, true);
+    assert.equal(cleaned.integrationCleanup.status, 'CLEANED');
+    assert.equal(existsSync(taskGraphIntegrationWorktreePath(root, parentTaskId)), false);
+    assert.equal(git(root, ['rev-parse', taskGraphIntegrationBranchRef(parentTaskId)]), integrated.integration.aggregateCommit);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('Task Graph integration refuses unresolved subtasks before creating aggregate state', async () => {
+  const root = repository('coordinate-graph-integration-gate-');
+  const parentTaskId = 'task-integration-gate';
+  try {
+    await seedGraph(root, parentTaskId, [
+      { id: 'alpha', implementer: 'antigravity', spec: 'Implement alpha.' },
+      { id: 'zeta', implementer: 'antigravity', spec: 'Implement zeta.' },
+    ], { only: ['alpha'] });
+    await assert.rejects(
+      runtimeTaskGraphIntegrate({ root, taskId: parentTaskId }),
+      error => error.code === 'TASK_STATE_CONFLICT'
+        && error.stage === 'graph-integration'
+        && error.details.unresolved.some(item => item.id === 'zeta'),
+    );
+    const stored = readTaskGraph(root, parentTaskId);
+    assert.equal(stored.integration, null);
+    assert.equal(existsSync(taskGraphIntegrationWorktreePath(root, parentTaskId)), false);
+    assert.equal(git(root, ['status', '--porcelain']), '');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('Task Graph review refuses an aggregate after the verified source commit changes', async () => {
+  const root = repository('coordinate-graph-integration-stale-review-');
+  const parentTaskId = 'task-integration-stale-review';
+  try {
+    const { seeded } = await seedGraph(root, parentTaskId, [
+      { id: 'alpha', implementer: 'antigravity', spec: 'Implement alpha.' },
+    ]);
+    const beforeHead = git(root, ['rev-parse', 'HEAD']);
+    const integrated = await runtimeTaskGraphIntegrate({ root, taskId: parentTaskId });
+    writeFileSync(join(seeded[0].worktreePath, 'alpha-followup.txt'), 'follow-up\n', 'utf8');
+    execFileSync('git', ['add', 'alpha-followup.txt'], { cwd: seeded[0].worktreePath, stdio: 'ignore', windowsHide: true });
+    execFileSync('git', ['commit', '-m', 'Follow up alpha'], { cwd: seeded[0].worktreePath, stdio: 'ignore', windowsHide: true });
+    const changedCommit = git(seeded[0].worktreePath, ['rev-parse', 'HEAD']);
+    setTaskGraphSubtaskState(root, parentTaskId, 'alpha', 'SUCCEEDED', {
+      expectedState: 'SUCCEEDED',
+      implementationCommit: changedCommit,
+      evidence: [{ type: 'IMPLEMENTATION_DONE', relatedCommit: changedCommit }],
+    });
+
+    const server = createMcpServer({ root });
+    const reviewed = await server.handle({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: {
+        name: 'coordinate_agents_task_graph_review',
+        arguments: { root, taskId: parentTaskId, decision: 'REVIEW_APPROVED' },
+      },
+    });
+    assert.equal(reviewed.result.isError, true);
+    assert.equal(reviewed.result.structuredContent.error.code, 'TASK_STATE_CONFLICT');
+    assert.notEqual(
+      reviewed.result.structuredContent.error.details.expectedSourceFingerprint,
+      integrated.integration.sourceFingerprint,
+    );
+    assert.equal(readTaskGraph(root, parentTaskId).review, null);
+    assert.equal(git(root, ['rev-parse', 'HEAD']), beforeHead);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('Task Graph integration preserves bounded conflict facts and source work when cherry-pick conflicts', async () => {
+  const root = repository('coordinate-graph-integration-conflict-');
+  const parentTaskId = 'task-integration-conflict';
+  try {
+    const { baseCommit, seeded } = await seedGraph(root, parentTaskId, [
+      { id: 'alpha', implementer: 'antigravity', spec: 'Implement alpha.', file: 'shared.txt', contents: 'alpha\n' },
+      { id: 'beta', implementer: 'antigravity', spec: 'Implement beta.', file: 'shared.txt', contents: 'beta\n' },
+    ]);
+    const beforeHead = git(root, ['rev-parse', 'HEAD']);
+    const failure = await runtimeTaskGraphIntegrate({ root, taskId: parentTaskId }).catch(error => error);
+    assert.equal(failure.code, 'WORKTREE_CONFLICT');
+    assert.equal(failure.stage, 'graph-integration');
+    const stored = readTaskGraph(root, parentTaskId);
+    assert.equal(stored.integration.state, 'FAILED');
+    assert.equal(stored.integration.conflict.state, 'CONFLICTED');
+    assert.equal(stored.integration.conflict.inProgress, true);
+    assert.equal(stored.integration.conflict.subtaskId, 'beta');
+    assert.deepEqual(stored.integration.appliedSubtasks, ['alpha']);
+    assert.ok(stored.integration.worktreePath);
+    assert.equal(existsSync(stored.integration.worktreePath), true);
+    assert.equal(git(root, ['rev-parse', 'HEAD']), beforeHead);
+    assert.equal(git(root, ['rev-parse', taskGraphIntegrationBranchRef(parentTaskId)]), stored.integration.aggregateCommit);
+    assert.equal(git(root, ['rev-parse', taskGraphBranchRef(parentTaskId, 'alpha')]), seeded.find(item => item.branch.endsWith('/alpha')).commit);
+    assert.equal(git(root, ['rev-parse', taskGraphBranchRef(parentTaskId, 'beta')]), seeded.find(item => item.branch.endsWith('/beta')).commit);
+    assert.equal(stored.integration.baseCommit, baseCommit.toLowerCase());
+
+    const inspected = readTaskGraph(root, parentTaskId);
+    assert.equal(inspected.integration.conflict.files.includes('shared.txt'), true);
+    const cleaned = await runtimeTaskGraphCleanup({ root, taskId: parentTaskId });
+    assert.equal(cleaned.integrationCleanup.status, 'CLEANED');
+    assert.equal(readTaskGraph(root, parentTaskId).integration.conflict.state, 'CONFLICTED');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/task-graph-integration.test.mjs
+++ b/test/task-graph-integration.test.mjs
@@ -225,7 +225,7 @@ test('Task Graph integration refuses unresolved subtasks before creating aggrega
 
 test('Task Graph review refuses an aggregate after the verified source commit changes', async () => {
   const root = repository('coordinate-graph-integration-stale-review-');
-  const parentTaskId = 'task-integration-stale-review';
+  const parentTaskId = 'task-stale-review';
   try {
     const { seeded } = await seedGraph(root, parentTaskId, [
       { id: 'alpha', implementer: 'antigravity', spec: 'Implement alpha.' },
@@ -267,7 +267,7 @@ test('Task Graph review refuses an aggregate after the verified source commit ch
 
 test('Task Graph integration preserves bounded conflict facts and source work when cherry-pick conflicts', async () => {
   const root = repository('coordinate-graph-integration-conflict-');
-  const parentTaskId = 'task-integration-conflict';
+  const parentTaskId = 'task-conflict';
   try {
     const { baseCommit, seeded } = await seedGraph(root, parentTaskId, [
       { id: 'alpha', implementer: 'antigravity', spec: 'Implement alpha.', file: 'shared.txt', contents: 'alpha\n' },


### PR DESCRIPTION
## Summary

- add deterministic integration of verified Task Graph subtask commits in a separate Runtime-owned worktree
- persist aggregate source, applied-ref, conflict, cleanup, and review facts
- expose graph integration and review through CLI and MCP while preserving release boundaries
- reject stale-source or dirty aggregate reviews and stabilize the test runner across PTY-heavy files

## Verification

- npm ci
- npm run check (199/199)
- npm run demo
- npm pack --dry-run
- Skill and Plugin validators

Closes #26