### PR TITLE
feat: expose conflict-aware graph preflight (#34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Codex turns that into a durable task, selects the configured Implementer adapter
 ## Key Capabilities
 
 - Durable local tasks, messages, review decisions, and runtime events.
-- Additive Task Graph v1 validation with optional Intent Map v1 write-scope declarations, deterministic conflict-aware READY waves, post-execution scope auditing, bounded parallel execution, isolated aggregate integration/review, and facts-first recovery across worktrees and Sessions.
+- Additive Task Graph v1 validation with optional Intent Map v1 write-scope declarations, deterministic conflict-aware Graph Preflight with bounded risks and resource estimates, post-execution scope auditing, bounded parallel execution, isolated aggregate integration/review, and facts-first recovery across worktrees and Sessions.
 - Explicit Planner, Implementer, and Reviewer role boundaries.
 - Adapter-based execution for exact configured CLI commands.
 - Persistent, bounded, and inspectable execution sessions.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -77,7 +77,7 @@ Codex 会把要求转成持久任务，选择已配置的 Implementer 适配器�
 ## 核心能力
 
 - 持久化本地任务、消息、审查结论和运行时事件。
-- 在任何执行副作用之前校验显式 DAG 与可选 Intent Map v1 写入范围，并支持确定性冲突感知 READY 波次、执行后范围审计、跨隔离 worktree/Session 的有界并行执行与基于事实的恢复。
+- 在任何执行副作用之前校验显式 DAG 与可选 Intent Map v1 写入范围，并支持带有界风险和资源估算的确定性冲突感知 Graph Preflight、执行后范围审计、跨隔离 worktree/Session 的有界并行执行与基于事实的恢复。
 - 明确区分 Planner、Implementer 与 Reviewer 角色。
 - 通过适配器精确执行已配置的 CLI 命令。
 - 提供持久、有限输出且可检查的 Execution Session。

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -58,9 +58,11 @@ it before sharing diagnostics.
   patterns, absolute or escaping paths, control characters, unsupported policies, and malformed
   durable facts. Patterns remain data and are never interpolated into a shell command.
 
-- Task Graph planning reports deterministic dependency, capacity, and exact configured
-  Agent/Adapter/executable facts without creating a worktree, Bus message, Session, lifecycle
-  event, or child process.
+- Task Graph Preflight reports deterministic dependency, capacity, exact configured
+  Agent/Adapter/executable facts, bounded risks, selected-wave resource estimates, and explicit
+  no-dispatch/no-review/no-release boundaries without creating a worktree, Bus message, Session,
+  lifecycle event, or child process. Missing Intent Map coverage is `UNVERIFIED` and never claims
+  that concurrent writes are safe.
 
 - With Intent Map coverage, planning treats any unprovable pattern separation conservatively,
   emits bounded `WRITE_INTENT_CONFLICT` facts, and defers the later READY subtask in stable ID

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -82,10 +82,12 @@ intersecting normalized patterns defer the later item with bounded
 separate. Dispatch rechecks conflicts with RUNNING work under the graph lock
 before launch. Missing coverage preserves v2.3 scheduling and is reported as
 unavailable. No dependency edge is inferred and this is not diff audit.
-`coordinate_agents_task_graph_plan` returns deterministic dependency and
-max-concurrency decisions with bounded reasons and exact configured Agent,
-Adapter, executable, and command-source facts. It does not create a worktree,
-Bus message, Session, event, or process.
+`coordinate_agents_task_graph_plan` returns a deterministic Graph Preflight:
+dependency and max-concurrency decisions, bounded reasons, exact configured
+Agent/Adapter/executable facts, scope policy, selected-wave resource estimates,
+bounded risks, and explicit execution/review/release boundaries. Missing Intent
+Map coverage is `UNVERIFIED` and does not prove concurrent writes safe. It does
+not create a worktree, Bus message, Session, event, or process.
 `coordinate_agents_task_graph_run` dispatches one deterministic eligible
 frontier concurrently up to the persisted maxConcurrency. Each subtask receives
 an isolated worktree, branch/ref, Bus handoff, and parent/subtask-associated

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -119,7 +119,7 @@ failure while preserving the implementation commit and worktree. Missing
 Intent Map coverage preserves legacy behavior without scope evidence. The
 evidence schema is `schemas/scope-audit-v1.schema.json`.
 
-`coordinate_agents_task_graph_plan` is a read-only scheduler view over the
+`coordinate_agents_task_graph_plan` is a read-only Graph Preflight over the
 persisted graph. It returns every subtask in deterministic identifier order,
 the dependency outcome and bounded reason for each decision, the concurrency-
 eligible prefix, capacity-limited READY subtasks, and exact configured Agent,
@@ -131,8 +131,12 @@ With Intent Map coverage, the plan additionally returns a deterministic
 `wave`, `conflictDeferred`, and bounded `WRITE_INTENT_CONFLICT` facts. Stable
 subtask-ID order greedily selects non-conflicting READY work up to capacity;
 unprovable glob separation is treated conservatively. Missing coverage keeps
-the v2.3 selection and reports `intentCoverageAvailable: false`. Dependency,
-capacity, and intent decisions remain distinct and no `dependsOn` edge changes.
+the v2.3 selection, reports `intentCoverageAvailable: false`, marks concurrent
+write safety `UNVERIFIED`, and emits a bounded risk rather than claiming the
+wave is safe. The additive `preflight` object includes scope policy,
+selected-wave worktree/branch/message/Session/process estimates, bounded risks,
+and explicit no-dispatch/no-review/no-release boundaries. Dependency, capacity,
+and intent decisions remain distinct and no `dependsOn` edge changes.
 
 `coordinate_agents_task_graph_run` executes only the eligible prefix from one
 deterministic scheduling snapshot, up to the persisted `maxConcurrency` after

--- a/docs/task-graph-v1.md
+++ b/docs/task-graph-v1.md
@@ -173,7 +173,7 @@ a deterministic reason. `TASK_GRAPH_SUBTASK_STATE_CHANGED` and
 `TASK_GRAPH_STATUS_CHANGED` events record later durable transitions; repeated
 identical transitions are idempotent.
 
-## Read-only scheduling plan
+## Read-only Graph Preflight
 
 Preview the next bounded scheduling decision without executing it:
 
@@ -183,10 +183,13 @@ coordinate-agents task graph-plan --root <repository> --id <parentTaskId> --json
 coordinate-agents task graph plan <parentTaskId> --root <repository> --json
 ```
 
-The MCP equivalent is `coordinate_agents_task_graph_plan`. The plan sorts all
-subtasks by identifier and derives one deterministic READY wave. Without an
+The MCP equivalent is `coordinate_agents_task_graph_plan`. This additive Graph
+Preflight preserves every v2.3 plan field, sorts all subtasks by identifier,
+and derives one deterministic READY wave. Without an
 Intent Map it preserves the v2.3 concurrency-eligible prefix and visibly marks
-intent coverage unavailable. With a map it greedily selects non-conflicting
+intent coverage unavailable. Its `concurrentWriteSafety` is `UNVERIFIED` and a
+bounded `INTENT_COVERAGE_UNAVAILABLE` risk explicitly says that the selected
+wave is not proof of safe concurrent writes. With a map it greedily selects non-conflicting
 READY subtasks up to capacity. A normalized literal-prefix mismatch proves two
 patterns disjoint; once glob syntax prevents proof, intersection is treated
 conservatively. A later conflicting subtask is returned in `conflictDeferred`
@@ -200,6 +203,12 @@ contradictory registry facts fail before execution.
 Planning reads one graph snapshot under the existing graph lock, including the
 persisted `maxConcurrency`, current RUNNING count, and normalized Intent Map.
 Execution uses the same wave derivation and rechecks the claim under that lock.
+The additive `preflight` object reports the effective scope policy, selected-wave
+worktree, branch, Bus message, Session, and process estimates, plus at most
+three bounded risk summaries. Its boundary facts state that planning does not
+change dependencies, dispatch an Agent, authorize review or release, or replace
+the explicit `graph-run` operation and exact human `RELEASE_APPROVED` gate.
+
 Planning is idempotent: unchanged durable state produces the same plan and creates no
 worktree, Bus message, Session, lifecycle event, or child process. The output
 contract is `schemas/task-graph-v1-plan.schema.json`.

--- a/docs/zh-CN/index.md
+++ b/docs/zh-CN/index.md
@@ -83,8 +83,9 @@ Task Graph v1 是向后兼容的新增契约。通过 MCP 的
 `TASK_GRAPH_CREATED` 事件；它不会启动 Adapter、Session 或 Implementer。既有 `task status`、
 `task inspect` 以及 `task graph-status`、`task graph-inspect` 别名可读取 READY/WAITING/BLOCKED
 前沿和有界生命周期事件。通过 `coordinate_agents_task_graph_plan` 或
-`task graph-plan --id <parentTaskId>` 可只读预览确定性依赖、Agent/Adapter/可执行文件与并发容量决策，
-不会创建 worktree、Bus 消息、Session、事件或子进程。通过 `coordinate_agents_task_graph_dispatch` 或
+`task graph-plan --id <parentTaskId>` 可执行只读 Graph Preflight，预览确定性依赖、Agent/Adapter/可执行文件、
+并发容量、范围策略、当前波次资源估算、有界风险以及不派发/不审查/不发布边界。缺少 Intent Map 时并发写入安全性
+标记为 `UNVERIFIED`，不会宣称并发写入安全；该操作不会创建 worktree、Bus 消息、Session、事件或子进程。通过 `coordinate_agents_task_graph_dispatch` 或
 `task graph-dispatch --id <parentTaskId> --subtask <subtaskId>` 可在完全隔离的 Git worktree
 （`.agent-bus/worktrees/<parentTaskId>/<subtaskId>`）和独立分支中派发单项 READY 子任务，安全捕获基准提交
 且不修改用户工作区中未提交的文件，并在完成后自动解锁依赖前沿。详见[Task Graph v1 契约](../task-graph-v1.html)。

--- a/lib/cli-core.mjs
+++ b/lib/cli-core.mjs
@@ -1491,6 +1491,63 @@ function schedulingDecision(graph, subtask, agent, eligibleIds, capacityLimitedI
   };
 }
 
+function graphPreflightFacts(decisions, intentCoverage) {
+  const selected = decisions.filter(item => item.decision === 'ELIGIBLE');
+  const conflictDeferred = decisions.filter(item => item.decision === 'WRITE_INTENT_CONFLICT');
+  const capacityLimited = decisions.filter(item => item.decision === 'CAPACITY_LIMITED');
+  const risks = [];
+  if (!intentCoverage.available) {
+    risks.push({
+      code: 'INTENT_COVERAGE_UNAVAILABLE',
+      severity: 'warning',
+      affectedSubtasks: selected.map(item => item.subtaskId),
+      message: 'No Intent Map is available; this legacy-compatible wave does not prove that concurrent writes are safe.',
+    });
+  }
+  if (conflictDeferred.length > 0) {
+    risks.push({
+      code: 'WRITE_INTENT_CONFLICT',
+      severity: 'warning',
+      affectedSubtasks: conflictDeferred.map(item => item.subtaskId),
+      message: `${conflictDeferred.length} READY subtask(s) are deferred because their declared write intents conflict with earlier selected work.`,
+    });
+  }
+  if (capacityLimited.length > 0) {
+    risks.push({
+      code: 'CAPACITY_LIMITED',
+      severity: 'info',
+      affectedSubtasks: capacityLimited.map(item => item.subtaskId),
+      message: `${capacityLimited.length} READY subtask(s) are deferred by the persisted concurrency limit.`,
+    });
+  }
+  const selectedCount = selected.length;
+  return {
+    schemaVersion: 1,
+    deterministic: true,
+    sideEffects: false,
+    scopePolicy: intentCoverage.scopePolicy,
+    concurrentWriteSafety: intentCoverage.available ? 'DECLARED_NON_CONFLICTING' : 'UNVERIFIED',
+    estimates: {
+      basis: 'current-selected-wave',
+      selectedSubtaskCount: selectedCount,
+      worktreeCount: selectedCount,
+      branchCount: selectedCount,
+      busMessageCount: selectedCount,
+      sessionCount: selectedCount,
+      processCount: selectedCount,
+    },
+    risks,
+    boundaries: {
+      changesDependencies: false,
+      dispatchesAgents: false,
+      authorizesReview: false,
+      authorizesRelease: false,
+      requiresExplicitGraphRun: true,
+      releaseApproval: 'RELEASE_APPROVED',
+    },
+  };
+}
+
 async function taskGraphPlanCommand(options, { json = false } = {}) {
   const root = assertGitRepositoryWithoutProcess(options.root, messages.en);
   const taskId = graphTaskId(options, root);
@@ -1566,6 +1623,7 @@ async function taskGraphPlanCommand(options, { json = false } = {}) {
       scheduling.wave.reasons,
       scheduling.wave.intentCoverageAvailable,
     ));
+  const intentCoverage = intentCoverageFacts(graph);
   const payload = jsonSuccess('task.graph-plan', {
     root,
     graphId: graph.parentTaskId,
@@ -1585,7 +1643,8 @@ async function taskGraphPlanCommand(options, { json = false } = {}) {
       conflicts: scheduling.wave.conflicts,
       wave: scheduling.wave,
       decisions,
-      intentCoverage: intentCoverageFacts(graph),
+      intentCoverage,
+      preflight: graphPreflightFacts(decisions, intentCoverage),
     },
   });
   if (!json) console.log(JSON.stringify(payload, null, 2));

--- a/llms.txt
+++ b/llms.txt
@@ -82,10 +82,12 @@ intersecting normalized patterns defer the later item with bounded
 separate. Dispatch rechecks conflicts with RUNNING work under the graph lock
 before launch. Missing coverage preserves v2.3 scheduling and is reported as
 unavailable. No dependency edge is inferred and this is not diff audit.
-`coordinate_agents_task_graph_plan` returns deterministic dependency and
-max-concurrency decisions with bounded reasons and exact configured Agent,
-Adapter, executable, and command-source facts. It does not create a worktree,
-Bus message, Session, event, or process.
+`coordinate_agents_task_graph_plan` returns a deterministic Graph Preflight:
+dependency and max-concurrency decisions, bounded reasons, exact configured
+Agent/Adapter/executable facts, scope policy, selected-wave resource estimates,
+bounded risks, and explicit execution/review/release boundaries. Missing Intent
+Map coverage is `UNVERIFIED` and does not prove concurrent writes safe. It does
+not create a worktree, Bus message, Session, event, or process.
 `coordinate_agents_task_graph_run` dispatches one deterministic eligible
 frontier concurrently up to the persisted maxConcurrency. Each subtask receives
 an isolated worktree, branch/ref, Bus handoff, and parent/subtask-associated

--- a/mcp/server.mjs
+++ b/mcp/server.mjs
@@ -259,7 +259,7 @@ const TOOL_DEFINITIONS = Object.freeze([
   },
   {
     name: 'coordinate_agents_task_graph_plan',
-    description: 'Read a deterministic dependency-, capacity-, and write-intent-aware scheduling wave without creating a worktree, Bus message, Session, or process.',
+    description: 'Read a deterministic dependency-, capacity-, and write-intent-aware Graph Preflight with bounded risks, resource estimates, and explicit execution/release boundaries, without creating a worktree, Bus message, Session, or process.',
     operation: 'taskGraphPlan',
     command: 'task.graph-plan',
     inputSchema: {

--- a/schemas/task-graph-v1-plan.schema.json
+++ b/schemas/task-graph-v1-plan.schema.json
@@ -3,7 +3,7 @@
   "$id": "https://github.com/hogancv/coordinate-agents/schemas/task-graph-v1-plan.schema.json",
   "title": "Coordinate Agents Task Graph v1 scheduling plan",
   "type": "object",
-  "required": ["schemaVersion", "deterministic", "sideEffects", "maxConcurrency", "runningCount", "availableSlots", "eligible", "capacityLimited", "conflictDeferred", "conflicts", "wave", "decisions", "intentCoverage"],
+  "required": ["schemaVersion", "deterministic", "sideEffects", "maxConcurrency", "runningCount", "availableSlots", "eligible", "capacityLimited", "conflictDeferred", "conflicts", "wave", "decisions", "intentCoverage", "preflight"],
   "properties": {
     "schemaVersion": { "const": 1 },
     "deterministic": { "const": true },
@@ -17,7 +17,8 @@
     "conflicts": { "type": "array", "maxItems": 256, "items": { "$ref": "#/$defs/conflict" } },
     "wave": { "$ref": "#/$defs/wave" },
     "decisions": { "type": "array", "minItems": 1, "maxItems": 256, "items": { "$ref": "#/$defs/decision" } },
-    "intentCoverage": { "$ref": "#/$defs/intentCoverage" }
+    "intentCoverage": { "$ref": "#/$defs/intentCoverage" },
+    "preflight": { "$ref": "#/$defs/preflight" }
   },
   "$defs": {
     "dependency": {
@@ -70,6 +71,60 @@
             },
             "additionalProperties": false
           }
+        }
+      },
+      "additionalProperties": false
+    },
+    "preflight": {
+      "type": "object",
+      "required": ["schemaVersion", "deterministic", "sideEffects", "scopePolicy", "concurrentWriteSafety", "estimates", "risks", "boundaries"],
+      "properties": {
+        "schemaVersion": { "const": 1 },
+        "deterministic": { "const": true },
+        "sideEffects": { "const": false },
+        "scopePolicy": { "type": ["string", "null"], "enum": ["observe", "warn", "strict", null] },
+        "concurrentWriteSafety": { "type": "string", "enum": ["DECLARED_NON_CONFLICTING", "UNVERIFIED"] },
+        "estimates": {
+          "type": "object",
+          "required": ["basis", "selectedSubtaskCount", "worktreeCount", "branchCount", "busMessageCount", "sessionCount", "processCount"],
+          "properties": {
+            "basis": { "const": "current-selected-wave" },
+            "selectedSubtaskCount": { "type": "integer", "minimum": 0, "maximum": 32 },
+            "worktreeCount": { "type": "integer", "minimum": 0, "maximum": 32 },
+            "branchCount": { "type": "integer", "minimum": 0, "maximum": 32 },
+            "busMessageCount": { "type": "integer", "minimum": 0, "maximum": 32 },
+            "sessionCount": { "type": "integer", "minimum": 0, "maximum": 32 },
+            "processCount": { "type": "integer", "minimum": 0, "maximum": 32 }
+          },
+          "additionalProperties": false
+        },
+        "risks": {
+          "type": "array",
+          "maxItems": 3,
+          "items": {
+            "type": "object",
+            "required": ["code", "severity", "affectedSubtasks", "message"],
+            "properties": {
+              "code": { "type": "string", "enum": ["INTENT_COVERAGE_UNAVAILABLE", "WRITE_INTENT_CONFLICT", "CAPACITY_LIMITED"] },
+              "severity": { "type": "string", "enum": ["info", "warning"] },
+              "affectedSubtasks": { "type": "array", "maxItems": 256, "uniqueItems": true, "items": { "type": "string", "pattern": "^[a-z][a-z0-9_-]{0,63}$" } },
+              "message": { "type": "string", "minLength": 1, "maxLength": 2048 }
+            },
+            "additionalProperties": false
+          }
+        },
+        "boundaries": {
+          "type": "object",
+          "required": ["changesDependencies", "dispatchesAgents", "authorizesReview", "authorizesRelease", "requiresExplicitGraphRun", "releaseApproval"],
+          "properties": {
+            "changesDependencies": { "const": false },
+            "dispatchesAgents": { "const": false },
+            "authorizesReview": { "const": false },
+            "authorizesRelease": { "const": false },
+            "requiresExplicitGraphRun": { "const": true },
+            "releaseApproval": { "const": "RELEASE_APPROVED" }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/skills/coordinate-agents/SKILL.md
+++ b/skills/coordinate-agents/SKILL.md
@@ -106,11 +106,14 @@ available. Intent Map v1 must use the same parent ID, cover each subtask once,
 and contain only normalized repository-relative patterns; an empty
 `writeIntent` is explicit coverage, while a missing map remains unavailable.
 Invalid maps stop creation before Runtime side effects. Call
-`coordinate_agents_task_graph_plan` to read the deterministic dependency and
-capacity decisions with explicit Agent, Adapter, and executable facts. When an
-Intent Map exists, planning also returns one stable non-conflicting READY wave,
-bounded `WRITE_INTENT_CONFLICT` facts, and explicit deferred reasons without
-changing `dependsOn`; planning never creates execution state. Call
+`coordinate_agents_task_graph_plan` to read the deterministic Graph Preflight:
+dependency and capacity decisions, explicit Agent/Adapter/executable facts,
+scope policy, current-wave Runtime resource estimates, bounded risks, and the
+unchanged graph-run/review/release boundaries. When an Intent Map exists,
+planning also returns one stable non-conflicting READY wave, bounded
+`WRITE_INTENT_CONFLICT` facts, and explicit deferred reasons without changing
+`dependsOn`. Missing coverage is marked `UNVERIFIED` and never presented as
+proof that concurrent writes are safe; planning never creates execution state. Call
 `coordinate_agents_task_graph_run` to dispatch the selected wave concurrently
 without exceeding the persisted limit; each selected subtask receives its own worktree and Session,
 and newly unlocked work remains READY for a later explicit run. Call

--- a/skills/coordinate-task/SKILL.md
+++ b/skills/coordinate-task/SKILL.md
@@ -126,12 +126,15 @@ atomically persists the parent, subtasks, dependency frontier, reasons,
 evidence, and lifecycle event without launching an Implementer. Use the
 existing `task status`/`task inspect` operations, or the explicit
 `task graph-status`/`task graph-inspect` aliases, to read the durable graph.
-Use `coordinate_agents_task_graph_plan` (or `task graph-plan`) to preview the
-deterministic dependency and capacity decisions with explicit configured
-Agent, Adapter, and executable facts. If Intent Map coverage is available, the
-plan greedily derives a stable non-conflicting READY wave and bounded
-`WRITE_INTENT_CONFLICT` facts. Conflict deferral never rewrites `dependsOn`.
-Planning creates no worktree, Bus message, Session, event, or process.
+Use `coordinate_agents_task_graph_plan` (or `task graph-plan`) as a Graph
+Preflight for deterministic dependency/capacity decisions, configured
+Agent/Adapter/executable facts, scope policy, selected-wave Runtime resource
+estimates, bounded risks, and explicit graph-run/review/release boundaries. If
+Intent Map coverage is available, the plan greedily derives a stable
+non-conflicting READY wave and bounded `WRITE_INTENT_CONFLICT` facts. Missing
+coverage is `UNVERIFIED` and does not prove concurrent writes are safe.
+Conflict deferral never rewrites `dependsOn`. Planning creates no worktree,
+Bus message, Session, event, or process.
 Use `coordinate_agents_task_graph_run` (or `task graph-run`) to execute the
 current selected wave concurrently up to `maxConcurrency`. Each selected
 subtask gets an isolated worktree, branch/ref, Bus message, and Runtime-owned

--- a/test/task-graph-intent-scheduler.test.mjs
+++ b/test/task-graph-intent-scheduler.test.mjs
@@ -80,6 +80,11 @@ test('plan exposes deterministic conflict-aware wave facts without changing depe
     ]);
     assert.match(first.plan.conflictDeferred[0].reason, /deferred from this wave/);
     assert.match(first.plan.eligible[0].reason, /no selected write-intent conflict/);
+    assert.equal(first.plan.preflight.scopePolicy, 'warn');
+    assert.equal(first.plan.preflight.concurrentWriteSafety, 'DECLARED_NON_CONFLICTING');
+    assert.equal(first.plan.preflight.estimates.worktreeCount, 2);
+    assert.deepEqual(first.plan.preflight.risks.map(item => item.code), ['WRITE_INTENT_CONFLICT']);
+    assert.deepEqual(first.plan.preflight.risks[0].affectedSubtasks, ['beta']);
     assert.deepEqual(
       readTaskGraph(root, 'task-intent-scheduler').subtasks.map(item => item.dependsOn),
       before.subtasks.map(item => item.dependsOn),

--- a/test/task-graph-scheduler.test.mjs
+++ b/test/task-graph-scheduler.test.mjs
@@ -91,6 +91,27 @@ test('Task Graph plan is deterministic, capacity-bounded, Agent-explicit, and re
       assert.equal(first.plan.availableSlots, 2);
       assert.deepEqual(first.plan.eligible.map(item => item.subtaskId), ['alpha', 'beta']);
       assert.deepEqual(first.plan.capacityLimited.map(item => item.subtaskId), ['gamma']);
+      assert.deepEqual(first.plan.preflight.estimates, {
+        basis: 'current-selected-wave',
+        selectedSubtaskCount: 2,
+        worktreeCount: 2,
+        branchCount: 2,
+        busMessageCount: 2,
+        sessionCount: 2,
+        processCount: 2,
+      });
+      assert.equal(first.plan.preflight.scopePolicy, null);
+      assert.equal(first.plan.preflight.concurrentWriteSafety, 'UNVERIFIED');
+      assert.equal(first.plan.preflight.risks[0].code, 'INTENT_COVERAGE_UNAVAILABLE');
+      assert.match(first.plan.preflight.risks[0].message, /does not prove.*safe/);
+      assert.deepEqual(first.plan.preflight.boundaries, {
+        changesDependencies: false,
+        dispatchesAgents: false,
+        authorizesReview: false,
+        authorizesRelease: false,
+        requiresExplicitGraphRun: true,
+        releaseApproval: 'RELEASE_APPROVED',
+      });
       assert.deepEqual(first.plan.decisions.map(item => item.subtaskId), [
         'after-alpha', 'after-beta', 'alpha', 'beta', 'gamma',
       ]);
@@ -145,12 +166,16 @@ test('Task Graph plan explains running, failed dependency, blocked, and remainin
   }
 });
 
-test('CLI and MCP expose the same no-process graph plan and reject unsupported scheduling input', async () => {
+test('CLI and MCP expose the same no-process graph plan with unavailable executables and reject unsupported input', async () => {
   const root = repository('coordinate-agents-graph-plan-transport-');
   const home = mkdtempSync(join(tmpdir(), 'coordinate-agents-graph-plan-home-'));
   try {
     await withIsolatedHome(home, async () => {
       await runtimeTaskGraphCreate({ root, graph: schedulerGraph('task-gd-plan-transport') });
+      const configPath = join(root, '.agent-bus', 'config.json');
+      const config = JSON.parse(readFileSync(configPath, 'utf8'));
+      for (const agent of config.agents) agent.command = `unavailable-preflight-${agent.id}`;
+      writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
       const cliResult = spawnSync(process.execPath, [
         cli, 'task', 'graph-plan', '--root', root, '--id', 'task-gd-plan-transport', '--json',
       ], {
@@ -161,6 +186,11 @@ test('CLI and MCP expose the same no-process graph plan and reject unsupported s
       assert.equal(cliResult.status, 0, cliResult.stderr || cliResult.stdout);
       const cliPlan = JSON.parse(cliResult.stdout);
       assert.deepEqual(cliPlan.plan.eligible.map(item => item.subtaskId), ['alpha', 'beta']);
+      assert.equal(cliPlan.plan.preflight.estimates.processCount, 2);
+      assert.equal(cliPlan.plan.preflight.concurrentWriteSafety, 'UNVERIFIED');
+      assert.equal(cliPlan.plan.eligible[0].agent.command, 'unavailable-preflight-codex');
+      assert.equal(existsSync(join(root, '.agent-bus', 'worktrees')), false);
+      assert.equal(existsSync(join(root, '.agent-bus', 'sessions')), false);
 
       const server = createMcpServer();
       const mcp = await server.handle({


### PR DESCRIPTION
## Summary

- extend `graph-plan` with additive Graph Preflight facts
- report scope policy, selected-wave resource estimates, bounded risks, and explicit execution/review/release boundaries
- preserve deterministic CLI/MCP parity and legacy graph compatibility
- document the shared contract in English and Simplified Chinese

## Validation

- `npm ci`
- `npm run check` (262 tests)
- `npm run demo`
- `npm pack --dry-run`
- Skill and Plugin validators via system `python3` (PyYAML 6.0.3)