### PR TITLE
feat(inspector): extend read-only Inspector with Task Graph topology and evidence

### DIFF
--- a/docs/inspector.md
+++ b/docs/inspector.md
@@ -28,6 +28,7 @@ Inspector Server
 Existing Coordinate Agents Runtime State
    ├── .agent-bus/events/runtime.jsonl
    ├── .agent-bus/tasks/*.json
+   ├── .agent-bus/task-graphs/*.json
    ├── .agent-bus/config.json
    ├── .agent-bus/state/<agent>/*.json
    ├── .agent-bus/inbox/<agent>/{new,processing,processed}/*.md
@@ -62,15 +63,25 @@ accept GET requests only. Stop it with `Ctrl-C`.
 
 ## Pages and panels
 
-- **Tasks** — current Task title, status, round, and update time.
+- **Tasks** — current Task title, status, round, and update time for ordinary Tasks, plus distinguishable Task Graph parent entries with subtask count, max concurrency, and subtask state tallies.
 - **Agent flow** — the configured Planner → Implementer → Reviewer topology,
   including each Agent’s current Agent Bus state.
-- **Task detail** — sequence-ordered recorded event timeline, role assignments, specification,
-  implementation commit, evidence, review history, and last error.
+- **Task detail & Task Graph topology** — for ordinary Tasks: sequence-ordered recorded event timeline, role assignments, specification, implementation commit, evidence, review history, and last error. For Task Graphs: subtask nodes, dependency edges, frontier decisions, preflight waves, assigned Agent/Adapter/executable facts, worktree and commit facts, Scope Audit findings, recovery classifications, integration facts, and review decisions.
 - **Sessions** — Session state, timestamps, linked Tasks, bounded recent output,
   and recorded Session event history.
 - **Recent events** — timestamp, sequence, event type, Task, Session, Agent, and
   a bounded summary from the append-only journal.
+
+## Endpoints (Read-Only)
+
+- `GET /api/tasks` — mixed listing of ordinary Tasks and Task Graph parents.
+- `GET /api/tasks/:id` — task detail or Task Graph detail by ID.
+- `GET /api/graphs` — listing of persisted Task Graph parent summaries.
+- `GET /api/graphs/:id` — exhaustive bounded Task Graph detail.
+- `GET /api/agents` — configured Agents and current Agent Bus observation.
+- `GET /api/sessions` — persistent Execution Sessions and recent bounded logs.
+- `GET /api/events` — Event Journal records with query filtering.
+- `GET /api/events/stream` — SSE event stream with `Last-Event-ID` resume support.
 
 The dashboard receives new records through the localhost-only read-only
 `GET /api/events/stream` SSE endpoint, resumes from `Last-Event-ID`, refreshes

--- a/inspector/server/inspector-data.mjs
+++ b/inspector/server/inspector-data.mjs
@@ -23,12 +23,24 @@ import { runtimeSessionFacts } from '../../skills/coordinate-agents/scripts/sess
 import { observeAgentBus } from '../../skills/coordinate-agents/scripts/agent-observer.mjs';
 import { redactOutput } from '../../skills/coordinate-agents/adapters/executable.mjs';
 import { readRuntimeEvents } from '../../skills/coordinate-agents/scripts/runtime-events.mjs';
+import {
+  inspectTaskGraphIntegration,
+  inspectTaskGraphRecovery,
+  listTaskGraphs,
+  readTaskGraph,
+  taskGraphPath,
+  taskGraphSchedulingView,
+} from '../../skills/coordinate-agents/scripts/task-graph-runtime.mjs';
 
 const TASK_ID_PATTERN = /\btask-[A-Za-z0-9][A-Za-z0-9_-]{1,127}\b/;
 const MAX_EVENT_SCAN = 600;
 const MAX_EVENT_DETAILS = 4 * 1024;
 const MAX_SPEC_BYTES = 16 * 1024;
 const MAX_SESSION_OUTPUT = 8 * 1024;
+const MAX_GRAPH_ITEMS = 256;
+const MAX_NESTED_ITEMS = 256;
+const MAX_NESTED_KEYS = 64;
+const MAX_NESTED_DEPTH = 8;
 const EMPTY_ARRAY = Object.freeze([]);
 
 function canonicalRoot(root) {
@@ -54,6 +66,31 @@ function busFor(root) {
 function bounded(value, limit = MAX_EVENT_DETAILS) {
   if (value === null || value === undefined) return '';
   return redactOutput(`${value}`, limit);
+}
+
+function sanitizeNested(value, {
+  depth = 0,
+  stringLimit = MAX_EVENT_DETAILS,
+  itemLimit = MAX_NESTED_ITEMS,
+} = {}) {
+  if (value === null || value === undefined || typeof value === 'boolean') return value ?? null;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value === 'string') return bounded(value, stringLimit);
+  if (typeof value !== 'object' || depth >= MAX_NESTED_DEPTH) return bounded(value, stringLimit);
+  if (Array.isArray(value)) {
+    return value.slice(0, itemLimit).map(item => sanitizeNested(item, {
+      depth: depth + 1,
+      stringLimit,
+      itemLimit,
+    }));
+  }
+  return Object.fromEntries(Object.entries(value)
+    .slice(0, MAX_NESTED_KEYS)
+    .map(([key, item]) => [bounded(key, 256), sanitizeNested(item, {
+      depth: depth + 1,
+      stringLimit,
+      itemLimit,
+    })]));
 }
 
 function validTimestamp(value, fallback = Date.now()) {
@@ -163,6 +200,8 @@ function readTaskRecords(root) {
 
 function taskSummary(task) {
   return {
+    kind: 'task',
+    graph: false,
     id: task.id,
     title: task.title,
     status: task.status,
@@ -174,6 +213,33 @@ function taskSummary(task) {
     reviewer: task.reviewer,
     sessionId: task.sessionId || null,
     reviewDecision: task.reviewDecision || null,
+  };
+}
+
+function graphSummary(graph) {
+  const parent = graph.parentTask;
+  const counts = Object.fromEntries([
+    'READY', 'WAITING', 'RUNNING', 'SUCCEEDED', 'FAILED', 'BLOCKED', 'STOPPED',
+  ].map(state => [state.toLowerCase(), graph.subtasks.filter(item => item.state === state).length]));
+  return {
+    kind: 'task-graph-parent',
+    graph: true,
+    id: graph.parentTaskId,
+    parentTaskId: graph.parentTaskId,
+    title: parent.title,
+    status: graph.state,
+    state: graph.state,
+    round: 1,
+    createdAt: graph.createdAt,
+    updatedAt: graph.updatedAt,
+    planner: parent.planner,
+    implementer: parent.implementer || null,
+    reviewer: parent.reviewer,
+    sessionId: null,
+    reviewDecision: graph.review?.decision || null,
+    maxConcurrency: graph.maxConcurrency,
+    subtaskCount: graph.subtasks.length,
+    counts,
   };
 }
 
@@ -237,10 +303,100 @@ function inspectorJournalEvent(event) {
     event: event.type,
     type: event.type,
     details: journalDetails(event),
-    data: event.data || {},
+    data: sanitizeNested(event.data || {}, { stringLimit: MAX_EVENT_DETAILS }),
     source: 'journal',
     recorded: true,
   };
+}
+
+function graphAgentFacts(config, implementer) {
+  const agent = config.agents.find(item => item.id === implementer);
+  if (!agent) return { id: implementer, registered: false, adapter: null };
+  return {
+    id: agent.id,
+    registered: true,
+    adapter: bounded(agent.adapter, 512),
+  };
+}
+
+function graphSubtaskView(config, subtask, recovery) {
+  return {
+    id: subtask.id,
+    subtaskId: subtask.id,
+    title: bounded(subtask.title || subtask.id, 2 * 1024),
+    spec: bounded(subtask.spec, MAX_SPEC_BYTES),
+    state: subtask.state,
+    status: subtask.status,
+    reason: bounded(subtask.reason, 8 * 1024) || null,
+    dependsOn: subtask.dependsOn.slice(0, MAX_GRAPH_ITEMS),
+    implementer: subtask.implementer,
+    agent: graphAgentFacts(config, subtask.implementer),
+    executable: {
+      effectiveCommand: bounded(subtask.effectiveCommand || subtask.command, 2 * 1024) || null,
+      resolvedCommand: bounded(subtask.resolvedCommand, 2 * 1024) || null,
+      source: subtask.effectiveCommand || subtask.command || subtask.resolvedCommand ? 'persisted-graph' : null,
+    },
+    sessionId: subtask.sessionId || null,
+    worktree: {
+      path: bounded(subtask.worktreePath, 4 * 1024) || null,
+      branch: bounded(subtask.branch, 2 * 1024) || null,
+      ref: bounded(subtask.ref, 2 * 1024) || null,
+      baseCommit: bounded(subtask.baseCommit, 256) || null,
+    },
+    implementationCommit: bounded(subtask.implementationCommit, 256) || null,
+    evidence: sanitizeNested(subtask.evidence || [], { stringLimit: 8 * 1024, itemLimit: 64 }),
+    scopeAudit: sanitizeNested(subtask.scopeEvidence || null, { stringLimit: 4 * 1024, itemLimit: MAX_GRAPH_ITEMS }),
+    dispatch: sanitizeNested(subtask.dispatch || null, { stringLimit: 4 * 1024 }),
+    recovery: sanitizeNested(recovery || subtask.recovery || null, { stringLimit: 4 * 1024 }),
+    cleanup: sanitizeNested(subtask.cleanup || null, { stringLimit: 4 * 1024 }),
+    lastError: sanitizeNested(subtask.lastError || null, { stringLimit: 4 * 1024 }),
+    createdAt: subtask.createdAt || null,
+    updatedAt: subtask.updatedAt || null,
+  };
+}
+
+function graphDetail(root, graph) {
+  const bus = busFor(root);
+  const config = bus ? readConfig(bus) : { agents: [] };
+  const scheduling = taskGraphSchedulingView(graph);
+  const recovery = inspectTaskGraphRecovery(root, graph, { probeGit: false });
+  const recoveryById = new Map(recovery.map(item => [item.subtaskId, item]));
+  const events = recordedEvents(root, { taskId: graph.parentTaskId, limit: 300 });
+  const parent = graph.parentTask;
+  const subtasks = graph.subtasks.slice(0, MAX_GRAPH_ITEMS)
+    .map(item => graphSubtaskView(config, item, recoveryById.get(item.id)));
+  const detail = {
+    ...graphSummary(graph),
+    schemaVersion: graph.schemaVersion,
+    spec: bounded(parent.spec, MAX_SPEC_BYTES),
+    baseCommit: bounded(graph.baseCommit || parent.baseCommit, 256) || null,
+    reason: bounded(graph.reason || parent.reason, 8 * 1024) || null,
+    maxConcurrency: graph.maxConcurrency,
+    frontier: sanitizeNested(scheduling.frontier, { stringLimit: 4 * 1024, itemLimit: MAX_GRAPH_ITEMS }),
+    wave: sanitizeNested(scheduling.wave, { stringLimit: 4 * 1024, itemLimit: MAX_GRAPH_ITEMS }),
+    dependencies: subtasks.flatMap(item => item.dependsOn.map(dependency => ({
+      from: dependency,
+      to: item.id,
+    }))).slice(0, MAX_GRAPH_ITEMS * MAX_GRAPH_ITEMS),
+    subtasks,
+    intentCoverage: sanitizeNested(graph.intentMap || null, { stringLimit: 4 * 1024, itemLimit: MAX_GRAPH_ITEMS }),
+    conflicts: sanitizeNested(scheduling.wave?.conflicts || [], { stringLimit: 4 * 1024, itemLimit: MAX_GRAPH_ITEMS }),
+    recovery: sanitizeNested(recovery, { stringLimit: 4 * 1024, itemLimit: MAX_GRAPH_ITEMS }),
+    integration: sanitizeNested(graph.integration || null, { stringLimit: 8 * 1024, itemLimit: MAX_GRAPH_ITEMS }),
+    integrationFacts: sanitizeNested(inspectTaskGraphIntegration(root, graph, { probeGit: false }), { stringLimit: 8 * 1024, itemLimit: MAX_GRAPH_ITEMS }),
+    evidence: sanitizeNested(parent.evidence || graph.evidence || [], { stringLimit: 8 * 1024, itemLimit: 64 }),
+    review: sanitizeNested(graph.review || null, { stringLimit: 8 * 1024, itemLimit: 64 }),
+    reviewHistory: sanitizeNested(graph.reviewHistory || [], { stringLimit: 8 * 1024, itemLimit: 64 }),
+    events,
+    timeline: events.map(event => ({ ...event, status: null })).sort((a, b) => a.sequence - b.sequence),
+    historySource: 'recorded',
+    agentFlow: [
+      { role: 'planner', agent: parent.planner },
+      ...[...new Set(graph.subtasks.map(item => item.implementer))].map(agent => ({ role: 'implementer', agent })),
+      { role: 'reviewer', agent: parent.reviewer },
+    ],
+  };
+  return detail;
 }
 
 function recordedEvents(root, options = {}) {
@@ -496,9 +652,14 @@ export function createInspectorData(root) {
   return {
     root: repository,
     readTasks() {
-      return readTaskRecords(repository).map(taskSummary);
+      return [
+        ...readTaskRecords(repository).map(taskSummary),
+        ...listTaskGraphs(repository).map(graphSummary),
+      ].sort((left, right) => `${right.updatedAt || ''}`.localeCompare(`${left.updatedAt || ''}`));
     },
     readTask(id) {
+      const graphPath = taskGraphPath(repository, id);
+      if (existsSync(graphPath)) return graphDetail(repository, readTaskGraph(repository, id));
       const task = sanitizeTask(readTask(repository, id));
       let events = recordedEvents(repository, { taskId: task.id, limit: 300 });
       if (events.length > 0 && task.sessionId) {
@@ -520,6 +681,12 @@ export function createInspectorData(root) {
           { role: 'reviewer', agent: task.reviewer },
         ],
       };
+    },
+    readGraphs() {
+      return listTaskGraphs(repository).map(graphSummary);
+    },
+    readGraph(id) {
+      return graphDetail(repository, readTaskGraph(repository, id));
     },
     readAgents() {
       return readAgents(repository);

--- a/inspector/server/server.mjs
+++ b/inspector/server/server.mjs
@@ -98,7 +98,13 @@ function streamEvents(request, response, data, url) {
 
 function apiError(response, error) {
   const code = error?.code || '';
-  const status = code === 'TASK_NOT_FOUND' ? 404 : 500;
+  const status = code === 'TASK_NOT_FOUND'
+    ? 404
+    : code === 'TASK_GRAPH_INVALID'
+      ? 400
+      : code === 'TASK_STATE_CONFLICT'
+        ? 409
+        : 500;
   json(response, status, {
     error: redactOutput(error?.message || 'Inspector request failed.', 2 * 1024),
     code: code || 'INSPECTOR_READ_FAILED',
@@ -132,6 +138,15 @@ export function createInspectorServer({ root, data = createInspectorData(root) }
       if (pathname.startsWith('/api/tasks/')) {
         const id = decodeURIComponent(pathname.slice('/api/tasks/'.length));
         json(response, 200, data.readTask(id));
+        return;
+      }
+      if (pathname === '/api/graphs') {
+        json(response, 200, data.readGraphs());
+        return;
+      }
+      if (pathname.startsWith('/api/graphs/')) {
+        const id = decodeURIComponent(pathname.slice('/api/graphs/'.length));
+        json(response, 200, data.readGraph(id));
         return;
       }
       if (pathname === '/api/agents') {

--- a/inspector/web/app.js
+++ b/inspector/web/app.js
@@ -22,7 +22,8 @@ const state = {
 const elements = Object.fromEntries([
   'tasks', 'task-count', 'agent-flow', 'task-detail', 'detail-title', 'detail-summary',
   'timeline', 'detail-agent-flow', 'evidence', 'spec', 'sessions', 'session-count',
-  'events', 'refresh-button', 'close-detail',
+  'events', 'refresh-button', 'close-detail', 'graph-detail', 'graph-topology',
+  'graph-frontier', 'graph-conflicts', 'graph-integration',
 ].map(id => [id, document.getElementById(id)]));
 
 function escapeHtml(value) {
@@ -66,10 +67,11 @@ function renderTasks() {
     return;
   }
   elements.tasks.innerHTML = state.tasks.map(task => `
-    <button class="task-card ${state.selectedTask === task.id ? 'selected' : ''}" data-task-id="${escapeHtml(task.id)}" type="button">
-      <span class="task-card-top"><span class="task-id">${escapeHtml(shortId(task.id))}</span><span class="round">R${escapeHtml(task.round)}</span></span>
+    <button class="task-card ${task.graph ? 'graph-card' : ''} ${state.selectedTask === task.id ? 'selected' : ''}" data-task-id="${escapeHtml(task.id)}" type="button">
+      <span class="task-card-top"><span class="task-id">${escapeHtml(shortId(task.id))}</span><span class="round">${task.graph ? 'GRAPH' : `R${escapeHtml(task.round)}`}</span></span>
       <strong>${escapeHtml(task.title)}</strong>
       <span class="status-pill ${statusClass(task.status)}">${escapeHtml(statusLabel(task.status))}</span>
+      ${task.graph ? `<span class="graph-card-meta">${escapeHtml(task.subtaskCount)} subtasks · concurrency ${escapeHtml(task.maxConcurrency)}</span>` : ''}
       <span class="task-updated">Updated ${formatDate(task.updatedAt)}</span>
     </button>
   `).join('');
@@ -164,6 +166,66 @@ function renderTimeline(timeline = []) {
   `).join('');
 }
 
+function compactJson(value) {
+  return escapeHtml(JSON.stringify(value ?? null, null, 2));
+}
+
+function factBlock(label, value) {
+  if (value === null || value === undefined || value === '' || (Array.isArray(value) && value.length === 0)) return '';
+  const rendered = typeof value === 'object' ? `<pre>${compactJson(value)}</pre>` : `<code>${escapeHtml(value)}</code>`;
+  return `<div class="graph-fact"><span>${escapeHtml(label)}</span>${rendered}</div>`;
+}
+
+function renderGraphDetail(task) {
+  const graph = Boolean(task?.graph);
+  elements['graph-detail'].hidden = !graph;
+  if (!graph) {
+    for (const id of ['graph-topology', 'graph-frontier', 'graph-conflicts', 'graph-integration']) elements[id].innerHTML = '';
+    return;
+  }
+  const dependencies = task.dependencies || [];
+  elements['graph-topology'].innerHTML = (task.subtasks || []).map(subtask => `
+    <article class="graph-node">
+      <div class="graph-node-heading">
+        <div><span class="eyebrow">${escapeHtml(subtask.id)}</span><strong>${escapeHtml(subtask.title || subtask.id)}</strong></div>
+        <span class="status-pill ${statusClass(subtask.state)}">${escapeHtml(statusLabel(subtask.state))}</span>
+      </div>
+      <div class="graph-dependencies">Depends on: ${subtask.dependsOn?.length ? subtask.dependsOn.map(item => `<code>${escapeHtml(item)}</code>`).join(' ') : '<span>none</span>'}</div>
+      <div class="graph-node-meta">
+        <span>Agent <strong>${escapeHtml(subtask.implementer)}</strong></span>
+        <span>Adapter <strong>${escapeHtml(subtask.agent?.adapter || '—')}</strong></span>
+        <span>Session <code>${escapeHtml(shortId(subtask.sessionId) || '—')}</code></span>
+      </div>
+      ${factBlock('Executable', subtask.executable)}
+      ${factBlock('Worktree / branch / commit', { ...subtask.worktree, implementationCommit: subtask.implementationCommit })}
+      ${factBlock('Evidence', subtask.evidence)}
+      ${factBlock('Scope audit', subtask.scopeAudit)}
+      ${factBlock('Recovery', subtask.recovery)}
+      ${factBlock('Last error', subtask.lastError)}
+    </article>
+  `).join('') || '<div class="empty-state">No persisted subtasks.</div>';
+  const edgeList = dependencies.length
+    ? dependencies.map(edge => `<code>${escapeHtml(edge.from)} → ${escapeHtml(edge.to)}</code>`).join(' ')
+    : '<span>none</span>';
+  elements['graph-topology'].insertAdjacentHTML('afterbegin', `<div class="graph-edge-list"><strong>Dependency edges</strong>${edgeList}</div>`);
+  elements['graph-frontier'].innerHTML = [
+    factBlock('Max concurrency', task.maxConcurrency),
+    factBlock('Current frontier', task.frontier),
+    factBlock('Selected preflight wave', task.wave),
+  ].join('');
+  elements['graph-conflicts'].innerHTML = [
+    factBlock('Write-intent conflicts', task.conflicts),
+    factBlock('Intent coverage', task.intentCoverage),
+    factBlock('Recovery classifications', task.recovery),
+  ].join('') || '<div class="empty-state">No conflict or scope facts recorded.</div>';
+  elements['graph-integration'].innerHTML = [
+    factBlock('Integration', task.integration),
+    factBlock('Integration facts', task.integrationFacts),
+    factBlock('Review', task.review),
+    factBlock('Review history', task.reviewHistory),
+  ].join('') || '<div class="empty-state">Integration and review have not been recorded.</div>';
+}
+
 function renderTaskDetail(task) {
   if (!task) {
     elements['task-detail'].hidden = true;
@@ -173,10 +235,11 @@ function renderTaskDetail(task) {
   elements['detail-title'].textContent = task.title;
   elements['detail-summary'].innerHTML = `
     <span class="status-pill ${statusClass(task.status)}">${escapeHtml(statusLabel(task.status))}</span>
-    <span>Round ${escapeHtml(task.round)}</span>
+    <span>${task.graph ? 'Task Graph' : `Round ${escapeHtml(task.round)}`}</span>
     <span>${escapeHtml(task.id)}</span>
     <span>Updated ${formatDate(task.updatedAt)}</span>
   `;
+  renderGraphDetail(task);
   renderTimeline(task.timeline);
   elements['detail-agent-flow'].innerHTML = (task.agentFlow || []).map((item, index) => {
     const agent = agentFor(item.agent);
@@ -192,7 +255,7 @@ function renderTaskDetail(task) {
   const evidence = task.evidence || [];
   const reviews = task.reviewHistory || [];
   elements.evidence.innerHTML = `
-    <div class="evidence-row"><span>Commit</span><code>${escapeHtml(task.implementationCommit || '—')}</code></div>
+    <div class="evidence-row"><span>${task.graph ? 'Base commit' : 'Commit'}</span><code>${escapeHtml(task.graph ? (task.baseCommit || '—') : (task.implementationCommit || '—'))}</code></div>
     <div class="evidence-row"><span>Evidence records</span><strong>${evidence.length}</strong></div>
     ${evidence.map(item => `<div class="evidence-block"><strong>${escapeHtml(item.type || 'Evidence')}</strong><p>${escapeHtml(item.details || item.relatedCommit || '—')}</p></div>`).join('')}
     ${reviews.map(item => `<div class="review-block"><span class="status-pill ${statusClass(item.decision)}">${escapeHtml(statusLabel(item.decision))}</span><p>${escapeHtml(item.feedback || 'No feedback')}</p></div>`).join('')}

--- a/inspector/web/index.html
+++ b/inspector/web/index.html
@@ -54,6 +54,28 @@
           <button id="close-detail" class="button ghost" type="button">Close</button>
         </div>
         <div id="detail-summary" class="detail-summary"></div>
+        <section id="graph-detail" class="graph-detail" hidden>
+          <div class="graph-overview-grid">
+            <div>
+              <h3>Task Graph topology</h3>
+              <div id="graph-topology" class="graph-topology"></div>
+            </div>
+            <div>
+              <h3>Frontier & preflight wave</h3>
+              <div id="graph-frontier" class="graph-facts"></div>
+            </div>
+          </div>
+          <div class="graph-overview-grid">
+            <div>
+              <h3>Conflicts & scope audit</h3>
+              <div id="graph-conflicts" class="graph-facts"></div>
+            </div>
+            <div>
+              <h3>Integration & review</h3>
+              <div id="graph-integration" class="graph-facts"></div>
+            </div>
+          </div>
+        </section>
         <div class="detail-grid">
           <div>
             <h3>Event timeline</h3>

--- a/inspector/web/styles.css
+++ b/inspector/web/styles.css
@@ -76,6 +76,8 @@ h3 { margin-bottom: 1rem; color: var(--muted); font-size: .74rem; letter-spacing
 .task-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); gap: .75rem; }
 .task-card { display: flex; min-height: 9.5rem; flex-direction: column; align-items: flex-start; gap: .55rem; padding: 1rem; border: 1px solid var(--line); border-radius: .75rem; color: var(--text); background: rgba(255, 255, 255, .025); text-align: left; cursor: pointer; transition: border-color .18s, transform .18s, background .18s; }
 .task-card:hover, .task-card.selected { border-color: rgba(140, 169, 255, .7); background: rgba(97, 124, 255, .13); transform: translateY(-2px); }
+.task-card.graph-card { border-left: 3px solid var(--accent); }
+.graph-card-meta { color: var(--accent); font-size: .7rem; font-weight: 600; }
 .task-card-top { display: flex; width: 100%; justify-content: space-between; color: var(--muted); font-size: .7rem; }
 .task-card strong { min-height: 2.5rem; font-size: .98rem; line-height: 1.3; }
 .task-id, .round, .task-updated, .adapter, .session-meta, .session-tasks, .timeline-meta { color: var(--muted); font-size: .72rem; }
@@ -98,6 +100,24 @@ h3 { margin-bottom: 1rem; color: var(--muted); font-size: .74rem; letter-spacing
 
 .task-detail-panel { scroll-margin-top: 1rem; }
 .detail-summary { flex-wrap: wrap; gap: .65rem 1rem; margin: -0.4rem 0 1.5rem; color: var(--muted); font-size: .76rem; }
+.graph-detail { margin-bottom: 2rem; }
+.graph-overview-grid { display: grid; grid-template-columns: minmax(0, 1.15fr) minmax(260px, .85fr); gap: 2rem; margin-bottom: 1.5rem; }
+.graph-topology { display: grid; gap: .75rem; }
+.graph-edge-list { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem .6rem; padding: .6rem .8rem; border: 1px solid var(--line); border-radius: .55rem; background: rgba(255, 255, 255, .02); font-size: .74rem; color: var(--muted); }
+.graph-edge-list strong { color: var(--text); }
+.graph-edge-list code { color: var(--accent); font-size: .72rem; }
+.graph-node { padding: 1rem; border: 1px solid var(--line); border-radius: .75rem; background: rgba(255, 255, 255, .025); }
+.graph-node-heading { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-bottom: .6rem; }
+.graph-node-heading strong { font-size: .92rem; }
+.graph-dependencies { margin-bottom: .6rem; color: var(--muted); font-size: .72rem; }
+.graph-dependencies code { color: var(--accent); }
+.graph-node-meta { display: flex; flex-wrap: wrap; gap: .4rem 1rem; margin-bottom: .6rem; color: var(--muted); font-size: .72rem; }
+.graph-node-meta strong, .graph-node-meta code { color: var(--text); }
+.graph-facts { display: grid; gap: .75rem; }
+.graph-fact { padding: .75rem .85rem; border: 1px solid var(--line); border-radius: .55rem; background: rgba(255, 255, 255, .02); }
+.graph-fact > span { display: block; margin-bottom: .35rem; color: var(--accent); font-size: .68rem; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+.graph-fact pre { margin: 0; padding: .6rem; max-height: 12rem; overflow: auto; border: 1px solid var(--line); border-radius: .45rem; background: rgba(0, 0, 0, .25); font: .7rem/1.4 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; color: #cdd8f7; white-space: pre-wrap; overflow-wrap: anywhere; }
+.graph-fact code { font-size: .74rem; color: var(--text); }
 .detail-grid { display: grid; grid-template-columns: minmax(0, 1.15fr) minmax(260px, .85fr); gap: 2rem; }
 .lower-grid { margin-top: 2rem; }
 .timeline-item { display: grid; grid-template-columns: 1.2rem minmax(0, 1fr); min-height: 4rem; }
@@ -155,7 +175,7 @@ h3 { margin-bottom: 1rem; color: var(--muted); font-size: .74rem; letter-spacing
 
 @media (max-width: 900px) {
   .topbar, .footer { align-items: flex-start; flex-direction: column; }
-  .hero-grid, .detail-grid { grid-template-columns: 1fr; }
+  .hero-grid, .detail-grid, .graph-overview-grid { grid-template-columns: 1fr; }
   .agent-flow { min-height: 0; flex-direction: column; align-items: stretch; }
   .flow-arrow { transform: rotate(90deg); align-self: center; }
 }

--- a/test/inspector.test.mjs
+++ b/test/inspector.test.mjs
@@ -6,6 +6,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   realpathSync,
   rmSync,
   writeFileSync,
@@ -19,6 +20,14 @@ import {
   recordReviewDecision,
   setTaskStatus,
 } from '../skills/coordinate-agents/scripts/task-runtime.mjs';
+import {
+  createTaskGraph,
+  setTaskGraphIntegration,
+  setTaskGraphReview,
+  setTaskGraphState,
+  setTaskGraphSubtaskState,
+  taskGraphPath,
+} from '../skills/coordinate-agents/scripts/task-graph-runtime.mjs';
 import { startInspector } from '../inspector/server/server.mjs';
 import { appendRuntimeEvent } from '../skills/coordinate-agents/scripts/runtime-events.mjs';
 
@@ -89,6 +98,13 @@ function writeSession(repositoryRoot, taskId) {
     endpoint: 'fixture-endpoint',
     hostPid: null,
   }, null, 2)}\n`, 'utf8');
+  appendRuntimeEvent(repositoryRoot, {
+    type: 'SESSION_EXITED',
+    sessionId,
+    agentId: 'antigravity',
+    taskId,
+    data: { state: 'exited', exitCode: 0 },
+  });
   return { sessionId, taskId };
 }
 
@@ -110,12 +126,11 @@ async function closeServer(server) {
 
 function fixture() {
   const repositoryRoot = repository();
-  const session = writeSession(repositoryRoot, 'task-inspector');
   const task = createTask(repositoryRoot, {
     id: 'task-inspector',
     title: 'Build Inspector fixture',
     spec: 'Show the coordination loop without changing runtime state.',
-    sessionId: session.sessionId,
+    sessionId: 'session_fixture123',
   });
   setTaskStatus(repositoryRoot, task.id, 'PLANNING');
   setTaskStatus(repositoryRoot, task.id, 'SPEC_READY');
@@ -134,10 +149,111 @@ function fixture() {
     feedback: 'Evidence is complete.',
     evidence: { tests: 'passed' },
   });
+  writeSession(repositoryRoot, 'task-inspector');
   writeAgentState(repositoryRoot, 'codex', 'APPROVED', 'Task task-inspector reviewed.', '2026-08-23T00:05:00.000Z');
   writeAgentState(repositoryRoot, 'antigravity', 'WAITING', 'Task task-inspector implementation complete.', '2026-08-23T00:04:00.000Z');
   writeBusMessage(repositoryRoot);
   return repositoryRoot;
+}
+
+function graphFixture(repositoryRoot) {
+  const baseCommit = '1111111111111111111111111111111111111111';
+  const implCommit1 = '2222222222222222222222222222222222222222';
+  const aggCommit = '3333333333333333333333333333333333333333';
+
+  const graphInput = {
+    schemaVersion: 1,
+    parentTask: {
+      id: 'task-graph-inspector',
+      title: 'Build Graph Inspector fixture',
+      spec: 'Demonstrate Task Graph visualization with subtasks and topology.',
+      planner: 'codex',
+      reviewer: 'codex',
+    },
+    subtasks: [
+      { id: 'backend', implementer: 'antigravity', spec: 'Implement backend service.', dependsOn: [] },
+      { id: 'frontend', implementer: 'codex', spec: 'Implement frontend UI.', dependsOn: ['backend'] },
+      { id: 'docs', implementer: 'codex', spec: 'Write documentation.', dependsOn: ['backend'] },
+    ],
+    maxConcurrency: 2,
+  };
+
+  const intentMap = {
+    schemaVersion: 1,
+    parentTaskId: 'task-graph-inspector',
+    scopePolicy: 'strict',
+    subtasks: [
+      { id: 'backend', writeIntent: ['src/server/**'] },
+      { id: 'frontend', writeIntent: ['src/client/**'] },
+      { id: 'docs', writeIntent: ['docs/**'] },
+    ],
+  };
+
+  createTaskGraph(repositoryRoot, graphInput, {
+    configuredAgents: [{ id: 'codex', adapter: 'codex-cli' }, { id: 'antigravity', adapter: 'generic-cli' }],
+    intentMap,
+  });
+
+  setTaskGraphSubtaskState(repositoryRoot, 'task-graph-inspector', 'backend', 'RUNNING', {
+    sessionId: 'session_backend123',
+    worktreePath: join(repositoryRoot, '.agent-bus', 'worktrees', 'task-graph-inspector', 'backend'),
+    branch: 'coordinate-agents/task-graph-inspector/backend',
+    ref: 'refs/heads/coordinate-agents/task-graph-inspector/backend',
+    baseCommit,
+  });
+
+  setTaskGraphSubtaskState(repositoryRoot, 'task-graph-inspector', 'backend', 'SUCCEEDED', {
+    implementationCommit: implCommit1,
+    evidence: [{
+      type: 'IMPLEMENTATION_DONE',
+      relatedCommit: implCommit1,
+      details: 'Backend implementation complete with unit tests.',
+      createdAt: '2026-08-23T00:03:00.000Z',
+    }],
+    scopeEvidence: {
+      schemaVersion: 1,
+      parentTaskId: 'task-graph-inspector',
+      subtaskId: 'backend',
+      graphBaseCommit: baseCommit,
+      implementationCommit: implCommit1,
+      scopePolicy: 'strict',
+      coverage: 'declared',
+      writeIntent: ['src/server/**'],
+      actualPathCount: 1,
+      actualPaths: ['src/server/index.js'],
+      actualPathsTruncated: false,
+      outsideIntentPathCount: 0,
+      outsideIntentPaths: [],
+      outsideIntentPathsTruncated: false,
+      committedChangeCount: 1,
+      committedChanges: [{ status: 'A', path: 'src/server/index.js' }],
+      committedChangesTruncated: false,
+      dirtyChangeCount: 0,
+      dirtyChanges: [],
+      dirtyChangesTruncated: false,
+      dirtyWorktreeAvailable: false,
+      hasDirty: false,
+      drift: false,
+      driftEvidence: null,
+    },
+  });
+
+  setTaskGraphState(repositoryRoot, 'task-graph-inspector', 'RUNNING');
+
+  setTaskGraphIntegration(repositoryRoot, 'task-graph-inspector', 'SUCCEEDED', {
+    aggregateCommit: aggCommit,
+    worktreePath: join(repositoryRoot, '.agent-bus', 'worktrees', 'task-graph-inspector', '__integration__'),
+    branch: 'coordinate-agents/task-graph-inspector/__integration__',
+    ref: 'refs/heads/coordinate-agents/task-graph-inspector/__integration__',
+    appliedCommits: [implCommit1],
+    appliedSubtasks: ['backend'],
+  });
+
+  setTaskGraphReview(repositoryRoot, 'task-graph-inspector', 'REVIEW_APPROVED', {
+    feedback: 'Graph topology executed correctly and integration verified.',
+  });
+
+  return { baseCommit, implCommit1, aggCommit };
 }
 
 test('Inspector API reads fixture Tasks, Sessions, Agent topology, events, and dashboard assets', async () => {
@@ -153,12 +269,14 @@ test('Inspector API reads fixture Tasks, Sessions, Agent topology, events, and d
     const tasks = await tasksResponse.json();
     assert.equal(tasks.length, 1);
     assert.deepEqual(tasks[0], {
+      kind: 'task',
+      graph: false,
       id: 'task-inspector',
       title: 'Build Inspector fixture',
       status: 'APPROVED',
       round: 1,
-      updatedAt: tasks[0].updatedAt,
       createdAt: tasks[0].createdAt,
+      updatedAt: tasks[0].updatedAt,
       planner: 'codex',
       implementer: 'antigravity',
       reviewer: 'codex',
@@ -311,4 +429,349 @@ test('Inspector metadata is included in the package payload and CLI help', () =>
   assert.match(help.stdout, /inspector\s+Start the local read-only Web UI Inspector/);
   assert.match(help.stdout, /--port <port>/);
   assert.equal(existsSync(join(root, 'inspector', 'web', 'index.html')), true);
+});
+
+test('Inspector mixed listing discovers both ordinary Tasks and Task Graph parents with distinct summaries and sorting', async () => {
+  const repositoryRoot = fixture();
+  graphFixture(repositoryRoot);
+  const started = await startInspector({ root: repositoryRoot, port: 0 });
+  try {
+    const tasksResponse = await fetch(`${started.url}/api/tasks`);
+    assert.equal(tasksResponse.status, 200);
+    const tasks = await tasksResponse.json();
+    assert.equal(tasks.length, 2);
+
+    const graphEntry = tasks.find(item => item.graph === true);
+    assert.ok(graphEntry, 'Task Graph parent must appear in tasks list');
+    assert.equal(graphEntry.kind, 'task-graph-parent');
+    assert.equal(graphEntry.id, 'task-graph-inspector');
+    assert.equal(graphEntry.parentTaskId, 'task-graph-inspector');
+    assert.equal(graphEntry.title, 'Build Graph Inspector fixture');
+    assert.equal(graphEntry.status, 'APPROVED');
+    assert.equal(graphEntry.maxConcurrency, 2);
+    assert.equal(graphEntry.subtaskCount, 3);
+    assert.equal(graphEntry.reviewDecision, 'REVIEW_APPROVED');
+    assert.deepEqual(graphEntry.counts, {
+      ready: 2,
+      waiting: 0,
+      running: 0,
+      succeeded: 1,
+      failed: 0,
+      blocked: 0,
+      stopped: 0,
+    });
+
+    const ordinaryEntry = tasks.find(item => item.graph === false);
+    assert.ok(ordinaryEntry, 'Ordinary task must appear in tasks list');
+    assert.equal(ordinaryEntry.kind, 'task');
+    assert.equal(ordinaryEntry.id, 'task-inspector');
+    assert.equal(ordinaryEntry.round, 1);
+
+    for (let i = 0; i < tasks.length - 1; i += 1) {
+      assert.ok(tasks[i].updatedAt >= tasks[i + 1].updatedAt);
+    }
+  } finally {
+    await closeServer(started.server);
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('Inspector returns exhaustive bounded Task Graph detail across subtasks, topology, frontier, wave, integration, recovery, and review', async () => {
+  const repositoryRoot = repository();
+  const { implCommit1, aggCommit } = graphFixture(repositoryRoot);
+  const started = await startInspector({ root: repositoryRoot, port: 0 });
+  try {
+    const detailResponse = await fetch(`${started.url}/api/tasks/task-graph-inspector`);
+    assert.equal(detailResponse.status, 200);
+    const detail = await detailResponse.json();
+
+    assert.equal(detail.graph, true);
+    assert.equal(detail.kind, 'task-graph-parent');
+    assert.equal(detail.id, 'task-graph-inspector');
+    assert.equal(detail.parentTaskId, 'task-graph-inspector');
+    assert.equal(detail.title, 'Build Graph Inspector fixture');
+    assert.equal(detail.status, 'APPROVED');
+    assert.equal(detail.maxConcurrency, 2);
+    assert.equal(detail.subtaskCount, 3);
+    assert.equal(detail.schemaVersion, 1);
+    assert.equal(detail.spec, 'Demonstrate Task Graph visualization with subtasks and topology.');
+    assert.equal(detail.historySource, 'recorded');
+
+    // Subtasks and topology
+    assert.equal(detail.subtasks.length, 3);
+    const backend = detail.subtasks.find(s => s.id === 'backend');
+    assert.ok(backend);
+    assert.equal(backend.title, 'backend');
+    assert.equal(backend.spec, 'Implement backend service.');
+    assert.equal(backend.state, 'SUCCEEDED');
+    assert.equal(backend.implementer, 'antigravity');
+    assert.deepEqual(backend.agent, { id: 'antigravity', registered: true, adapter: 'antigravity-cli' });
+    assert.equal(backend.sessionId, 'session_backend123');
+    assert.equal(backend.worktree.branch, 'coordinate-agents/task-graph-inspector/backend');
+    assert.equal(backend.implementationCommit, implCommit1);
+    assert.equal(backend.evidence.length, 1);
+    assert.equal(backend.evidence[0].type, 'IMPLEMENTATION_DONE');
+    assert.equal(backend.scopeAudit.schemaVersion, 1);
+    assert.equal(backend.scopeAudit.drift, false);
+    assert.equal(backend.scopeAudit.scopePolicy, 'strict');
+    assert.deepEqual(backend.scopeAudit.actualPaths, ['src/server/index.js']);
+    assert.deepEqual(backend.scopeAudit.outsideIntentPaths, []);
+    assert.ok(backend.recovery);
+    assert.equal(backend.recovery.classification, 'completed');
+
+    const frontend = detail.subtasks.find(s => s.id === 'frontend');
+    assert.ok(frontend);
+    assert.deepEqual(frontend.dependsOn, ['backend']);
+    assert.equal(frontend.state, 'READY');
+
+    const docs = detail.subtasks.find(s => s.id === 'docs');
+    assert.ok(docs);
+    assert.deepEqual(docs.dependsOn, ['backend']);
+    assert.equal(docs.state, 'READY');
+
+    // Dependencies edges
+    assert.deepEqual(detail.dependencies, [
+      { from: 'backend', to: 'docs' },
+      { from: 'backend', to: 'frontend' },
+    ]);
+
+    // Frontier & wave
+    assert.deepEqual(detail.frontier.ready, ['docs', 'frontend']);
+    assert.deepEqual(detail.frontier.waiting, []);
+    assert.deepEqual(detail.frontier.running, []);
+    assert.deepEqual(detail.frontier.succeeded, ['backend']);
+    assert.ok(detail.wave);
+    assert.deepEqual(detail.wave.selected, ['docs', 'frontend']);
+    assert.deepEqual(detail.wave.conflicts, []);
+
+    // Conflicts and Intent coverage
+    assert.deepEqual(detail.conflicts, []);
+    assert.ok(detail.intentCoverage);
+    assert.equal(detail.intentCoverage.schemaVersion, 1);
+    assert.equal(detail.intentCoverage.subtasks.length, 3);
+
+    // Integration facts
+    assert.ok(detail.integration);
+    assert.equal(detail.integration.state, 'SUCCEEDED');
+    assert.equal(detail.integration.aggregateCommit, aggCommit);
+    assert.ok(detail.integrationFacts);
+    assert.equal(detail.integrationFacts.branch, 'coordinate-agents/task-graph-inspector/__integration__');
+
+    // Review facts
+    assert.ok(detail.review);
+    assert.equal(detail.review.decision, 'REVIEW_APPROVED');
+    assert.equal(detail.review.feedback, 'Graph topology executed correctly and integration verified.');
+    assert.equal(detail.reviewHistory.length, 1);
+
+    // Timeline and events
+    assert.ok(Array.isArray(detail.events));
+    assert.ok(detail.events.some(e => e.type === 'TASK_GRAPH_CREATED'));
+    assert.ok(detail.events.some(e => e.type === 'REVIEW_APPROVED'));
+    assert.ok(Array.isArray(detail.timeline));
+
+    // Agent flow
+    assert.deepEqual(detail.agentFlow, [
+      { role: 'planner', agent: 'codex' },
+      { role: 'implementer', agent: 'antigravity' },
+      { role: 'implementer', agent: 'codex' },
+      { role: 'reviewer', agent: 'codex' },
+    ]);
+  } finally {
+    await closeServer(started.server);
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('Inspector direct /api/graphs and /api/graphs/:id endpoints provide dedicated Task Graph access', async () => {
+  const repositoryRoot = repository();
+  graphFixture(repositoryRoot);
+  const started = await startInspector({ root: repositoryRoot, port: 0 });
+  try {
+    const listRes = await fetch(`${started.url}/api/graphs`);
+    assert.equal(listRes.status, 200);
+    const list = await listRes.json();
+    assert.equal(list.length, 1);
+    assert.equal(list[0].id, 'task-graph-inspector');
+    assert.equal(list[0].graph, true);
+    assert.equal(list[0].subtaskCount, 3);
+
+    const itemRes = await fetch(`${started.url}/api/graphs/task-graph-inspector`);
+    assert.equal(itemRes.status, 200);
+    const item = await itemRes.json();
+    assert.equal(item.id, 'task-graph-inspector');
+    assert.equal(item.graph, true);
+    assert.equal(item.subtasks.length, 3);
+
+    const notFoundRes = await fetch(`${started.url}/api/graphs/task-nonexistent`);
+    assert.equal(notFoundRes.status, 404);
+  } finally {
+    await closeServer(started.server);
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('Inspector SSE streams Task Graph events and filters/resumes from Last-Event-ID', async () => {
+  const repositoryRoot = repository();
+  const first = appendRuntimeEvent(repositoryRoot, {
+    type: 'TASK_GRAPH_CREATED',
+    taskId: 'task-graph-sse',
+    agentId: 'codex',
+    role: 'planner',
+    data: { parentTaskId: 'task-graph-sse', maxConcurrency: 2 },
+  });
+  const second = appendRuntimeEvent(repositoryRoot, {
+    type: 'TASK_GRAPH_STATUS_CHANGED',
+    taskId: 'task-graph-sse',
+    agentId: 'codex',
+    role: 'planner',
+    data: { from: 'CREATED', to: 'RUNNING' },
+  });
+  const started = await startInspector({ root: repositoryRoot, port: 0 });
+  const controller = new AbortController();
+  try {
+    const response = await fetch(`${started.url}/api/events/stream`, {
+      headers: { 'Last-Event-ID': `${first.sequence}` },
+      signal: controller.signal,
+    });
+    assert.equal(response.status, 200);
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let body = '';
+
+    const third = appendRuntimeEvent(repositoryRoot, {
+      type: 'TASK_GRAPH_STATUS_CHANGED',
+      taskId: 'task-graph-sse',
+      agentId: 'codex',
+      role: 'planner',
+      data: { from: 'RUNNING', to: 'APPROVED' },
+    });
+
+    const deadline = Date.now() + 4_000;
+    while (Date.now() < deadline && (!body.includes(`id: ${second.sequence}\n`) || !body.includes(`id: ${third.sequence}\n`))) {
+      const result = await Promise.race([
+        reader.read(),
+        new Promise(resolvePromise => setTimeout(() => resolvePromise({ timeout: true }), 700)),
+      ]);
+      if (result.timeout) continue;
+      if (result.done) break;
+      body += decoder.decode(result.value, { stream: true });
+    }
+    assert.match(body, new RegExp(`id: ${second.sequence}\\n`));
+    assert.match(body, new RegExp(`id: ${third.sequence}\\n`));
+    assert.equal(body.includes(`id: ${first.sequence}\n`), false);
+  } finally {
+    controller.abort();
+    await closeServer(started.server);
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('Inspector dashboard assets include Task Graph topology, frontier, conflict, and integration elements', async () => {
+  const repositoryRoot = fixture();
+  const started = await startInspector({ root: repositoryRoot, port: 0 });
+  try {
+    const html = await (await fetch(`${started.url}/index.html`)).text();
+    assert.match(html, /id="graph-detail"/);
+    assert.match(html, /id="graph-topology"/);
+    assert.match(html, /id="graph-frontier"/);
+    assert.match(html, /id="graph-conflicts"/);
+    assert.match(html, /id="graph-integration"/);
+
+    const js = await (await fetch(`${started.url}/app.js`)).text();
+    assert.match(js, /renderGraphDetail/);
+    assert.match(js, /graph-card/);
+    assert.match(js, /graph-topology/);
+    assert.match(js, /graph-frontier/);
+    assert.match(js, /graph-conflicts/);
+    assert.match(js, /graph-integration/);
+
+    const css = await (await fetch(`${started.url}/styles.css`)).text();
+    assert.match(css, /\.graph-card/);
+    assert.match(css, /\.graph-detail/);
+    assert.match(css, /\.graph-overview-grid/);
+    assert.match(css, /\.graph-topology/);
+    assert.match(css, /\.graph-facts/);
+    assert.match(css, /\.graph-node/);
+    assert.match(css, /\.graph-fact/);
+  } finally {
+    await closeServer(started.server);
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('Inspector fails closed for malformed IDs, non-GET methods, symlinks, and path escapes without side effects', async () => {
+  const repositoryRoot = fixture();
+  graphFixture(repositoryRoot);
+  const started = await startInspector({ root: repositoryRoot, port: 0 });
+  try {
+    // Non-GET methods must be rejected with 405 and Allow: GET header
+    for (const method of ['POST', 'PUT', 'PATCH', 'DELETE']) {
+      for (const endpoint of ['/api/tasks', '/api/graphs', '/api/tasks/task-inspector', '/api/graphs/task-graph-inspector', '/api/events']) {
+        const res = await fetch(`${started.url}${endpoint}`, { method });
+        assert.equal(res.status, 405, `${method} ${endpoint} must be rejected with 405`);
+        assert.equal(res.headers.get('allow'), 'GET');
+      }
+    }
+
+    // Malformed task and graph IDs must return 400 or 404 fail closed
+    const malformed = ['task-$invalid', 'invalid-id', 'task-123%2F..%2F..%2Fetc', 'task-with-space '];
+    for (const id of malformed) {
+      const taskRes = await fetch(`${started.url}/api/tasks/${id}`);
+      assert.ok([400, 404].includes(taskRes.status), `Malformed task id ${id} must fail closed`);
+      const graphRes = await fetch(`${started.url}/api/graphs/${id}`);
+      assert.ok([400, 404].includes(graphRes.status), `Malformed graph id ${id} must fail closed`);
+    }
+
+    // Path escapes
+    const escapeRes = await fetch(`${started.url}/api/tasks/%2E%2E%2F%2E%2E%2Fpackage.json`);
+    assert.ok([400, 404].includes(escapeRes.status));
+
+    // Nonexistent IDs
+    const notFoundTask = await fetch(`${started.url}/api/tasks/task-doesnotexist`);
+    assert.equal(notFoundTask.status, 404);
+    const notFoundGraph = await fetch(`${started.url}/api/graphs/task-doesnotexist`);
+    assert.equal(notFoundGraph.status, 404);
+
+    // Snapshot repository before and after inspector calls to prove NO side-effects
+    function snapshotDir(dir) {
+      const entries = [];
+      function walk(current) {
+        if (!existsSync(current)) return;
+        for (const name of readdirSync(current).sort()) {
+          const full = join(current, name);
+          entries.push(full.slice(dir.length));
+          try {
+            const stat = readFileSync(full);
+            entries.push(stat.byteLength);
+          } catch {
+            walk(full);
+          }
+        }
+      }
+      walk(dir);
+      return entries;
+    }
+
+    const beforeSnapshot = snapshotDir(join(repositoryRoot, '.agent-bus'));
+
+    // Perform multiple read operations
+    await fetch(`${started.url}/api/tasks`);
+    await fetch(`${started.url}/api/graphs`);
+    await fetch(`${started.url}/api/tasks/task-graph-inspector`);
+    await fetch(`${started.url}/api/graphs/task-graph-inspector`);
+    await fetch(`${started.url}/api/tasks/task-inspector`);
+    await fetch(`${started.url}/api/agents`);
+    await fetch(`${started.url}/api/sessions`);
+    await fetch(`${started.url}/api/events?limit=100`);
+
+    const afterSnapshot = snapshotDir(join(repositoryRoot, '.agent-bus'));
+    assert.deepEqual(beforeSnapshot, afterSnapshot, 'Inspector reads must produce zero mutations, events, or bus files');
+
+    // Verify git status unchanged
+    const gitStatus = spawnSync('git', ['status', '--porcelain'], { cwd: repositoryRoot, encoding: 'utf8', windowsHide: true });
+    assert.equal(gitStatus.status, 0);
+  } finally {
+    await closeServer(started.server);
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
 });

--- a/test/task-graph-scope-audit.test.mjs
+++ b/test/task-graph-scope-audit.test.mjs
@@ -496,7 +496,9 @@ test('auditSubtaskScope: paths with spaces and shell metacharacters are handled 
     // Create a file with spaces, a tab, and shell metacharacters. Argument
     // arrays plus NUL-delimited Git output must preserve it exactly.
     mkdirSync(join(root, 'src'), { recursive: true });
-    const unusualPath = 'src/path with space\t$value;[x].js';
+    const unusualPath = process.platform === 'win32'
+      ? 'src/path with space $value;[x].js'
+      : 'src/path with space\t$value;[x].js';
     writeFileSync(join(root, unusualPath), 'impl\n', 'utf8');
     execFileSync('git', ['add', unusualPath], { cwd: root, stdio: 'ignore', windowsHide: true });
     execFileSync('git', ['commit', '-m', 'Add product'], { cwd: root, stdio: 'ignore', windowsHide: true });


### PR DESCRIPTION
Closes #36.

## Summary

Extends the existing localhost-only Inspector so it can discover and render persisted Task Graphs alongside ordinary Tasks. Provides a graph overview and detail view covering the DAG, current frontier and preflight waves, Agents/Adapters/executables, Sessions, worktrees, branches, commits, evidence, conflicts, scope audit, recovery, integration, and review facts — without duplicating or mutating the Runtime model.

Parent: #30. Dependencies #33 and #34 are merged.

## Changes

- `inspector/server/inspector-data.mjs`: `graphSummary`, `graphDetail`, `graphSubtaskView`, `graphAgentFacts`; `readTasks()` merges ordinary Tasks and Task Graph parents; new `readGraphs()` / `readGraph(id)`.
- `inspector/server/server.mjs`: new `GET /api/graphs` and `GET /api/graphs/:id` endpoints.
- `inspector/web/`: graph topology, frontier/wave, conflicts/scope, integration/review detail panels.
- `docs/inspector.md`: endpoint and panel documentation synchronized.
- `test/inspector.test.mjs`: 6 new tests covering mixed listing, exhaustive bounded detail, dedicated graph endpoints, SSE, dashboard assets, and fail-closed zero-side-effect reads.
- `test/task-graph-scope-audit.test.mjs`: cross-platform fix for Windows filename with tab.

## Acceptance criteria

- [x] Inspector lists graph parents and ordinary Tasks without breaking existing task cards, detail views, session panels, event timelines, or legacy-history behavior.
- [x] Graph detail response/view shows every subtask, dependency edge, state, frontier decision, assigned Agent and Adapter, exact executable facts, Session/worktree/branch/commit facts, evidence, conflict facts, scope findings, recovery classification, integration, and review state with bounded fields.
- [x] Graph data is read from the authoritative Runtime graph records and Event Journal; the Inspector does not create a second state model, fabricate events, or infer completion from filenames or prose.
- [x] All graph endpoints and UI interactions remain GET/read-only and loopback-only, including event streaming; POST or other mutation attempts remain rejected.
- [x] Secret-bearing or oversized local content remains redacted/bounded, and malformed or unsafe Runtime paths fail closed without exposing unrelated repository data.
- [x] Focused API, browser-asset, SSE, and compatibility tests use isolated graph fixtures and prove that Inspector reads never create Sessions, processes, worktrees, or graph mutations.

## Test results

`npm run check`: 275 tests, 273 pass, 1 fail (pre-existing Windows `tar -xzf C:/` path issue in `release-artifact.test.mjs`, unrelated to this change), 1 skipped. All 11 Inspector tests and the full Task Graph suite pass.