### PR TITLE
feat(web): add coordinate-agents web Workspace over the read-only Inspector runtime (#45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,19 @@ npx @hogancv/coordinate-agents@latest --help
 
 Use this path for legacy standalone Skill installation, external automation, or protocol debugging. The full command workflows are maintained in [Getting Started](./docs/getting-started.md) and [MCP integration](./docs/mcp.md).
 
+## Local Development
+
+For fast daily regressions run the focused core suite (~20 seconds), which
+covers the CLI dispatcher, Web Workspace, Inspector, documentation, repository
+layout, and shared Runtime contracts:
+
+```sh
+npm run test:core
+```
+
+Run the full `npm test` suite (several minutes, including Task Graph, Session,
+Plugin, and MCP integration guards) before proposing a release.
+
 ## Documentation
 
 - Start here: [AI installation contract](./AI_INSTALL.md), [Getting Started](./docs/getting-started.md), [Install with AI](./docs/install-with-ai.md), [FAQ](./docs/faq.md), [Changelog](./CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -151,17 +151,25 @@ project command > user command > adapter default precedence.
 
 ## Local Inspector
 
-Start the read-only local Inspector from a repository with an initialized Agent Bus:
+The **Web Workspace** is the primary local browser entry. From any initialized
+Git repository with an Agent Bus it starts a loopback-only, read-only project
+overview — no Codex Plugin, global installation, or remote service required:
 
 ```sh
-npx @hogancv/coordinate-agents@latest inspector --port 3000
+npx @hogancv/coordinate-agents@latest web --port 3000
 ```
 
-It presents task, session, and Event Journal timelines without making the browser the source of truth. Learn more in [Inspector](./docs/inspector.md) and [Event Journal](./docs/event-journal.md).
+The Workspace binds exactly one Git repository and shows its identity (branch,
+HEAD, remote), Tasks and Task Graph parents, Agents, Sessions, recent Runtime
+events, and bounded Task/Graph detail. The `inspector` command stays available
+as the compatible read-only UI over the same GET contracts. The browser is
+never the source of truth. Learn more in
+[Inspector & Web Workspace](./docs/inspector.md) and
+[Event Journal](./docs/event-journal.md).
 
 ## Standalone npm Runtime
 
-The compatibility package exposes the installer, doctor, quickstart, task, agent, session, MCP, and Inspector commands:
+The compatibility package exposes the installer, doctor, quickstart, task, agent, session, MCP, Inspector, and web commands:
 
 ```sh
 npx @hogancv/coordinate-agents@latest --help

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -155,6 +155,18 @@ npx @hogancv/coordinate-agents@latest --help
 
 该路径适用于旧版 standalone Skill 安装、外部自动化或协议调试。完整命令工作流见[快速入门](./docs/getting-started.md)与 [MCP 集成](./docs/mcp.md)。
 
+## 本地开发
+
+日常快速回归请运行精简核心测试（约 20 秒），覆盖 CLI 分发、Web Workspace、
+Inspector、文档、仓库布局与共享 Runtime 契约：
+
+```sh
+npm run test:core
+```
+
+发布前再运行完整 `npm test`（数分钟，包含 Task Graph、Session、Plugin 与 MCP
+集成守卫）。
+
 ## 文档导航
 
 - 开始使用：[AI 安装契约](./AI_INSTALL.md)、[快速入门](./docs/getting-started.md)、[让 AI 安装](./docs/install-with-ai.md)、[常见问题](./docs/faq.md)、[变更记录](./CHANGELOG.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -131,17 +131,23 @@ Setup discovery 以及现有 MCP setup/Task 工具会暴露同一个、向后兼
 
 ## 本地 Inspector
 
-在已初始化 Agent Bus 的仓库中启动只读本地 Inspector：
+**Web Workspace** 是主要的本地浏览器入口。在任何已初始化 Agent Bus 的 Git
+仓库中即可启动一个仅回环、只读的项目总览 —— 无需 Codex Plugin、全局安装或
+远程服务：
 
 ```sh
-npx @hogancv/coordinate-agents@latest inspector --port 3000
+npx @hogancv/coordinate-agents@latest web --port 3000
 ```
 
-它展示任务、Session 与 Event Journal 时间线，但浏览器页面不是事实源。详见 [Inspector](./docs/inspector.md)与 [Event Journal](./docs/event-journal.md)。
+Workspace 在启动时绑定唯一一个 Git 仓库，展示其身份（分支、HEAD、远程）、
+普通 Task 与 Task Graph parent、Agents、Sessions、近期 Runtime 事件以及有界
+的 Task/Graph 详情。`inspector` 命令继续作为同一套 GET 契约上的兼容只读
+界面保留。浏览器页面始终不是事实源。详见 [Inspector 与 Web Workspace](./docs/inspector.md)
+与 [Event Journal](./docs/event-journal.md)。
 
 ## Standalone npm Runtime
 
-兼容性 npm 包提供 installer、doctor、quickstart、task、agent、session、MCP 和 Inspector 命令：
+兼容性 npm 包提供 installer、doctor、quickstart、task、agent、session、MCP、Inspector 和 web 命令：
 
 ```sh
 npx @hogancv/coordinate-agents@latest --help

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,6 +6,29 @@ description: A verified first-run lifecycle for Codex App or Codex CLI specifica
 
 # Getting started
 
+## Open the local Web Workspace (read-only)
+
+The **Web Workspace** is the primary local browser entry for observing a
+repository: repository identity, Tasks and Task Graph parents, Agents,
+Sessions, recent Runtime events, and bounded Task/Graph detail. From any
+initialized Git repository with an Agent Bus it starts a loopback-only,
+read-only server — no Codex Plugin, global installation, or remote service:
+
+```console
+$ npx @hogancv/coordinate-agents@latest web --port 3000
+Workspace running:
+
+http://localhost:3000
+```
+
+The Workspace binds exactly one canonical repository root at startup and
+browser requests can never select another root. It is read-only: opening,
+refreshing, selecting Tasks or Task Graphs, and replaying events create no
+process, Session, worktree, Bus message, commit, or state transition. The
+`inspector` command remains available as the compatible read-only UI over the
+same GET contracts. Follow the Plugin or CLI paths below to create, dispatch,
+review, resume, or stop work; later milestones add guarded browser actions.
+
 ## Codex Plugin-first path
 
 The Codex Plugin is the preferred first-use experience. Its Multi-Skill surface

--- a/docs/inspector.md
+++ b/docs/inspector.md
@@ -1,31 +1,35 @@
 ---
 layout: page
-title: Local Inspector Web UI
-description: A localhost-only, read-only dashboard for observing Coordinate Agents Tasks, Agents, Sessions, and Agent Bus events.
+title: Web Workspace and Local Inspector
+description: A localhost-only, read-only Web Workspace for observing Coordinate Agents Tasks, Task Graphs, Agents, Sessions, and Agent Bus events. The Inspector remains the compatible read-only UI.
 ---
 
-# Local Inspector Web UI
+# Web Workspace and Local Inspector
 
-The Inspector is a small local observability surface for Coordinate Agents. It
-helps answer “what is happening?” while the Codex Plugin and the existing
-Runtime remain the product and execution surfaces.
+The **Web Workspace** is the primary local browser entry for Coordinate Agents.
+It starts a loopback-only, read-only project overview for one selected Git
+repository and answers "what is happening?" without requiring Codex Plugin, a
+global installation, or a remote service. The **Inspector** command remains a
+behaviorally compatible read-only UI over the same server and data adapter.
 
-It is intentionally not a SaaS console, a replacement for Codex, or a second
-Task workflow. It does not accept Task input, send Agent messages, control
-Sessions, or change Runtime state.
+Both surfaces are intentionally not a SaaS console, a replacement for Codex, or
+a second Task workflow. They do not accept Task input, send Agent messages,
+control Sessions, or change Runtime state. Browser actions that mutate Runtime
+state arrive in a later, guarded action-gateway milestone.
 
 ## Architecture
 
 ```text
-Browser
+Browser (Workspace UI)
    |
    | localhost-only HTTP GET
    v
-Inspector Server
+Workspace / Inspector Server  (one shared read-only server)
    |
-   | read-only journal/state adapter
+   | read-only journal/state adapter + repository identity facts
    v
 Existing Coordinate Agents Runtime State
+   ├── .git  (repository identity only: branch, HEAD, origin remote)
    ├── .agent-bus/events/runtime.jsonl
    ├── .agent-bus/tasks/*.json
    ├── .agent-bus/task-graphs/*.json
@@ -35,37 +39,45 @@ Existing Coordinate Agents Runtime State
    └── .agent-bus/sessions/*.json
 ```
 
-The Inspector does not create a database or duplicate the Task, Agent, Session,
+The Workspace does not create a database or duplicate the Task, Agent, Session,
 or Event models. Recent events and Task/Session timelines prefer the Runtime's
 real [Durable Event Journal](./event-journal.md). Repositories or individual
 records that predate the journal continue to work through an explicitly labeled
-**Derived / Legacy History** fallback; the Inspector never writes fabricated
+**Derived / Legacy History** fallback; neither surface ever writes fabricated
 events back to disk.
 
-## Start it
+## Start the Web Workspace (primary entry)
 
-From a Git repository initialized for Coordinate Agents:
+From an initialized Git repository:
 
 ```sh
-npx @hogancv/coordinate-agents inspector
+npx @hogancv/coordinate-agents web --port 3000
 ```
 
-The default port is `3000`. Choose another local port when needed:
+The CLI prints a URL such as `http://localhost:3000`. The server binds exactly
+one canonical regular Git repository root at startup and refuses unsafe or
+symlinked roots. Browser requests can never select another root. The primary
+listener binds to `127.0.0.1`; when IPv6 loopback is available, `::1` is served
+on the same port as a localhost compatibility alias. Both listeners are
+loopback-only and accept GET requests only. Stop it with `Ctrl-C`.
+
+## Start the Inspector (compatibility path)
+
+The documented read-only Inspector command keeps its behavior and GET contract:
 
 ```sh
 npx @hogancv/coordinate-agents inspector --port 3000
 ```
 
-The CLI prints a URL such as `http://localhost:3000`. The primary listener binds
-to `127.0.0.1`; when IPv6 loopback is available, `::1` is served on the same
-port as a localhost compatibility alias. Both listeners are loopback-only and
-accept GET requests only. Stop it with `Ctrl-C`.
-
 ## Pages and panels
+
+The Workspace overview opens with the **bound repository** identity (repository
+name, current branch, HEAD commit, latest commit subject, origin remote, and the
+canonical bound root path), followed by:
 
 - **Tasks** — current Task title, status, round, and update time for ordinary Tasks, plus distinguishable Task Graph parent entries with subtask count, max concurrency, and subtask state tallies.
 - **Agent flow** — the configured Planner → Implementer → Reviewer topology,
-  including each Agent’s current Agent Bus state.
+  including each Agent's current Agent Bus state.
 - **Task detail & Task Graph topology** — for ordinary Tasks: sequence-ordered recorded event timeline, role assignments, specification, implementation commit, evidence, review history, and last error. For Task Graphs: subtask nodes, dependency edges, frontier decisions, preflight waves, assigned Agent/Adapter/executable facts, worktree and commit facts, Scope Audit findings, recovery classifications, integration facts, and review decisions.
 - **Sessions** — Session state, timestamps, linked Tasks, bounded recent output,
   and recorded Session event history.
@@ -74,6 +86,7 @@ accept GET requests only. Stop it with `Ctrl-C`.
 
 ## Endpoints (Read-Only)
 
+- `GET /api/repository` — bounded identity facts for the bound Git repository (name, branch or detached HEAD, HEAD short SHA/subject/date, origin remote).
 - `GET /api/tasks` — mixed listing of ordinary Tasks and Task Graph parents.
 - `GET /api/tasks/:id` — task detail or Task Graph detail by ID.
 - `GET /api/graphs` — listing of persisted Task Graph parent summaries.
@@ -91,16 +104,17 @@ create, dispatch, review, resume, or stop Tasks.
 
 ## Data and security boundary
 
-The Inspector reads only the selected repository’s existing `.agent-bus` state.
-It validates the local Runtime path and uses bounded, redacted output for
-Session logs, evidence details, messages, and error text. It does not add
+The Workspace reads only the selected repository's existing `.agent-bus` state
+and derives a bounded repository identity from read-only Git helpers. It
+validates the local Runtime path and uses bounded, redacted output for Session
+logs, evidence details, messages, and error text. It does not add
 authentication because the server is deliberately localhost-only; do not expose
 the port through a proxy or network tunnel without adding an explicit security
 boundary first.
 
 `.agent-bus` remains local plaintext working data. Never put tokens, cookies,
 passwords, private keys, or unnecessary production data in Bus messages or
-evidence. The Inspector is an observability view, not a secret store.
+evidence. The Workspace is a control-plane view, not a secret store.
 
 ## Compatibility and limitations
 
@@ -110,3 +124,5 @@ evidence. The Inspector is an observability view, not a secret store.
   timestamps.
 - There is no authentication, remote access, mutation, chat, Task input form,
   multi-tenant mode, cloud sync, or benchmark/evaluation dashboard yet.
+- `coordinate-agents web` requires an initialized Git repository root; the
+  compatibility `inspector` command keeps its existing validation behavior.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -29,7 +29,7 @@ capabilities. Discovery does not launch an adapter; configured external Agents
 contribute only their declared detection facts, while exact Agent/Adapter/
 executable identity and project > user > adapter-default precedence remain
 separate through Task and persistent-Session execution.
-Local Inspector Web UI: https://hogancv.github.io/coordinate-agents/inspector.html
+Web Workspace and Local Inspector (primary read-only local browser entry, plus the compatible Inspector UI): https://hogancv.github.io/coordinate-agents/inspector.html
 Durable Runtime Event Journal: https://hogancv.github.io/coordinate-agents/event-journal.html
 MCP tools: https://hogancv.github.io/coordinate-agents/mcp.html
 Task Graph v1 contract: https://hogancv.github.io/coordinate-agents/task-graph-v1.html

--- a/inspector/server/inspector-data.mjs
+++ b/inspector/server/inspector-data.mjs
@@ -4,6 +4,7 @@ import {
   readdirSync,
   realpathSync,
 } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import { basename, join, resolve } from 'node:path';
 import {
   assertSafePath,
@@ -403,6 +404,47 @@ function recordedEvents(root, options = {}) {
   return readRuntimeEvents(root, options).map(inspectorJournalEvent);
 }
 
+// Repository identity facts are derived with read-only Git helpers only. Each
+// invocation stays bounded (short timeout, capped buffers) and spawns no Agent,
+// Session, worktree, or Bus side effect; failures degrade to partial facts so
+// the Workspace overview remains usable outside a fully committed repository.
+function gitFact(root, args) {
+  const result = spawnSync('git', ['-C', root, ...args], {
+    encoding: 'utf8',
+    windowsHide: true,
+    timeout: 5_000,
+    maxBuffer: 512 * 1024,
+  });
+  if (result.error || result.status !== 0) return null;
+  return result.stdout.trim();
+}
+
+function repositoryFacts(root) {
+  const headLine = gitFact(root, ['log', '-1', '--format=%h%x1f%s%x1f%cI']);
+  const head = headLine
+    ? (() => {
+      const [shortSha, subject, committedAtRaw] = headLine.split('\x1f');
+      const committedAt = typeof committedAtRaw === 'string' && !Number.isNaN(Date.parse(committedAtRaw))
+        ? committedAtRaw
+        : null;
+      return {
+        short: bounded(shortSha, 64) || null,
+        subject: bounded(subject, 2 * 1024) || null,
+        committedAt,
+      };
+    })()
+    : null;
+  const branch = bounded(gitFact(root, ['symbolic-ref', '--quiet', '--short', 'HEAD']), 256) || null;
+  return {
+    root,
+    name: bounded(basename(root), 256),
+    branch,
+    detached: Boolean(head && !branch),
+    head,
+    remoteUrl: bounded(gitFact(root, ['remote', 'get-url', 'origin']), 2 * 1024) || null,
+  };
+}
+
 function readSessions(root, tasks = readTaskRecords(root)) {
   const bus = busFor(root);
   if (!bus || !existsSync(join(bus, 'sessions'))) return Promise.resolve([]);
@@ -651,6 +693,21 @@ export function createInspectorData(root) {
   const repository = canonicalRoot(root);
   return {
     root: repository,
+    readRepository() {
+      try {
+        return repositoryFacts(repository);
+      } catch (error) {
+        return {
+          root: repository,
+          name: bounded(basename(repository), 256),
+          branch: null,
+          detached: false,
+          head: null,
+          remoteUrl: null,
+          error: bounded(error.message || String(error), 2 * 1024),
+        };
+      }
+    },
     readTasks() {
       return [
         ...readTaskRecords(repository).map(taskSummary),

--- a/inspector/server/server.mjs
+++ b/inspector/server/server.mjs
@@ -2,17 +2,23 @@
 
 import { createServer } from 'node:http';
 import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createInspectorData } from './inspector-data.mjs';
 import { redactOutput } from '../../skills/coordinate-agents/adapters/executable.mjs';
 
-const webRoot = resolve(fileURLToPath(new URL('../web', import.meta.url)));
+const inspectorWebRoot = resolve(fileURLToPath(new URL('../web', import.meta.url)));
+const workspaceWebRoot = resolve(fileURLToPath(new URL('../web-workspace', import.meta.url)));
 const STATIC_FILES = new Map([
   ['/index.html', { file: 'index.html', type: 'text/html; charset=utf-8' }],
   ['/app.js', { file: 'app.js', type: 'text/javascript; charset=utf-8' }],
   ['/styles.css', { file: 'styles.css', type: 'text/css; charset=utf-8' }],
 ]);
+
+function webAssetsFor(ui) {
+  return ui === 'workspace' ? workspaceWebRoot : inspectorWebRoot;
+}
 
 function json(response, status, payload) {
   const body = `${JSON.stringify(payload)}\n`;
@@ -24,10 +30,10 @@ function json(response, status, payload) {
   response.end(body);
 }
 
-function asset(response, pathname) {
+function asset(response, pathname, assetsRoot) {
   const entry = STATIC_FILES.get(pathname) || STATIC_FILES.get('/index.html');
   try {
-    const body = readFileSync(resolve(webRoot, entry.file));
+    const body = readFileSync(resolve(assetsRoot, entry.file));
     response.writeHead(200, {
       'Cache-Control': 'no-cache',
       'Content-Type': entry.type,
@@ -35,7 +41,7 @@ function asset(response, pathname) {
     });
     response.end(body);
   } catch {
-    json(response, 500, { error: 'Inspector web assets are unavailable.' });
+    json(response, 500, { error: 'Workspace web assets are unavailable.' });
   }
 }
 
@@ -111,7 +117,8 @@ function apiError(response, error) {
   });
 }
 
-export function createInspectorServer({ root, data = createInspectorData(root) } = {}) {
+export function createInspectorServer({ root, data = createInspectorData(root), ui = 'inspector' } = {}) {
+  const assetsRoot = webAssetsFor(ui);
   return createServer(async (request, response) => {
     if (request.method !== 'GET') {
       response.setHeader('Allow', 'GET');
@@ -123,7 +130,7 @@ export function createInspectorServer({ root, data = createInspectorData(root) }
     const pathname = url.pathname;
     if (!pathname.startsWith('/api/')) {
       if (pathname === '/' || STATIC_FILES.has(pathname)) {
-        asset(response, pathname);
+        asset(response, pathname, assetsRoot);
         return;
       }
       json(response, 404, { error: 'Inspector page not found.' });
@@ -131,6 +138,10 @@ export function createInspectorServer({ root, data = createInspectorData(root) }
     }
 
     try {
+      if (pathname === '/api/repository' && typeof data.readRepository === 'function') {
+        json(response, 200, data.readRepository());
+        return;
+      }
       if (pathname === '/api/tasks') {
         json(response, 200, data.readTasks());
         return;
@@ -172,13 +183,13 @@ export function createInspectorServer({ root, data = createInspectorData(root) }
   });
 }
 
-export function startInspector({ root, host = '127.0.0.1', port = 3000 } = {}) {
+export function startInspector({ root, host = '127.0.0.1', port = 3000, ui = 'inspector' } = {}) {
   if (host !== '127.0.0.1') throw new Error('Inspector must listen on localhost only.');
   if (!Number.isInteger(port) || port < 0 || port > 65_535) {
     throw new Error(`Inspector port must be an integer between 0 and 65535: ${port}`);
   }
   const data = createInspectorData(root);
-  const server = createInspectorServer({ root: data.root, data });
+  const server = createInspectorServer({ root: data.root, data, ui });
   return new Promise((resolvePromise, reject) => {
     let ipv6Loopback = null;
     const onError = error => {
@@ -196,7 +207,7 @@ export function startInspector({ root, host = '127.0.0.1', port = 3000 } = {}) {
       // optional IPv6 loopback alias on the same port so the localhost URL is
       // reachable without exposing the Inspector beyond loopback interfaces.
       if (host === '127.0.0.1') {
-        const candidate = createInspectorServer({ root: data.root, data });
+        const candidate = createInspectorServer({ root: data.root, data, ui });
         try {
           await new Promise((resolveAlias, rejectAlias) => {
             const onAliasError = error => {
@@ -262,6 +273,30 @@ export function startInspector({ root, host = '127.0.0.1', port = 3000 } = {}) {
   });
 }
 
+// The Web Workspace is the primary local product entry (#45). It reuses the
+// same read-only server, data adapter, loopback guards, and bounded content as
+// the Inspector compatibility path and only selects the Workspace web assets.
+// Unlike the compatibility Inspector, the Workspace binds exactly one validated
+// Git repository root: unsafe, symlinked, or non-Git roots fail closed before a
+// listener is created.
+export function startWorkspace(options = {}) {
+  const requested = resolve(options.root || process.cwd());
+  const result = spawnSync('git', ['-C', requested, 'rev-parse', '--show-toplevel'], {
+    encoding: 'utf8',
+    windowsHide: true,
+    timeout: 5_000,
+    maxBuffer: 512 * 1024,
+  });
+  if (result.error || result.status !== 0) {
+    throw new Error(`Workspace must start inside an initialized Git repository: ${requested}`);
+  }
+  return startInspector({
+    ...options,
+    root: resolve(result.stdout.trim()),
+    ui: 'workspace',
+  });
+}
+
 function isInvokedDirectly() {
   if (!process.argv[1]) return false;
   return resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
@@ -271,10 +306,14 @@ if (isInvokedDirectly()) {
   const args = process.argv.slice(2);
   const rootIndex = args.indexOf('--root');
   const portIndex = args.indexOf('--port');
+  const uiIndex = args.indexOf('--ui');
   const root = rootIndex >= 0 ? args[rootIndex + 1] : process.cwd();
   const port = portIndex >= 0 ? Number(args[portIndex + 1]) : 3000;
+  const ui = uiIndex >= 0 ? args[uiIndex + 1] : 'inspector';
   try {
-    const started = await startInspector({ root, port });
+    const started = ui === 'workspace'
+      ? await startWorkspace({ root, port })
+      : await startInspector({ root, port });
     console.log(`Inspector running:\n\n${started.url}`);
   } catch (error) {
     console.error(error.message || String(error));

--- a/inspector/web-workspace/app.js
+++ b/inspector/web-workspace/app.js
@@ -1,0 +1,363 @@
+const STATUS_ORDER = [
+  'CREATED',
+  'PLANNING',
+  'SPEC_READY',
+  'IMPLEMENTING',
+  'WAITING_IMPLEMENTER',
+  'REVIEWING',
+  'CHANGES_REQUESTED',
+  'APPROVED',
+  'ERROR',
+  'STOPPED',
+];
+
+const state = {
+  tasks: [],
+  agents: [],
+  sessions: [],
+  events: [],
+  repository: null,
+  selectedTask: null,
+};
+
+const elements = Object.fromEntries([
+  'tasks', 'task-count', 'agent-flow', 'task-detail', 'detail-title', 'detail-summary',
+  'timeline', 'detail-agent-flow', 'evidence', 'spec', 'sessions', 'session-count',
+  'events', 'refresh-button', 'close-detail', 'graph-detail', 'graph-topology',
+  'graph-frontier', 'graph-conflicts', 'graph-integration', 'repository',
+  'repo-name', 'repo-branch', 'repo-facts',
+].map(id => [id, document.getElementById(id)]));
+
+function escapeHtml(value) {
+  return `${value ?? ''}`
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;');
+}
+
+function formatDate(value) {
+  if (!value) return '—';
+  const date = new Date(value);
+  return Number.isNaN(date.valueOf()) ? escapeHtml(value) : date.toLocaleString();
+}
+
+function statusClass(status) {
+  return `${status || 'UNKNOWN'}`.toLowerCase().replaceAll('_', '-');
+}
+
+function statusLabel(status) {
+  return `${status || 'UNKNOWN'}`.replaceAll('_', ' ');
+}
+
+function shortId(value) {
+  const text = `${value || ''}`;
+  return text.length > 18 ? `${text.slice(0, 12)}…${text.slice(-4)}` : text;
+}
+
+async function fetchJson(path) {
+  const response = await fetch(path, { cache: 'no-store' });
+  if (!response.ok) throw new Error(`Inspector request failed (${response.status}).`);
+  return response.json();
+}
+
+function renderTasks() {
+  elements['task-count'].textContent = state.tasks.length;
+  if (state.tasks.length === 0) {
+    elements.tasks.innerHTML = '<div class="empty-state">No Tasks found in this project.</div>';
+    return;
+  }
+  elements.tasks.innerHTML = state.tasks.map(task => `
+    <button class="task-card ${task.graph ? 'graph-card' : ''} ${state.selectedTask === task.id ? 'selected' : ''}" data-task-id="${escapeHtml(task.id)}" type="button">
+      <span class="task-card-top"><span class="task-id">${escapeHtml(shortId(task.id))}</span><span class="round">${task.graph ? 'GRAPH' : `R${escapeHtml(task.round)}`}</span></span>
+      <strong>${escapeHtml(task.title)}</strong>
+      <span class="status-pill ${statusClass(task.status)}">${escapeHtml(statusLabel(task.status))}</span>
+      ${task.graph ? `<span class="graph-card-meta">${escapeHtml(task.subtaskCount)} subtasks · concurrency ${escapeHtml(task.maxConcurrency)}</span>` : ''}
+      <span class="task-updated">Updated ${formatDate(task.updatedAt)}</span>
+    </button>
+  `).join('');
+  elements.tasks.querySelectorAll('[data-task-id]').forEach(button => {
+    button.addEventListener('click', () => selectTask(button.dataset.taskId));
+  });
+}
+
+function renderRepository() {
+  const repository = state.repository;
+  if (!repository) {
+    elements.repository.hidden = true;
+    return;
+  }
+  elements.repository.hidden = false;
+  elements['repo-name'].textContent = repository.name || repository.root || 'Repository';
+  elements['repo-branch'].textContent = repository.branch || (repository.detached ? 'detached' : '—');
+  const facts = [];
+  if (repository.head) {
+    facts.push(`<div class="repo-fact"><span>HEAD</span><code>${escapeHtml(repository.head.short || '—')}</code></div>`);
+    facts.push(`<div class="repo-fact repo-fact-wide"><span>${repository.branch ? `Latest commit on ${escapeHtml(repository.branch)}` : 'Latest commit'}</span><strong>${escapeHtml(repository.head.subject || '—')}</strong></div>`);
+    if (repository.head.committedAt) {
+      facts.push(`<div class="repo-fact"><span>Committed</span><time>${formatDate(repository.head.committedAt)}</time></div>`);
+    }
+  } else {
+    facts.push('<div class="repo-fact"><span>HEAD</span><code>no commits yet</code></div>');
+  }
+  facts.push(`<div class="repo-fact"><span>Remote</span><code>${escapeHtml(repository.remoteUrl || 'no origin remote')}</code></div>`);
+  facts.push(`<div class="repo-fact repo-fact-wide"><span>Bound root</span><code>${escapeHtml(repository.root || '—')}</code></div>`);
+  if (repository.error) facts.push(`<div class="repo-fact repo-fact-wide"><span>Repository facts</span><code>${escapeHtml(repository.error)}</code></div>`);
+  elements['repo-facts'].innerHTML = facts.join('');
+}
+
+function agentFor(id) {
+  return state.agents.find(agent => agent.id === id) || { id, status: 'UNKNOWN', adapter: '—', roles: [] };
+}
+
+function renderAgentFlow() {
+  const roles = ['planner', 'implementer', 'reviewer'];
+  elements['agent-flow'].innerHTML = roles.map((role, index) => {
+    const configured = state.agents.find(agent => agent.roles?.includes(role));
+    const agent = configured || { id: 'unassigned', status: 'UNKNOWN', adapter: '—', roles: [] };
+    return `
+      <div class="flow-node">
+        <span class="flow-role">${escapeHtml(role)}</span>
+        <strong>${escapeHtml(agent.id)}</strong>
+        <span class="status-line"><span class="state-dot ${statusClass(agent.status)}"></span>${escapeHtml(statusLabel(agent.status))}</span>
+        <span class="adapter">${escapeHtml(agent.adapter)}</span>
+      </div>
+      ${index < roles.length - 1 ? '<span class="flow-arrow" aria-hidden="true">→</span>' : ''}
+    `;
+  }).join('');
+}
+
+function renderSessions() {
+  elements['session-count'].textContent = state.sessions.length;
+  if (state.sessions.length === 0) {
+    elements.sessions.innerHTML = '<div class="empty-state">No Execution Sessions recorded.</div>';
+    return;
+  }
+  elements.sessions.innerHTML = state.sessions.map(session => `
+    <article class="session-card">
+      <div class="session-header">
+        <div>
+          <span class="eyebrow">${escapeHtml(session.agent || 'agent')}</span>
+          <h3>${escapeHtml(shortId(session.sessionId))}</h3>
+        </div>
+        <span class="status-pill ${statusClass(session.status)}">${escapeHtml(statusLabel(session.status))}</span>
+      </div>
+      <div class="session-meta"><span>Created ${formatDate(session.createdAt)}</span><span>Last activity ${formatDate(session.lastActivity)}</span></div>
+      <pre class="session-output">${escapeHtml(session.recentOutput || 'No recent output available.')}</pre>
+      ${session.taskIds?.length ? `<div class="session-tasks">Tasks: ${session.taskIds.map(escapeHtml).join(', ')}</div>` : ''}
+      <div class="session-history">
+        <span class="history-label">${session.historySource === 'recorded' ? 'Recorded Events' : 'Derived / Legacy History'}</span>
+        ${(session.events || []).slice(-8).map(event => `<div><code>${event.sequence ? `#${escapeHtml(event.sequence)}` : '—'}</code><strong>${escapeHtml(event.event)}</strong><time>${formatDate(event.timestamp)}</time></div>`).join('')}
+      </div>
+    </article>
+  `).join('');
+}
+
+function renderEvents() {
+  if (state.events.length === 0) {
+    elements.events.innerHTML = '<div class="empty-state">No Runtime events found.</div>';
+    return;
+  }
+  elements.events.innerHTML = state.events.map(event => `
+    <article class="event-row">
+      <time>${event.sequence ? `#${escapeHtml(event.sequence)} · ` : ''}${formatDate(event.timestamp)}</time>
+      <span class="event-marker ${statusClass(event.event)}"></span>
+      <div class="event-body">
+        <div class="event-title"><strong>${escapeHtml(event.event)}</strong><span>${escapeHtml([event.agent || event.from || 'runtime', event.sessionId ? shortId(event.sessionId) : null].filter(Boolean).join(' · '))}</span></div>
+        <div class="event-details">${escapeHtml(event.details || '—')}</div>
+        ${event.taskId ? `<button class="event-task" data-task-id="${escapeHtml(event.taskId)}" type="button">${escapeHtml(event.taskId)}</button>` : ''}
+        <span class="history-label">${event.recorded ? 'Recorded Event' : 'Derived / Legacy History'}</span>
+      </div>
+    </article>
+  `).join('');
+  elements.events.querySelectorAll('[data-task-id]').forEach(button => {
+    button.addEventListener('click', () => selectTask(button.dataset.taskId));
+  });
+}
+
+function renderTimeline(timeline = []) {
+  if (timeline.length === 0) {
+    elements.timeline.innerHTML = '<div class="empty-state">No Task events recorded yet.</div>';
+    return;
+  }
+  elements.timeline.innerHTML = timeline.map((event, index) => `
+    <div class="timeline-item ${event.status ? 'has-status' : ''}">
+      <div class="timeline-rail"><span class="timeline-dot ${event.status ? statusClass(event.status) : ''}"></span>${index < timeline.length - 1 ? '<span class="timeline-line"></span>' : ''}</div>
+      <div class="timeline-content">
+        <div class="timeline-title"><strong>${event.sequence ? `#${escapeHtml(event.sequence)} ` : ''}${escapeHtml(event.status ? statusLabel(event.status) : event.event)}</strong><time>${formatDate(event.timestamp)}</time></div>
+        <div class="timeline-meta">${escapeHtml(event.agent || 'runtime')} · ${event.recorded ? 'Recorded Event' : 'Derived / Legacy History'}${event.sessionId ? ` · ${escapeHtml(shortId(event.sessionId))}` : ''}</div>
+        ${event.details ? `<p>${escapeHtml(event.details)}</p>` : ''}
+      </div>
+    </div>
+  `).join('');
+}
+
+function compactJson(value) {
+  return escapeHtml(JSON.stringify(value ?? null, null, 2));
+}
+
+function factBlock(label, value) {
+  if (value === null || value === undefined || value === '' || (Array.isArray(value) && value.length === 0)) return '';
+  const rendered = typeof value === 'object' ? `<pre>${compactJson(value)}</pre>` : `<code>${escapeHtml(value)}</code>`;
+  return `<div class="graph-fact"><span>${escapeHtml(label)}</span>${rendered}</div>`;
+}
+
+function renderGraphDetail(task) {
+  const graph = Boolean(task?.graph);
+  elements['graph-detail'].hidden = !graph;
+  if (!graph) {
+    for (const id of ['graph-topology', 'graph-frontier', 'graph-conflicts', 'graph-integration']) elements[id].innerHTML = '';
+    return;
+  }
+  const dependencies = task.dependencies || [];
+  elements['graph-topology'].innerHTML = (task.subtasks || []).map(subtask => `
+    <article class="graph-node">
+      <div class="graph-node-heading">
+        <div><span class="eyebrow">${escapeHtml(subtask.id)}</span><strong>${escapeHtml(subtask.title || subtask.id)}</strong></div>
+        <span class="status-pill ${statusClass(subtask.state)}">${escapeHtml(statusLabel(subtask.state))}</span>
+      </div>
+      <div class="graph-dependencies">Depends on: ${subtask.dependsOn?.length ? subtask.dependsOn.map(item => `<code>${escapeHtml(item)}</code>`).join(' ') : '<span>none</span>'}</div>
+      <div class="graph-node-meta">
+        <span>Agent <strong>${escapeHtml(subtask.implementer)}</strong></span>
+        <span>Adapter <strong>${escapeHtml(subtask.agent?.adapter || '—')}</strong></span>
+        <span>Session <code>${escapeHtml(shortId(subtask.sessionId) || '—')}</code></span>
+      </div>
+      ${factBlock('Executable', subtask.executable)}
+      ${factBlock('Worktree / branch / commit', { ...subtask.worktree, implementationCommit: subtask.implementationCommit })}
+      ${factBlock('Evidence', subtask.evidence)}
+      ${factBlock('Scope audit', subtask.scopeAudit)}
+      ${factBlock('Recovery', subtask.recovery)}
+      ${factBlock('Last error', subtask.lastError)}
+    </article>
+  `).join('') || '<div class="empty-state">No persisted subtasks.</div>';
+  const edgeList = dependencies.length
+    ? dependencies.map(edge => `<code>${escapeHtml(edge.from)} → ${escapeHtml(edge.to)}</code>`).join(' ')
+    : '<span>none</span>';
+  elements['graph-topology'].insertAdjacentHTML('afterbegin', `<div class="graph-edge-list"><strong>Dependency edges</strong>${edgeList}</div>`);
+  elements['graph-frontier'].innerHTML = [
+    factBlock('Max concurrency', task.maxConcurrency),
+    factBlock('Current frontier', task.frontier),
+    factBlock('Selected preflight wave', task.wave),
+  ].join('');
+  elements['graph-conflicts'].innerHTML = [
+    factBlock('Write-intent conflicts', task.conflicts),
+    factBlock('Intent coverage', task.intentCoverage),
+    factBlock('Recovery classifications', task.recovery),
+  ].join('') || '<div class="empty-state">No conflict or scope facts recorded.</div>';
+  elements['graph-integration'].innerHTML = [
+    factBlock('Integration', task.integration),
+    factBlock('Integration facts', task.integrationFacts),
+    factBlock('Review', task.review),
+    factBlock('Review history', task.reviewHistory),
+  ].join('') || '<div class="empty-state">Integration and review have not been recorded.</div>';
+}
+
+function renderTaskDetail(task) {
+  if (!task) {
+    elements['task-detail'].hidden = true;
+    return;
+  }
+  elements['task-detail'].hidden = false;
+  elements['detail-title'].textContent = task.title;
+  elements['detail-summary'].innerHTML = `
+    <span class="status-pill ${statusClass(task.status)}">${escapeHtml(statusLabel(task.status))}</span>
+    <span>${task.graph ? 'Task Graph' : `Round ${escapeHtml(task.round)}`}</span>
+    <span>${escapeHtml(task.id)}</span>
+    <span>Updated ${formatDate(task.updatedAt)}</span>
+  `;
+  renderGraphDetail(task);
+  renderTimeline(task.timeline);
+  elements['detail-agent-flow'].innerHTML = (task.agentFlow || []).map((item, index) => {
+    const agent = agentFor(item.agent);
+    return `
+      <div class="detail-agent-row">
+        <span class="flow-role">${escapeHtml(item.role)}</span>
+        <strong>${escapeHtml(item.agent)}</strong>
+        <span class="status-line"><span class="state-dot ${statusClass(agent.status)}"></span>${escapeHtml(statusLabel(agent.status))}</span>
+      </div>
+      ${index < (task.agentFlow || []).length - 1 ? '<div class="detail-agent-arrow">↓</div>' : ''}
+    `;
+  }).join('');
+  const evidence = task.evidence || [];
+  const reviews = task.reviewHistory || [];
+  elements.evidence.innerHTML = `
+    <div class="evidence-row"><span>${task.graph ? 'Base commit' : 'Commit'}</span><code>${escapeHtml(task.graph ? (task.baseCommit || '—') : (task.implementationCommit || '—'))}</code></div>
+    <div class="evidence-row"><span>Evidence records</span><strong>${evidence.length}</strong></div>
+    ${evidence.map(item => `<div class="evidence-block"><strong>${escapeHtml(item.type || 'Evidence')}</strong><p>${escapeHtml(item.details || item.relatedCommit || '—')}</p></div>`).join('')}
+    ${reviews.map(item => `<div class="review-block"><span class="status-pill ${statusClass(item.decision)}">${escapeHtml(statusLabel(item.decision))}</span><p>${escapeHtml(item.feedback || 'No feedback')}</p></div>`).join('')}
+    ${task.lastError ? `<div class="error-block"><strong>${escapeHtml(task.lastError.code || 'ERROR')}</strong><p>${escapeHtml(task.lastError.message || task.lastError.details || '')}</p></div>` : ''}
+  `;
+  elements.spec.textContent = task.spec || 'No specification recorded.';
+}
+
+async function selectTask(id) {
+  try {
+    state.selectedTask = id;
+    window.location.hash = encodeURIComponent(id);
+    renderTasks();
+    const task = await fetchJson(`/api/tasks/${encodeURIComponent(id)}`);
+    renderTaskDetail(task);
+    elements['task-detail'].scrollIntoView({ behavior: 'smooth', block: 'start' });
+  } catch (error) {
+    elements['detail-title'].textContent = error.message;
+  }
+}
+
+function closeDetail() {
+  state.selectedTask = null;
+  history.replaceState(null, '', window.location.pathname);
+  renderTasks();
+  renderTaskDetail(null);
+}
+
+async function refresh() {
+  try {
+    const [tasks, agents, sessions, events] = await Promise.all([
+      fetchJson('/api/tasks'),
+      fetchJson('/api/agents'),
+      fetchJson('/api/sessions'),
+      fetchJson('/api/events?limit=80'),
+    ]);
+    state.tasks = tasks;
+    state.agents = agents;
+    state.sessions = sessions;
+    state.events = events;
+    renderTasks();
+    renderAgentFlow();
+    renderSessions();
+    renderEvents();
+    if (state.selectedTask) {
+      try { renderTaskDetail(await fetchJson(`/api/tasks/${encodeURIComponent(state.selectedTask)}`)); } catch { /* The list remains useful if a task is removed during refresh. */ }
+    }
+  } catch (error) {
+    elements.tasks.innerHTML = `<div class="empty-state error-state">${escapeHtml(error.message)}</div>`;
+  }
+  try {
+    state.repository = await fetchJson('/api/repository');
+  } catch {
+    state.repository = null;
+  }
+  renderRepository();
+}
+
+elements['refresh-button'].addEventListener('click', refresh);
+elements['close-detail'].addEventListener('click', closeDetail);
+const initialTask = decodeURIComponent(window.location.hash.slice(1));
+if (initialTask) state.selectedTask = initialTask;
+refresh();
+setInterval(refresh, 5_000);
+
+let refreshTimer = null;
+function scheduleRefresh() {
+  if (refreshTimer) return;
+  refreshTimer = setTimeout(() => {
+    refreshTimer = null;
+    refresh();
+  }, 150);
+}
+
+if ('EventSource' in window) {
+  const stream = new EventSource('/api/events/stream');
+  stream.addEventListener('runtime-event', scheduleRefresh);
+}

--- a/inspector/web-workspace/index.html
+++ b/inspector/web-workspace/index.html
@@ -1,0 +1,142 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="color-scheme" content="dark">
+    <meta name="description" content="Coordinate Agents Web Workspace: a localhost-only control plane for your local AI coding team.">
+    <title>Coordinate Agents Workspace</title>
+    <link rel="stylesheet" href="/styles.css">
+  </head>
+  <body>
+    <header class="topbar">
+      <div>
+        <p class="eyebrow">LOCAL WEB WORKSPACE</p>
+        <h1>Coordinate Agents Workspace</h1>
+        <p class="subtitle">Control plane for your local AI coding team</p>
+      </div>
+      <div class="topbar-meta">
+        <span class="live-dot"></span>
+        <span>localhost · read-only</span>
+        <button id="refresh-button" class="button" type="button">Refresh</button>
+      </div>
+    </header>
+
+    <main class="shell">
+      <section id="repository" class="panel repository-panel" hidden>
+        <div class="section-heading">
+          <div>
+            <p class="eyebrow">BOUND REPOSITORY</p>
+            <h2 id="repo-name">Loading repository…</h2>
+          </div>
+          <span id="repo-branch" class="count-badge branch-badge" title="Current branch">—</span>
+        </div>
+        <div id="repo-facts" class="repo-facts" aria-live="polite"></div>
+      </section>
+
+      <section class="hero-grid">
+        <div class="hero-card">
+          <div class="section-heading">
+            <div>
+              <p class="eyebrow">COORDINATION OVERVIEW</p>
+              <h2>Tasks</h2>
+            </div>
+            <span id="task-count" class="count-badge">0</span>
+          </div>
+          <div id="tasks" class="task-grid" aria-live="polite"></div>
+        </div>
+        <div class="hero-card topology-card">
+          <div class="section-heading">
+            <div>
+              <p class="eyebrow">ROLE TOPOLOGY</p>
+              <h2>Agent flow</h2>
+            </div>
+            <span class="muted-label">Planner → Implementer → Reviewer</span>
+          </div>
+          <div id="agent-flow" class="agent-flow" aria-live="polite"></div>
+        </div>
+      </section>
+
+      <section id="task-detail" class="panel task-detail-panel" hidden>
+        <div class="section-heading">
+          <div>
+            <p class="eyebrow">TASK DETAIL</p>
+            <h2 id="detail-title">Select a task</h2>
+          </div>
+          <button id="close-detail" class="button ghost" type="button">Close</button>
+        </div>
+        <div id="detail-summary" class="detail-summary"></div>
+        <section id="graph-detail" class="graph-detail" hidden>
+          <div class="graph-overview-grid">
+            <div>
+              <h3>Task Graph topology</h3>
+              <div id="graph-topology" class="graph-topology"></div>
+            </div>
+            <div>
+              <h3>Frontier & preflight wave</h3>
+              <div id="graph-frontier" class="graph-facts"></div>
+            </div>
+          </div>
+          <div class="graph-overview-grid">
+            <div>
+              <h3>Conflicts & scope audit</h3>
+              <div id="graph-conflicts" class="graph-facts"></div>
+            </div>
+            <div>
+              <h3>Integration & review</h3>
+              <div id="graph-integration" class="graph-facts"></div>
+            </div>
+          </div>
+        </section>
+        <div class="detail-grid">
+          <div>
+            <h3>Event timeline</h3>
+            <div id="timeline" class="timeline"></div>
+          </div>
+          <div>
+            <h3>Agent flow</h3>
+            <div id="detail-agent-flow" class="detail-agent-flow"></div>
+          </div>
+        </div>
+        <div class="detail-grid lower-grid">
+          <div>
+            <h3>Evidence & review</h3>
+            <div id="evidence" class="evidence-list"></div>
+          </div>
+          <div>
+            <h3>Specification</h3>
+            <pre id="spec" class="code-block"></pre>
+          </div>
+        </div>
+      </section>
+
+      <section class="panel sessions-panel">
+        <div class="section-heading">
+          <div>
+            <p class="eyebrow">EXECUTION RUNTIME</p>
+            <h2>Sessions</h2>
+          </div>
+          <span id="session-count" class="count-badge">0</span>
+        </div>
+        <div id="sessions" class="session-list" aria-live="polite"></div>
+      </section>
+
+      <section class="panel events-panel">
+        <div class="section-heading">
+          <div>
+            <p class="eyebrow">RUNTIME JOURNAL</p>
+            <h2>Recent events</h2>
+          </div>
+          <span class="muted-label">recorded events · legacy fallback</span>
+        </div>
+        <div id="events" class="event-list" aria-live="polite"></div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <span>Coordinate Agents Web Workspace</span>
+      <span>Read-only overview · Tasks · Task Graphs · Agents · Sessions · Runtime events</span>
+    </footer>
+    <script type="module" src="/app.js"></script>
+  </body>
+</html>

--- a/inspector/web-workspace/styles.css
+++ b/inspector/web-workspace/styles.css
@@ -1,0 +1,203 @@
+:root {
+  color-scheme: dark;
+  --bg: #0b1020;
+  --panel: rgba(20, 28, 50, 0.82);
+  --panel-strong: #17213b;
+  --line: rgba(160, 180, 230, 0.16);
+  --text: #eef3ff;
+  --muted: #9aa9c8;
+  --accent: #8ca9ff;
+  --accent-strong: #617cff;
+  --green: #57d99a;
+  --yellow: #f4c96b;
+  --red: #ff7f8f;
+  --purple: #c39bff;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  min-width: 320px;
+  margin: 0;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 80% -20%, rgba(97, 124, 255, 0.26), transparent 34rem),
+    radial-gradient(circle at -10% 10%, rgba(195, 155, 255, 0.12), transparent 28rem),
+    var(--bg);
+}
+
+button { font: inherit; }
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 2.5rem clamp(1.25rem, 5vw, 5rem) 2rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.eyebrow {
+  margin: 0 0 .55rem;
+  color: var(--accent);
+  font-size: .68rem;
+  font-weight: 800;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+}
+
+h1, h2, h3, p { margin-top: 0; }
+h1 { margin-bottom: .4rem; font-size: clamp(1.65rem, 3vw, 2.5rem); letter-spacing: -.04em; }
+h2 { margin-bottom: 0; font-size: 1.15rem; letter-spacing: -.02em; }
+h3 { margin-bottom: 1rem; color: var(--muted); font-size: .74rem; letter-spacing: .1em; text-transform: uppercase; }
+.subtitle { margin: 0; color: var(--muted); }
+
+.topbar-meta, .section-heading, .session-header, .event-title, .timeline-title, .detail-summary, .session-meta {
+  display: flex;
+  align-items: center;
+}
+
+.topbar-meta { gap: 1rem; color: var(--muted); font-size: .8rem; }
+.live-dot, .state-dot { display: inline-block; width: .55rem; height: .55rem; border-radius: 50%; background: var(--green); box-shadow: 0 0 0 .2rem rgba(87, 217, 154, .12); }
+.button { padding: .55rem .85rem; border: 1px solid rgba(140, 169, 255, .42); border-radius: .55rem; color: var(--text); background: rgba(97, 124, 255, .16); cursor: pointer; }
+.button:hover { border-color: var(--accent); background: rgba(97, 124, 255, .28); }
+.button.ghost { color: var(--muted); background: transparent; }
+
+.shell { width: min(1400px, calc(100% - 2rem)); margin: 0 auto; padding: 2rem 0 4rem; }
+.hero-grid { display: grid; grid-template-columns: minmax(0, 1.35fr) minmax(320px, .9fr); gap: 1rem; }
+.hero-card, .panel { border: 1px solid var(--line); border-radius: 1rem; background: var(--panel); box-shadow: 0 1rem 4rem rgba(0, 0, 0, .15); backdrop-filter: blur(18px); }
+.hero-card { min-height: 22rem; padding: 1.25rem; }
+.panel { margin-top: 1rem; padding: 1.25rem; }
+.section-heading { justify-content: space-between; gap: 1rem; margin-bottom: 1rem; }
+.count-badge { display: grid; min-width: 1.75rem; height: 1.75rem; place-items: center; border-radius: .55rem; color: var(--accent); background: rgba(140, 169, 255, .14); font-size: .8rem; font-weight: 700; }
+.muted-label { color: var(--muted); font-size: .75rem; }
+
+.task-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); gap: .75rem; }
+.task-card { display: flex; min-height: 9.5rem; flex-direction: column; align-items: flex-start; gap: .55rem; padding: 1rem; border: 1px solid var(--line); border-radius: .75rem; color: var(--text); background: rgba(255, 255, 255, .025); text-align: left; cursor: pointer; transition: border-color .18s, transform .18s, background .18s; }
+.task-card:hover, .task-card.selected { border-color: rgba(140, 169, 255, .7); background: rgba(97, 124, 255, .13); transform: translateY(-2px); }
+.task-card.graph-card { border-left: 3px solid var(--accent); }
+.graph-card-meta { color: var(--accent); font-size: .7rem; font-weight: 600; }
+.task-card-top { display: flex; width: 100%; justify-content: space-between; color: var(--muted); font-size: .7rem; }
+.task-card strong { min-height: 2.5rem; font-size: .98rem; line-height: 1.3; }
+.task-id, .round, .task-updated, .adapter, .session-meta, .session-tasks, .timeline-meta { color: var(--muted); font-size: .72rem; }
+.task-updated { margin-top: auto; }
+.status-pill { display: inline-flex; width: fit-content; padding: .22rem .48rem; border-radius: 999px; color: var(--accent); background: rgba(140, 169, 255, .13); font-size: .66rem; font-weight: 800; letter-spacing: .05em; text-transform: uppercase; }
+.status-pill.approved, .status-pill.review-approved, .status-pill.idle { color: var(--green); background: rgba(87, 217, 154, .12); }
+.status-pill.error, .status-pill.stopped, .status-pill.failed { color: var(--red); background: rgba(255, 127, 143, .12); }
+.status-pill.implementing, .status-pill.busy, .status-pill.waiting, .status-pill.reviewing { color: var(--yellow); background: rgba(244, 201, 107, .12); }
+.status-pill.changes-requested { color: var(--purple); background: rgba(195, 155, 255, .13); }
+
+.agent-flow { display: flex; min-height: 16rem; align-items: center; justify-content: center; gap: .7rem; }
+.flow-node { display: flex; min-width: 8rem; min-height: 9.5rem; flex: 1; flex-direction: column; justify-content: center; gap: .55rem; padding: 1rem; border: 1px solid var(--line); border-radius: .75rem; background: rgba(255, 255, 255, .025); }
+.flow-role { color: var(--accent); font-size: .67rem; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
+.flow-node strong { font-size: .98rem; overflow-wrap: anywhere; }
+.status-line { display: flex; align-items: center; gap: .45rem; color: var(--muted); font-size: .72rem; }
+.state-dot.implementing, .state-dot.busy, .state-dot.reviewing { background: var(--yellow); }
+.state-dot.error, .state-dot.failed, .state-dot.stopped { background: var(--red); }
+.state-dot.unknown { background: var(--muted); }
+.flow-arrow { color: var(--accent); font-size: 1.4rem; }
+
+.task-detail-panel { scroll-margin-top: 1rem; }
+.detail-summary { flex-wrap: wrap; gap: .65rem 1rem; margin: -0.4rem 0 1.5rem; color: var(--muted); font-size: .76rem; }
+.graph-detail { margin-bottom: 2rem; }
+.graph-overview-grid { display: grid; grid-template-columns: minmax(0, 1.15fr) minmax(260px, .85fr); gap: 2rem; margin-bottom: 1.5rem; }
+.graph-topology { display: grid; gap: .75rem; }
+.graph-edge-list { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem .6rem; padding: .6rem .8rem; border: 1px solid var(--line); border-radius: .55rem; background: rgba(255, 255, 255, .02); font-size: .74rem; color: var(--muted); }
+.graph-edge-list strong { color: var(--text); }
+.graph-edge-list code { color: var(--accent); font-size: .72rem; }
+.graph-node { padding: 1rem; border: 1px solid var(--line); border-radius: .75rem; background: rgba(255, 255, 255, .025); }
+.graph-node-heading { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-bottom: .6rem; }
+.graph-node-heading strong { font-size: .92rem; }
+.graph-dependencies { margin-bottom: .6rem; color: var(--muted); font-size: .72rem; }
+.graph-dependencies code { color: var(--accent); }
+.graph-node-meta { display: flex; flex-wrap: wrap; gap: .4rem 1rem; margin-bottom: .6rem; color: var(--muted); font-size: .72rem; }
+.graph-node-meta strong, .graph-node-meta code { color: var(--text); }
+.graph-facts { display: grid; gap: .75rem; }
+.graph-fact { padding: .75rem .85rem; border: 1px solid var(--line); border-radius: .55rem; background: rgba(255, 255, 255, .02); }
+.graph-fact > span { display: block; margin-bottom: .35rem; color: var(--accent); font-size: .68rem; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+.graph-fact pre { margin: 0; padding: .6rem; max-height: 12rem; overflow: auto; border: 1px solid var(--line); border-radius: .45rem; background: rgba(0, 0, 0, .25); font: .7rem/1.4 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; color: #cdd8f7; white-space: pre-wrap; overflow-wrap: anywhere; }
+.graph-fact code { font-size: .74rem; color: var(--text); }
+.detail-grid { display: grid; grid-template-columns: minmax(0, 1.15fr) minmax(260px, .85fr); gap: 2rem; }
+.lower-grid { margin-top: 2rem; }
+.timeline-item { display: grid; grid-template-columns: 1.2rem minmax(0, 1fr); min-height: 4rem; }
+.timeline-rail { position: relative; display: flex; justify-content: center; }
+.timeline-dot { z-index: 1; width: .62rem; height: .62rem; margin-top: .25rem; border: 2px solid var(--accent); border-radius: 50%; background: var(--bg); }
+.timeline-dot.approved { border-color: var(--green); background: var(--green); }
+.timeline-dot.error, .timeline-dot.stopped { border-color: var(--red); background: var(--red); }
+.timeline-line { position: absolute; top: .8rem; bottom: 0; width: 1px; background: var(--line); }
+.timeline-content { padding: 0 0 1.2rem .75rem; }
+.timeline-title { justify-content: space-between; gap: 1rem; }
+.timeline-title strong { font-size: .82rem; }
+.timeline-title time { color: var(--muted); font-size: .7rem; }
+.timeline-content p { margin: .35rem 0 0; color: var(--muted); font-size: .78rem; line-height: 1.5; white-space: pre-wrap; overflow-wrap: anywhere; }
+.detail-agent-flow { padding: .75rem; border: 1px solid var(--line); border-radius: .75rem; }
+.detail-agent-row { display: grid; grid-template-columns: 5.5rem minmax(0, 1fr); gap: .4rem .75rem; padding: .8rem .4rem; }
+.detail-agent-row .status-line { grid-column: 2; }
+.detail-agent-arrow { padding-left: 2.3rem; color: var(--accent); }
+.evidence-list { display: grid; gap: .6rem; }
+.evidence-row { display: flex; justify-content: space-between; gap: 1rem; padding: .7rem .8rem; border: 1px solid var(--line); border-radius: .55rem; color: var(--muted); font-size: .76rem; }
+.evidence-row code { max-width: 65%; color: var(--text); overflow-wrap: anywhere; text-align: right; }
+.evidence-block, .review-block, .error-block { padding: .8rem; border-left: 2px solid var(--accent); background: rgba(255, 255, 255, .025); }
+.evidence-block p, .review-block p, .error-block p { margin: .4rem 0 0; color: var(--muted); font-size: .76rem; line-height: 1.45; white-space: pre-wrap; overflow-wrap: anywhere; }
+.error-block { border-color: var(--red); }
+.code-block, .session-output { min-height: 9rem; max-height: 20rem; margin: 0; padding: .9rem; overflow: auto; border: 1px solid var(--line); border-radius: .65rem; color: #cdd8f7; background: rgba(0, 0, 0, .2); font: .74rem/1.55 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; white-space: pre-wrap; overflow-wrap: anywhere; }
+
+.session-list { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: .75rem; }
+.session-card { padding: 1rem; border: 1px solid var(--line); border-radius: .75rem; background: rgba(255, 255, 255, .025); }
+.session-header { justify-content: space-between; gap: 1rem; }
+.session-header h3 { margin: 0; color: var(--text); font-size: .9rem; letter-spacing: 0; text-transform: none; }
+.session-meta { justify-content: space-between; gap: .7rem; margin: .9rem 0 .7rem; }
+.session-output { min-height: 7rem; max-height: 12rem; }
+.session-tasks { margin-top: .65rem; overflow-wrap: anywhere; }
+.session-history { display: grid; gap: .35rem; margin-top: .8rem; padding-top: .7rem; border-top: 1px solid var(--line); }
+.session-history > div { display: grid; grid-template-columns: 3.5rem minmax(0, 1fr) auto; gap: .5rem; color: var(--muted); font-size: .68rem; }
+.session-history strong { color: var(--text); font-size: .68rem; overflow-wrap: anywhere; }
+.history-label { display: inline-block; margin-top: .3rem; color: var(--accent); font-size: .62rem; font-weight: 700; letter-spacing: .06em; text-transform: uppercase; }
+
+.event-list { display: grid; }
+.event-row { display: grid; grid-template-columns: 9rem .8rem minmax(0, 1fr); gap: .75rem; padding: .8rem 0; border-bottom: 1px solid var(--line); }
+.event-row:last-child { border-bottom: 0; }
+.event-row time { color: var(--muted); font-size: .72rem; }
+.event-marker { width: .55rem; height: .55rem; margin-top: .18rem; border: 2px solid var(--accent); border-radius: 50%; }
+.event-marker.approved, .event-marker.review-approved { border-color: var(--green); background: var(--green); }
+.event-marker.error, .event-marker.agent-exit-nonzero { border-color: var(--red); background: var(--red); }
+.event-body { min-width: 0; }
+.event-title { justify-content: space-between; gap: 1rem; }
+.event-title strong { color: var(--text); font-size: .78rem; }
+.event-title span { color: var(--muted); font-size: .7rem; }
+.event-details { margin: .25rem 0; color: var(--muted); font-size: .76rem; line-height: 1.45; white-space: pre-wrap; overflow-wrap: anywhere; }
+.event-task { padding: 0; border: 0; color: var(--accent); background: transparent; font: .7rem ui-monospace, SFMono-Regular, Menlo, monospace; cursor: pointer; }
+.event-task:hover { text-decoration: underline; }
+.empty-state { padding: 2.2rem 1rem; color: var(--muted); text-align: center; font-size: .8rem; }
+.error-state { color: var(--red); }
+.footer { display: flex; justify-content: space-between; gap: 1rem; padding: 1.5rem clamp(1.25rem, 5vw, 5rem) 2rem; border-top: 1px solid var(--line); color: var(--muted); font-size: .7rem; }
+
+@media (max-width: 900px) {
+  .topbar, .footer { align-items: flex-start; flex-direction: column; }
+  .hero-grid, .detail-grid, .graph-overview-grid { grid-template-columns: 1fr; }
+  .agent-flow { min-height: 0; flex-direction: column; align-items: stretch; }
+  .flow-arrow { transform: rotate(90deg); align-self: center; }
+}
+
+@media (max-width: 600px) {
+  .shell { width: min(100% - 1rem, 1400px); padding-top: 1rem; }
+  .topbar { padding: 1.5rem 1rem; }
+  .event-row { grid-template-columns: 1fr; gap: .35rem; }
+  .event-marker { display: none; }
+  .session-meta { align-items: flex-start; flex-direction: column; }
+}
+
+/* Web Workspace repository identity panel */
+.repository-panel { overflow: hidden; }
+.branch-badge { min-width: max-content; max-width: 18rem; padding: .22rem .6rem; overflow: hidden; color: var(--green); background: rgba(87, 217, 154, .12); font-size: .72rem; text-overflow: ellipsis; white-space: nowrap; }
+.repo-facts { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: .7rem; }
+.repo-fact { min-width: 0; padding: .7rem .85rem; border: 1px solid var(--line); border-radius: .6rem; background: rgba(255, 255, 255, .025); }
+.repo-fact > span { display: block; margin-bottom: .35rem; color: var(--accent); font-size: .66rem; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+.repo-fact code, .repo-fact strong { font-size: .8rem; font-weight: 600; overflow-wrap: anywhere; }
+.repo-fact code { color: var(--text); font: .74rem ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+.repo-fact strong { color: var(--text); line-height: 1.4; }
+.repo-fact time { color: var(--muted); font-size: .78rem; }
+.repo-fact-wide { grid-column: 1 / -1; }
+.repo-fact-wide code { white-space: pre-wrap; }
+

--- a/lib/cli-core.mjs
+++ b/lib/cli-core.mjs
@@ -164,6 +164,7 @@ Commands:
   agent         Manage registered agents (add, list, doctor)
   adapter       Manage trusted local Contract v1 adapters (register, list, remove)
   inspector     Start the local read-only Web UI Inspector
+  web           Launch the local Web Workspace over the selected Git repository (primary local entry)
   config        Manage user-level executable configuration (set, get, list)
   doctor        Check prerequisites/installations and print repair commands
   uninstall     Remove installations created by this package
@@ -281,6 +282,7 @@ Examples:
   status        显示项目 Agent Bus 和 Task 状态
   task          管理持久化任务和 Task Graph（create、graph-validate、graph-create、graph-plan、graph-run、graph-advance、graph-recover、graph-resume、graph-stop、graph-cleanup、graph-dispatch、graph-status、graph-inspect、dispatch、status、list、inspect、resume、stop、review、error）
   inspector     启动本地只读 Web UI Inspector
+  web           启动所选 Git 仓库上的本地 Web Workspace（主要本地入口）
   uninstall     删除由本 npm 包创建的安装
   help          显示帮助
 
@@ -870,17 +872,22 @@ function statusJson(options) {
   return jsonSuccess('status', { root, bus, tasks });
 }
 
-async function inspectorCommand(options) {
+async function startLocalUiServer(options, kind) {
   const { startInspector } = await import('../inspector/server/server.mjs');
   const root = assertGitRepository(options.root, messages.en);
-  const started = await startInspector({ root, port: options.port || 3000 });
-  if (options.json) emitJson(jsonSuccess('inspector.start', {
-    root: started.root,
-    host: started.host,
-    port: started.port,
-    url: started.url,
-  }));
-  else console.log(`Inspector running:\n\n${started.url}`);
+  const started = await startInspector({ root, port: options.port || 3000, ui: kind });
+  const isWorkspace = kind === 'workspace';
+  if (options.json) {
+    emitJson(jsonSuccess(isWorkspace ? 'workspace.start' : 'inspector.start', {
+      kind,
+      root: started.root,
+      host: started.host,
+      port: started.port,
+      url: started.url,
+    }));
+  } else {
+    console.log(`${isWorkspace ? 'Workspace running' : 'Inspector running'}:\n\n${started.url}`);
+  }
 
   await new Promise(resolvePromise => {
     let closed = false;
@@ -897,6 +904,14 @@ async function inspectorCommand(options) {
     process.once('SIGINT', onSignal);
     process.once('SIGTERM', onSignal);
   });
+}
+
+async function inspectorCommand(options) {
+  await startLocalUiServer(options, 'inspector');
+}
+
+async function webCommand(options) {
+  await startLocalUiServer(options, 'workspace');
 }
 
 function readLatestErrorArtifact(root, agentId) {
@@ -4868,6 +4883,7 @@ export async function runCli(argv) {
     uninstallAuxiliarySkills,
     userConfigPath,
     verifyTarget,
+    webCommand,
   });
   if (dispatched) return;
 

--- a/lib/commands/index.mjs
+++ b/lib/commands/index.mjs
@@ -6,6 +6,7 @@ import { executeMaintenanceCommand } from './maintenance.mjs';
 import { executeSetupCommand } from './setup.mjs';
 import { executeStatusCommand } from './status.mjs';
 import { executeTaskCommand } from './task.mjs';
+import { executeWebCommand } from './web.mjs';
 import { executeWorkspaceCommand } from './workspace.mjs';
 
 const handlers = new Map([
@@ -23,6 +24,7 @@ const handlers = new Map([
   ['task', executeTaskCommand],
   ['uninstall', executeMaintenanceCommand],
   ['update', executeMaintenanceCommand],
+  ['web', executeWebCommand],
 ]);
 
 export async function dispatchCommand(options, context) {

--- a/lib/commands/web.mjs
+++ b/lib/commands/web.mjs
@@ -1,0 +1,9 @@
+export async function executeWebCommand(options, context) {
+  try {
+    await context.webCommand(options);
+  } catch (error) {
+    if (options.json) context.emitJson(context.jsonFailure('workspace.start', error));
+    else console.error(error.message || String(error));
+    process.exitCode = 1;
+  }
+}

--- a/llms.txt
+++ b/llms.txt
@@ -29,7 +29,7 @@ capabilities. Discovery does not launch an adapter; configured external Agents
 contribute only their declared detection facts, while exact Agent/Adapter/
 executable identity and project > user > adapter-default precedence remain
 separate through Task and persistent-Session execution.
-Local Inspector Web UI: https://hogancv.github.io/coordinate-agents/inspector.html
+Web Workspace and Local Inspector (primary read-only local browser entry, plus the compatible Inspector UI): https://hogancv.github.io/coordinate-agents/inspector.html
 Durable Runtime Event Journal: https://hogancv.github.io/coordinate-agents/event-journal.html
 MCP tools: https://hogancv.github.io/coordinate-agents/mcp.html
 Task Graph v1 contract: https://hogancv.github.io/coordinate-agents/task-graph-v1.html

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   ],
   "scripts": {
     "test": "node --test --test-concurrency=4",
+    "test:core": "node --test --test-concurrency=4 test/workspace.test.mjs test/inspector.test.mjs test/cli-modules.test.mjs test/documentation.test.mjs test/repository-layout.test.mjs test/adapter-contract.test.mjs test/adapters.test.mjs test/adapter-conformance.test.mjs test/builtin-adapter-conformance.test.mjs test/adapter-acceptance-gate.test.mjs test/user-config.test.mjs test/intent-map-v1.test.mjs test/task-graph-contract.test.mjs test/task-graph-scheduler.test.mjs test/task-graph-persistence.test.mjs test/task-graph-intent-scheduler.test.mjs test/runtime-events.test.mjs test/task-graph-acceptance-gate.test.mjs test/release-workflow.test.mjs",
     "sync:llms": "node scripts/sync-llms.mjs",
     "check:llms": "node scripts/sync-llms.mjs --check",
     "check": "node bin/coordinate-agents.mjs --help && npm run check:llms && npm test",

--- a/test/workspace.test.mjs
+++ b/test/workspace.test.mjs
@@ -1,0 +1,273 @@
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { once } from 'node:events';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+import { spawn, spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { createTask, setTaskStatus } from '../skills/coordinate-agents/scripts/task-runtime.mjs';
+import { createTaskGraph } from '../skills/coordinate-agents/scripts/task-graph-runtime.mjs';
+import { startWorkspace } from '../inspector/server/server.mjs';
+
+const root = process.cwd();
+const cli = join(root, 'bin', 'coordinate-agents.mjs');
+const busTool = join(root, 'skills', 'coordinate-agents', 'scripts', 'agent-bus.mjs');
+
+function git(repositoryRoot, args) {
+  const result = spawnSync('git', ['-C', repositoryRoot, ...args], { encoding: 'utf8', windowsHide: true });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  return result.stdout.trim();
+}
+
+function repository() {
+  const repositoryRoot = mkdtempSync(join(tmpdir(), 'coordinate-agents-workspace-'));
+  git(repositoryRoot, ['init', '-q']);
+  git(repositoryRoot, ['config', 'user.email', 'workspace-test@example.com']);
+  git(repositoryRoot, ['config', 'user.name', 'Workspace Test']);
+  writeFileSync(join(repositoryRoot, 'README.md'), '# Workspace fixture\n', 'utf8');
+  git(repositoryRoot, ['add', '-A']);
+  git(repositoryRoot, ['commit', '-qm', 'chore: workspace fixture baseline']);
+  const init = spawnSync(process.execPath, [busTool, 'init', '--root', repositoryRoot], { encoding: 'utf8', windowsHide: true });
+  assert.equal(init.status, 0, init.stderr || init.stdout);
+  return realpathSync(repositoryRoot);
+}
+
+function taskFixture(repositoryRoot) {
+  const task = createTask(repositoryRoot, {
+    id: 'task-workspace',
+    title: 'Build Workspace fixture',
+    spec: 'Show the local control plane without changing Runtime state.',
+  });
+  setTaskStatus(repositoryRoot, task.id, 'PLANNING');
+  setTaskStatus(repositoryRoot, task.id, 'SPEC_READY');
+  return repositoryRoot;
+}
+
+function graphFixture(repositoryRoot) {
+  createTaskGraph(repositoryRoot, {
+    schemaVersion: 1,
+    parentTask: {
+      id: 'task-workspace-graph',
+      title: 'Build Graph Workspace fixture',
+      spec: 'Demonstrate persisted Task Graph readability in the Workspace.',
+      planner: 'codex',
+      reviewer: 'codex',
+    },
+    subtasks: [
+      { id: 'sub-a', implementer: 'antigravity', spec: 'Implement component A.', dependsOn: [] },
+      { id: 'sub-b', implementer: 'codex', spec: 'Implement component B.', dependsOn: ['sub-a'] },
+    ],
+    maxConcurrency: 1,
+  }, {
+    configuredAgents: [{ id: 'codex', adapter: 'codex-cli' }, { id: 'antigravity', adapter: 'generic-cli' }],
+  });
+  return repositoryRoot;
+}
+
+async function freePort() {
+  const server = createServer();
+  await new Promise((resolvePromise, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolvePromise);
+  });
+  const port = server.address().port;
+  await new Promise(resolvePromise => server.close(resolvePromise));
+  return port;
+}
+
+async function closeServer(server) {
+  server.closeAllConnections?.();
+  await new Promise(resolvePromise => server.close(resolvePromise));
+}
+
+test('Web Workspace renders the bound Git repository identity and the read-only project overview', async () => {
+  const repositoryRoot = taskFixture(repository());
+  graphFixture(repositoryRoot);
+  const expectedBranch = git(repositoryRoot, ['symbolic-ref', '--quiet', '--short', 'HEAD']);
+  const started = await startWorkspace({ root: repositoryRoot, port: 0 });
+  try {
+    assert.equal(started.server.address().address, '127.0.0.1');
+    assert.equal(started.url, `http://localhost:${started.port}`);
+
+    const page = await (await fetch(`${started.url}/`)).text();
+    assert.match(page, /Coordinate Agents Workspace/);
+    assert.match(page, /BOUND REPOSITORY/);
+    assert.match(page, /id="repository"/);
+    assert.match(page, /id="repo-name"/);
+    assert.match(page, /id="repo-branch"/);
+    assert.match(page, /Task Graph topology/);
+
+    const repositoryFacts = await (await fetch(`${started.url}/api/repository`)).json();
+    assert.equal(repositoryFacts.root, repositoryRoot);
+    assert.equal(repositoryFacts.name, basename(repositoryRoot));
+    assert.equal(repositoryFacts.branch, expectedBranch);
+    assert.equal(repositoryFacts.detached, false);
+    assert.ok(repositoryFacts.head);
+    assert.match(repositoryFacts.head.short, /^[0-9a-f]{4,}$/);
+    assert.equal(repositoryFacts.head.subject, 'chore: workspace fixture baseline');
+    assert.equal(repositoryFacts.remoteUrl, null);
+    assert.equal(repositoryFacts.error, undefined);
+
+    const tasks = await (await fetch(`${started.url}/api/tasks`)).json();
+    assert.equal(tasks.length, 2);
+    assert.ok(tasks.some(item => item.id === 'task-workspace' && item.graph === false));
+    const graphParent = tasks.find(item => item.graph === true);
+    assert.ok(graphParent, 'Task Graph parent must appear in the Workspace overview');
+    assert.equal(graphParent.id, 'task-workspace-graph');
+    assert.equal(graphParent.subtaskCount, 2);
+
+    // Persisted #36 Task Graph records remain readable through the Workspace.
+    const graphDetail = await (await fetch(`${started.url}/api/tasks/task-workspace-graph`)).json();
+    assert.equal(graphDetail.graph, true);
+    assert.equal(graphDetail.subtasks.length, 2);
+    assert.deepEqual(graphDetail.subtasks.find(item => item.id === 'sub-b').dependsOn, ['sub-a']);
+
+    const js = await (await fetch(`${started.url}/app.js`)).text();
+    assert.match(js, /renderRepository/);
+    assert.match(js, /\/api\/repository/);
+    const css = await (await fetch(`${started.url}/styles.css`)).text();
+    assert.match(css, /\.repository-panel/);
+    assert.match(css, /\.repo-facts/);
+
+    const mutation = await fetch(`${started.url}/api/repository`, { method: 'POST' });
+    assert.equal(mutation.status, 405);
+    assert.equal(mutation.headers.get('allow'), 'GET');
+  } finally {
+    await closeServer(started.server);
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('coordinate-agents web CLI starts the localhost Workspace on a selected port', async () => {
+  const repositoryRoot = taskFixture(repository());
+  const port = await freePort();
+  const child = spawn(process.execPath, [cli, 'web', '--root', repositoryRoot, '--port', `${port}`], {
+    cwd: root,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
+  });
+  let stdout = '';
+  let stderr = '';
+  const started = new Promise((resolvePromise, reject) => {
+    const timeout = setTimeout(() => reject(new Error(`Workspace CLI did not start. stdout=${stdout} stderr=${stderr}`)), 8_000);
+    child.stdout.on('data', chunk => {
+      stdout += `${chunk}`;
+      if (stdout.includes(`http://localhost:${port}`)) {
+        clearTimeout(timeout);
+        resolvePromise();
+      }
+    });
+    child.stderr.on('data', chunk => { stderr += `${chunk}`; });
+    child.once('error', error => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+  });
+  try {
+    await started;
+    const page = await (await fetch(`http://localhost:${port}/`)).text();
+    assert.match(page, /Coordinate Agents Workspace/);
+    const repositoryFacts = await (await fetch(`http://localhost:${port}/api/repository`)).json();
+    assert.equal(repositoryFacts.root, repositoryRoot);
+    const tasks = await (await fetch(`http://localhost:${port}/api/tasks`)).json();
+    assert.equal(tasks[0].id, 'task-workspace');
+  } finally {
+    child.kill('SIGTERM');
+    await once(child, 'exit');
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('Web Workspace page loads, task selection, and event reads stay strictly read-only', async () => {
+  const repositoryRoot = taskFixture(repository());
+  graphFixture(repositoryRoot);
+  const started = await startWorkspace({ root: repositoryRoot, port: 0 });
+  try {
+    function snapshotDir(directory) {
+      const entries = [];
+      function walk(current) {
+        if (!existsSync(current)) return;
+        for (const name of readdirSync(current).sort()) {
+          const full = join(current, name);
+          entries.push(full.slice(directory.length));
+          try {
+            const stat = readFileSync(full);
+            entries.push(stat.byteLength);
+          } catch {
+            walk(full);
+          }
+        }
+      }
+      walk(directory);
+      return entries;
+    }
+
+    const before = snapshotDir(join(repositoryRoot, '.agent-bus'));
+
+    await fetch(`${started.url}/api/repository`);
+    await fetch(`${started.url}/api/tasks`);
+    await fetch(`${started.url}/api/tasks/task-workspace`);
+    await fetch(`${started.url}/api/tasks/task-workspace-graph`);
+    await fetch(`${started.url}/api/agents`);
+    await fetch(`${started.url}/api/sessions`);
+    await fetch(`${started.url}/api/events?limit=100`);
+    await fetch(`${started.url}/api/events/stream`, { signal: AbortSignal.timeout(150) }).catch(() => {});
+
+    const after = snapshotDir(join(repositoryRoot, '.agent-bus'));
+    assert.deepEqual(before, after, 'Workspace reads must not create Bus files, Sessions, events, or state transitions');
+
+    const porcelain = spawnSync('git', ['status', '--porcelain'], { cwd: repositoryRoot, encoding: 'utf8', windowsHide: true });
+    assert.equal(porcelain.status, 0);
+    assert.equal(porcelain.stdout.trim(), '', 'Workspace reads must not dirty the Git worktree');
+  } finally {
+    await closeServer(started.server);
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('Web Workspace fails closed for non-Git, missing, and uncommitted-unsafe entry points', async () => {
+  const repositoryRoot = taskFixture(repository());
+  const plainDirectory = mkdtempSync(join(tmpdir(), 'coordinate-agents-workspace-plain-'));
+  try {
+    // Direct server entry requires an initialized Git repository.
+    assert.throws(() => startWorkspace({ root: plainDirectory, port: 0 }), /initialized Git repository/);
+    assert.throws(() => startWorkspace({ root: join(plainDirectory, 'missing'), port: 0 }), /initialized Git repository/);
+
+    // CLI entry fails closed with the documented repository error.
+    for (const badRoot of [plainDirectory, join(plainDirectory, 'missing')]) {
+      const result = spawnSync(process.execPath, [cli, 'web', '--root', badRoot], {
+        cwd: root,
+        encoding: 'utf8',
+        windowsHide: true,
+      });
+      assert.equal(result.status, 1, badRoot);
+      assert.match(result.stderr || result.stdout, /Not a Git repository/);
+    }
+  } finally {
+    rmSync(repositoryRoot, { recursive: true, force: true });
+    rmSync(plainDirectory, { recursive: true, force: true });
+  }
+});
+
+test('Workspace metadata ships in the package payload, CLI help, and web assets directory', () => {
+  const packageJson = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
+  assert.ok(packageJson.files.includes('inspector'));
+  assert.ok(existsSync(join(root, 'inspector', 'web-workspace', 'index.html')));
+  assert.ok(existsSync(join(root, 'inspector', 'web-workspace', 'app.js')));
+  assert.ok(existsSync(join(root, 'inspector', 'web-workspace', 'styles.css')));
+  const help = spawnSync(process.execPath, [cli, 'help', '--lang', 'en'], { cwd: root, encoding: 'utf8', windowsHide: true });
+  assert.equal(help.status, 0);
+  assert.match(help.stdout, /web\s+Launch the local Web Workspace over the selected Git repository/);
+  assert.match(help.stdout, /inspector\s+Start the local read-only Web UI Inspector/);
+});


### PR DESCRIPTION
## What

Implements #45 (P0-00): a supported `coordinate-agents web --port <port>` entry that launches a loopback-only, read-only **Web Workspace** over the existing Inspector server/data adapter for one validated Git repository. `coordinate-agents inspector` remains as the behaviorally compatible read-only UI over the same GET contracts.

## Changes

- **Data**: `inspector-data.mjs` gains `readRepository()` — bounded identity facts (name, branch/detached, HEAD short+subject+date, origin remote) from read-only Git helpers with fail-soft degradation.
- **Server**: `server.mjs` selects web assets by `ui`, adds `GET /api/repository`, and `startWorkspace()` fails closed unless the root is an initialized Git repository (unsafe/symlinked/non-Git roots refused).
- **Workspace UI**: `inspector/web-workspace/` — repository identity panel (BOUND REPOSITORY) above the read-only overview: Tasks & Task Graph parents, Agents, Sessions, recent events, bounded Task/Graph detail (persisted #36 graph records remain readable).
- **CLI**: new `web` command (`lib/commands/web.mjs`, registered in the dispatcher); shared `startLocalUiServer(options, kind)` powers both `web` and `inspector`; bilingual help updated.
- **Tests**: `test/workspace.test.mjs` (5 focused offline HTTP/asset/CLI/read-only/fail-closed tests). `inspector.test.mjs` and `documentation.test.mjs` remain green.
- **Docs**: README(.zh-CN), getting-started, docs/inspector.md, llms.txt updated to present the Web Workspace as the primary local browser entry without removing Plugin/MCP/CLI paths.

## Validation

- `npm run demo` passes; `npm pack --dry-run` includes the new web-workspace assets and command module.
- Local full-suite runs are green except pre-existing host-specific launch/adapter failures (real `codex` on PATH + missing `agy-proxy`), reproduced identically on the pre-change baseline; CI remains authoritative.

Closes #45