### PR TITLE
feat(web): add guarded browser-to-Runtime action gateway (#46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,11 @@ npx @hogancv/coordinate-agents@latest web --port 3000
 
 The Workspace binds exactly one Git repository and shows its identity (branch,
 HEAD, remote), Tasks and Task Graph parents, Agents, Sessions, recent Runtime
-events, and bounded Task/Graph detail. The `inspector` command stays available
-as the compatible read-only UI over the same GET contracts. The browser is
-never the source of truth. Learn more in
+events, and bounded Task/Graph detail. Overview and refresh are strictly
+read-only; a guarded `POST /api/action` endpoint routes an explicit allow-list
+of Runtime operations through the same services as CLI and MCP. The
+`inspector` command stays available as the compatible read-only UI over the
+same GET contracts. The browser is never the source of truth. Learn more in
 [Inspector & Web Workspace](./docs/inspector.md) and
 [Event Journal](./docs/event-journal.md).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -141,8 +141,10 @@ npx @hogancv/coordinate-agents@latest web --port 3000
 
 Workspace 在启动时绑定唯一一个 Git 仓库，展示其身份（分支、HEAD、远程）、
 普通 Task 与 Task Graph parent、Agents、Sessions、近期 Runtime 事件以及有界
-的 Task/Graph 详情。`inspector` 命令继续作为同一套 GET 契约上的兼容只读
-界面保留。浏览器页面始终不是事实源。详见 [Inspector 与 Web Workspace](./docs/inspector.md)
+的 Task/Graph 详情。总览与刷新严格只读；受保护的 `POST /api/action` 端点把
+显式白名单内的 Runtime 操作路由到与 CLI/MCP 相同的服务。`inspector` 命令
+继续作为同一套 GET 契约上的兼容只读界面保留。浏览器页面始终不是事实源。
+详见 [Inspector 与 Web Workspace](./docs/inspector.md)
 与 [Event Journal](./docs/event-journal.md)。
 
 ## Standalone npm Runtime

--- a/docs/inspector.md
+++ b/docs/inspector.md
@@ -1,21 +1,24 @@
 ---
 layout: page
 title: Web Workspace and Local Inspector
-description: A localhost-only, read-only Web Workspace for observing Coordinate Agents Tasks, Task Graphs, Agents, Sessions, and Agent Bus events. The Inspector remains the compatible read-only UI.
+description: A localhost-only Web Workspace for Coordinate Agents with read-only project overview and a guarded browser-to-Runtime action gateway. The Inspector remains the compatible read-only UI.
 ---
 
 # Web Workspace and Local Inspector
 
 The **Web Workspace** is the primary local browser entry for Coordinate Agents.
-It starts a loopback-only, read-only project overview for one selected Git
-repository and answers "what is happening?" without requiring Codex Plugin, a
-global installation, or a remote service. The **Inspector** command remains a
-behaviorally compatible read-only UI over the same server and data adapter.
+It starts a loopback-only project overview for one selected Git repository and
+answers "what is happening?" without requiring Codex Plugin, a global
+installation, or a remote service. Overview, refresh, selection, and event
+replay are strictly read-only; a guarded action endpoint routes a small,
+explicit allow-list of operations to the shared Runtime without making the
+browser a second state owner. The **Inspector** command remains a behaviorally
+compatible read-only UI over the same server and data adapter.
 
 Both surfaces are intentionally not a SaaS console, a replacement for Codex, or
-a second Task workflow. They do not accept Task input, send Agent messages,
-control Sessions, or change Runtime state. Browser actions that mutate Runtime
-state arrive in a later, guarded action-gateway milestone.
+a second Task workflow. Read paths never send Agent messages, control Sessions,
+or change Runtime state; action-gateway mutations reuse the exact Runtime
+validation, locks, and durable state owned by CLI and MCP.
 
 ## Architecture
 
@@ -59,7 +62,45 @@ one canonical regular Git repository root at startup and refuses unsafe or
 symlinked roots. Browser requests can never select another root. The primary
 listener binds to `127.0.0.1`; when IPv6 loopback is available, `::1` is served
 on the same port as a localhost compatibility alias. Both listeners are
-loopback-only and accept GET requests only. Stop it with `Ctrl-C`.
+loopback-only. Every read path accepts GET only; the sole mutation surface is
+the guarded action endpoint below. Stop it with `Ctrl-C`.
+
+## Guarded actions (POST /api/action)
+
+The Workspace exposes exactly one additive, guarded action endpoint for later
+controls: `POST /api/action`. It routes an explicit allow-list of structured
+operations to the same shared Runtime services used by CLI and MCP
+(`taskCreate`, `taskStatus`, `taskInspect`, `taskGraphStatus`,
+`taskGraphInspect`, `taskGraphPlan`, `taskGraphValidate`, `recoverInspect`).
+The gateway never shells out, parses CLI output, proxies MCP, accepts an
+arbitrary operation name, or lets a request choose a different repository root.
+
+Every non-GET request must carry the server-issued **per-launch capability** in
+the `x-coordinate-agents-capability` header. The Workspace page receives it in a
+`meta[name="coordinate-agents-capability"]` tag at load time; it changes on
+every server start. Requests are validated in this order and fail closed before
+any Runtime side effect:
+
+1. Path must be `/api/action`; every other path stays a read-only GET surface.
+2. `Host` and (when present) `Origin` must be loopback (`localhost`,
+   `127.0.0.1`, or `::1`).
+3. The per-launch capability must match.
+4. `Content-Type` must be `application/json` and the body is bounded.
+5. The body must be a JSON object with an allow-listed `action` name and a
+   `params` object whose keys match the action schema (including an optional
+   `root` that must equal the bound repository root).
+6. The operation runs through `runtime-services.mjs` with the bound root
+   injected. Responses preserve Runtime identity fields (`ok`, `command`),
+   canonical error codes, recoverability, and bounded diagnostics, and carry a
+   `correlation` value echoed from the request's `correlationId` or
+   `x-correlation-id` header.
+
+Concurrency and replay safety follow the existing Runtime locks and
+deduplication rules: deterministic Task IDs make `taskCreate` replay-safe
+(repeats return `TASK_STATE_CONFLICT`), graph validation and preflight stay
+side-effect free, and read paths never launch an Agent or mutate graph/session
+state. Process-launching, Session-input, stop, cleanup, integration, and review
+operations require explicit UI confirmation and are added by later tickets.
 
 ## Start the Inspector (compatibility path)
 
@@ -84,7 +125,9 @@ canonical bound root path), followed by:
 - **Recent events** — timestamp, sequence, event type, Task, Session, Agent, and
   a bounded summary from the append-only journal.
 
-## Endpoints (Read-Only)
+## Endpoints
+
+Read-only GET surface:
 
 - `GET /api/repository` — bounded identity facts for the bound Git repository (name, branch or detached HEAD, HEAD short SHA/subject/date, origin remote).
 - `GET /api/tasks` — mixed listing of ordinary Tasks and Task Graph parents.
@@ -96,11 +139,17 @@ canonical bound root path), followed by:
 - `GET /api/events` — Event Journal records with query filtering.
 - `GET /api/events/stream` — SSE event stream with `Last-Event-ID` resume support.
 
+Guarded action surface (Workspace only):
+
+- `POST /api/action` — allow-listed Runtime operations with per-launch
+  capability, loopback Host/Origin, bounded JSON, and bound-root enforcement
+  (see [Guarded actions](#guarded-actions-post-apiaction) above).
+
 The dashboard receives new records through the localhost-only read-only
 `GET /api/events/stream` SSE endpoint, resumes from `Last-Event-ID`, refreshes
-periodically as a fallback, and has a manual Refresh button. It is
-read-only by design; use the Plugin or the existing CLI/Runtime operations to
-create, dispatch, review, resume, or stop Tasks.
+periodically as a fallback, and has a manual Refresh button. Every read path is
+side-effect free; use the action gateway for the allow-listed Runtime
+operations or the Plugin/CLI for dispatch, review, resume, and stop.
 
 ## Data and security boundary
 
@@ -122,7 +171,10 @@ evidence. The Workspace is a control-plane view, not a secret store.
   incomplete; old history is never fabricated or backfilled.
 - Recorded ordering uses repository-monotonic sequence values rather than
   timestamps.
-- There is no authentication, remote access, mutation, chat, Task input form,
-  multi-tenant mode, cloud sync, or benchmark/evaluation dashboard yet.
+- There is no authentication beyond the local per-launch capability, remote
+  access, chat, multi-tenant mode, cloud sync, or benchmark/evaluation
+  dashboard. Workspace mutations are limited to the allow-listed actions above;
+  process-launching, Session-input, stop, cleanup, integration, and review
+  controls (with explicit UI confirmation) arrive in later tickets.
 - `coordinate-agents web` requires an initialized Git repository root; the
   compatibility `inspector` command keeps its existing validation behavior.

--- a/inspector/server/action-gateway.mjs
+++ b/inspector/server/action-gateway.mjs
@@ -1,0 +1,337 @@
+/**
+ * Guarded browser-to-Runtime action gateway (#46).
+ *
+ * The Web Workspace is read-only on GET paths; this module is the narrow,
+ * additive action boundary for later Workspace controls. It binds one
+ * canonical repository root to the server process, requires a server-issued
+ * per-launch capability on every non-GET request, validates loopback
+ * Host/Origin and bounded JSON bodies, exposes only an explicit allow-list of
+ * structured operations, and routes them exclusively to the shared
+ * `runtime-services.mjs` operation map used by CLI and MCP.
+ *
+ * The gateway never shells out, parses CLI stdout, proxies MCP, accepts an
+ * arbitrary operation name, or lets a request choose a different repository
+ * root. Concurrency and replay safety are delegated to the existing Runtime
+ * locks/deduplication rules (deterministic Task IDs, atomic Task records,
+ * graph validation, claim/state conflicts); the HTTP seam only serializes
+ * through the single-threaded Node event loop.
+ */
+
+import { randomBytes, randomUUID, timingSafeEqual } from 'node:crypto';
+import { resolve } from 'node:path';
+import { invokeRuntimeOperation } from '../../skills/coordinate-agents/scripts/runtime-services.mjs';
+import {
+  jsonFailure,
+  normalizeRuntimeError,
+} from '../../skills/coordinate-agents/scripts/runtime-contract.mjs';
+import { redactOutput } from '../../skills/coordinate-agents/adapters/executable.mjs';
+
+export const ACTION_ENDPOINT = '/api/action';
+export const CAPABILITY_HEADER = 'x-coordinate-agents-capability';
+export const CORRELATION_HEADER = 'x-correlation-id';
+export const DEFAULT_MAX_BODY_BYTES = 512 * 1024;
+export const CAPABILITY_PLACEHOLDER = '__COORDINATE_AGENTS_CAPABILITY__';
+
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
+const CORRELATION_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
+
+/**
+ * First explicit Workspace action allow-list. Every entry maps to one shared
+ * Runtime operation and is deliberately free of process-launching,
+ * Session-input, stop, cleanup, integration, and review side effects; those
+ * operations require explicit UI confirmation and arrive in later tickets.
+ * `taskCreate` keeps its deterministic-id conflict as the replay guard.
+ */
+const ACTION_DEFINITIONS = Object.freeze({
+  taskCreate: {
+    operation: 'taskCreate',
+    command: 'task.create',
+    params: {
+      title: { type: 'string', required: true, max: 1024 },
+      id: { type: 'string', max: 128 },
+      spec: { type: 'string', max: 256 * 1024 },
+      planner: { type: 'string', max: 64 },
+      implementer: { type: 'string', max: 64 },
+      reviewer: { type: 'string', max: 64 },
+    },
+  },
+  taskStatus: {
+    operation: 'taskStatus',
+    command: 'task.status',
+    params: {
+      taskId: { type: 'string', required: true, max: 128 },
+    },
+  },
+  taskInspect: {
+    operation: 'taskInspect',
+    command: 'task.inspect',
+    params: {
+      taskId: { type: 'string', required: true, max: 128 },
+    },
+  },
+  taskGraphStatus: {
+    operation: 'taskGraphStatus',
+    command: 'task.graph-status',
+    params: {
+      taskId: { type: 'string', required: true, max: 128 },
+    },
+  },
+  taskGraphInspect: {
+    operation: 'taskGraphInspect',
+    command: 'task.graph-inspect',
+    params: {
+      taskId: { type: 'string', required: true, max: 128 },
+    },
+  },
+  taskGraphPlan: {
+    operation: 'taskGraphPlan',
+    command: 'task.graph-plan',
+    params: {
+      taskId: { type: 'string', required: true, max: 128 },
+    },
+  },
+  taskGraphValidate: {
+    operation: 'taskGraphValidate',
+    command: 'task.graph-validate',
+    params: {
+      graph: { type: 'object', required: true, max: 512 * 1024 },
+      intentMap: { type: 'object', max: 512 * 1024 },
+    },
+  },
+  recoverInspect: {
+    operation: 'recoverInspect',
+    command: 'recover.inspect',
+    params: {
+      taskId: { type: 'string', required: true, max: 128 },
+    },
+  },
+});
+
+function gatewayError(code, message) {
+  return {
+    ok: false,
+    command: 'action',
+    error: {
+      code,
+      message: redactOutput(`${message || code}`, 2 * 1024),
+      recoverable: false,
+    },
+  };
+}
+
+function actionEnvelope(payload, { action, correlation }) {
+  return {
+    ...payload,
+    action,
+    correlation,
+  };
+}
+
+function readBody(request, maxBytes) {
+  return new Promise((resolvePromise, reject) => {
+    const chunks = [];
+    let received = 0;
+    let tooLarge = false;
+    request.on('data', chunk => {
+      if (tooLarge) return; // keep draining so the client can read our 413.
+      received += chunk.length;
+      if (received > maxBytes) {
+        tooLarge = true;
+        chunks.length = 0;
+        return;
+      }
+      chunks.push(chunk);
+    });
+    request.on('end', () => {
+      if (tooLarge) resolvePromise({ tooLarge: true, body: null });
+      else resolvePromise({ tooLarge: false, body: Buffer.concat(chunks) });
+    });
+    request.on('error', error => reject({ code: 'ACTION_BODY_READ_FAILED', status: 400, message: error.message }));
+  });
+}
+
+function parseHost(request) {
+  const header = request.headers.host || '';
+  const hostname = (header.split(':')[0] || '').trim().toLowerCase();
+  return hostname;
+}
+
+function originAllowed(request) {
+  const origin = request.headers.origin;
+  if (origin === undefined || origin === null || origin === '') return true;
+  let url;
+  try {
+    url = new URL(origin);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return false;
+  return LOOPBACK_HOSTS.has(url.hostname.toLowerCase());
+}
+
+function capabilityMatches(actual, expected) {
+  if (typeof actual !== 'string' || typeof expected !== 'string') return false;
+  const actualBuffer = Buffer.from(actual);
+  const expectedBuffer = Buffer.from(expected);
+  if (actualBuffer.length !== expectedBuffer.length) return false;
+  return timingSafeEqual(actualBuffer, expectedBuffer);
+}
+
+function validateParams(definition, params) {
+  const allowed = new Set(Object.keys(definition.params));
+  for (const key of Object.keys(params)) {
+    // root is validated and bound by the gateway itself before this point.
+    if (key === 'root') continue;
+    if (!allowed.has(key)) return `Unsupported action parameter: ${key}`;
+  }
+  for (const [key, rule] of Object.entries(definition.params)) {
+    const value = params[key];
+    const present = value !== undefined && value !== null;
+    if (rule.required && !present) return `Missing required parameter: ${key}`;
+    if (!present) continue;
+    if (rule.type === 'string') {
+      if (typeof value !== 'string') return `Parameter ${key} must be a string.`;
+      if (value.length > rule.max) return `Parameter ${key} exceeds the supported size limit.`;
+    } else if (rule.type === 'object') {
+      if (typeof value !== 'object' || Array.isArray(value) || value === null) {
+        return `Parameter ${key} must be an object.`;
+      }
+      if (Buffer.byteLength(JSON.stringify(value)) > rule.max) return `Parameter ${key} exceeds the supported size limit.`;
+    }
+  }
+  return null;
+}
+
+export function createActionGateway({ root, capability, maxBodyBytes = DEFAULT_MAX_BODY_BYTES } = {}) {
+  const boundRoot = resolve(root || process.cwd());
+  return {
+    capability,
+    async handleAction(request, response, pathname) {
+      const send = (status, payload) => {
+        const body = `${JSON.stringify({ ...payload, correlation })}\n`;
+        response.writeHead(status, {
+          'Cache-Control': 'no-store',
+          'Content-Type': 'application/json; charset=utf-8',
+          'Content-Length': Buffer.byteLength(body),
+        });
+        response.end(body);
+      };
+      const correlation = request.headers[CORRELATION_HEADER] && CORRELATION_PATTERN.test(request.headers[CORRELATION_HEADER])
+        ? request.headers[CORRELATION_HEADER]
+        : randomUUID();
+
+      // Only the single documented action endpoint accepts non-GET traffic;
+      // every other path remains a GET-only read surface (405 with Allow: GET).
+      if (pathname !== ACTION_ENDPOINT) {
+        response.setHeader('Allow', 'GET');
+        send(405, gatewayError('ACTION_ENDPOINT_NOT_FOUND', `Workspace endpoint is read-only; only ${ACTION_ENDPOINT} accepts actions.`));
+        return;
+      }
+
+      // Loopback Host and Origin policy run before any body is parsed.
+      if (!LOOPBACK_HOSTS.has(parseHost(request))) {
+        send(403, gatewayError('ACTION_HOST_DISALLOWED', 'Workspace actions require a loopback Host header.'));
+        return;
+      }
+      if (!originAllowed(request)) {
+        send(403, gatewayError('ACTION_ORIGIN_DISALLOWED', 'Workspace actions require a same-origin or loopback Origin.'));
+        return;
+      }
+
+      // Per-launch capability is mandatory for every non-GET request.
+      const suppliedCapability = request.headers[CAPABILITY_HEADER];
+      if (!capabilityMatches(suppliedCapability, capability)) {
+        send(401, gatewayError('ACTION_CAPABILITY_REQUIRED', 'Workspace actions require the server-issued per-launch capability.'));
+        return;
+      }
+
+      const contentType = `${request.headers['content-type'] || ''}`.split(';')[0].trim().toLowerCase();
+      if (contentType !== 'application/json') {
+        send(415, gatewayError('ACTION_CONTENT_TYPE_INVALID', 'Workspace action bodies must be application/json.'));
+        return;
+      }
+
+      let read;
+      try {
+        read = await readBody(request, maxBodyBytes);
+      } catch (error) {
+        send(error.status || 400, gatewayError(error.code || 'ACTION_BODY_READ_FAILED', error.message || 'Action body could not be read.'));
+        return;
+      }
+      if (read.tooLarge) {
+        send(413, gatewayError('ACTION_BODY_TOO_LARGE', 'Workspace action body exceeds the supported size limit.'));
+        return;
+      }
+      if (read.body.length === 0) {
+        send(400, gatewayError('ACTION_BODY_INVALID', 'Workspace action body is required.'));
+        return;
+      }
+
+      let parsed;
+      try {
+        parsed = JSON.parse(read.body.toString('utf8'));
+      } catch {
+        send(400, gatewayError('ACTION_BODY_INVALID', 'Workspace action body is not valid JSON.'));
+        return;
+      }
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        send(400, gatewayError('ACTION_BODY_INVALID', 'Workspace action body must be a JSON object.'));
+        return;
+      }
+
+      const { action, params: rawParams = {}, correlationId } = parsed;
+      if (typeof action !== 'string') {
+        send(400, gatewayError('ACTION_NOT_ALLOWED', 'Workspace action name is required.'));
+        return;
+      }
+      const correlationValue = typeof correlationId === 'string' && CORRELATION_PATTERN.test(correlationId)
+        ? correlationId
+        : correlation;
+      const definition = ACTION_DEFINITIONS[action];
+      if (!definition) {
+        send(404, gatewayError('ACTION_NOT_ALLOWED', `Unknown Workspace action: ${action}`));
+        return;
+      }
+      if (typeof rawParams !== 'object' || rawParams === null || Array.isArray(rawParams)) {
+        send(400, gatewayError('ACTION_PARAMS_INVALID', 'Workspace action params must be an object.'));
+        return;
+      }
+
+      // The repository root is bound at startup. A request may echo the bound
+      // root for tool compatibility but may never select another root.
+      const params = { ...rawParams };
+      if (params.root !== undefined) {
+        let requestedRoot;
+        try {
+          requestedRoot = resolve(`${params.root}`);
+        } catch {
+          requestedRoot = null;
+        }
+        if (!requestedRoot || requestedRoot !== boundRoot) {
+          send(403, gatewayError('ACTION_ROOT_MISMATCH', 'Workspace action root does not match the bound repository.'));
+          return;
+        }
+        delete params.root;
+      }
+      params.root = boundRoot;
+
+      const invalid = validateParams(definition, params);
+      if (invalid) {
+        send(400, gatewayError('ACTION_PARAMS_INVALID', invalid));
+        return;
+      }
+
+      try {
+        const payload = await invokeRuntimeOperation(definition.operation, params);
+        send(200, actionEnvelope(payload || {}, { action, correlation: correlationValue }));
+      } catch (error) {
+        const payload = jsonFailure(definition.command, normalizeRuntimeError(error));
+        send(200, actionEnvelope(payload, { action, correlation: correlationValue }));
+      }
+    },
+  };
+}
+
+export function createWorkspaceCapability() {
+  return randomBytes(24).toString('hex');
+}

--- a/inspector/server/server.mjs
+++ b/inspector/server/server.mjs
@@ -6,6 +6,11 @@ import { spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createInspectorData } from './inspector-data.mjs';
+import {
+  createActionGateway,
+  createWorkspaceCapability,
+  CAPABILITY_PLACEHOLDER,
+} from './action-gateway.mjs';
 import { redactOutput } from '../../skills/coordinate-agents/adapters/executable.mjs';
 
 const inspectorWebRoot = resolve(fileURLToPath(new URL('../web', import.meta.url)));
@@ -30,10 +35,13 @@ function json(response, status, payload) {
   response.end(body);
 }
 
-function asset(response, pathname, assetsRoot) {
+function asset(response, pathname, assetsRoot, capability = null) {
   const entry = STATIC_FILES.get(pathname) || STATIC_FILES.get('/index.html');
   try {
-    const body = readFileSync(resolve(assetsRoot, entry.file));
+    let body = readFileSync(resolve(assetsRoot, entry.file));
+    if (capability && entry.file === 'index.html') {
+      body = Buffer.from(body.toString('utf8').replaceAll(CAPABILITY_PLACEHOLDER, capability), 'utf8');
+    }
     response.writeHead(200, {
       'Cache-Control': 'no-cache',
       'Content-Type': entry.type,
@@ -117,10 +125,23 @@ function apiError(response, error) {
   });
 }
 
-export function createInspectorServer({ root, data = createInspectorData(root), ui = 'inspector' } = {}) {
+export function createInspectorServer({
+  root,
+  data = createInspectorData(root),
+  ui = 'inspector',
+  capability = null,
+  gateway = null,
+} = {}) {
   const assetsRoot = webAssetsFor(ui);
   return createServer(async (request, response) => {
     if (request.method !== 'GET') {
+      // The Workspace action gateway is the only non-GET surface; the
+      // compatibility Inspector path remains strictly GET-only.
+      if (gateway) {
+        const actionUrl = new URL(request.url || '/', 'http://localhost');
+        await gateway.handleAction(request, response, actionUrl.pathname);
+        return;
+      }
       response.setHeader('Allow', 'GET');
       json(response, 405, { error: 'Inspector is read-only; only GET is supported.' });
       return;
@@ -130,7 +151,7 @@ export function createInspectorServer({ root, data = createInspectorData(root), 
     const pathname = url.pathname;
     if (!pathname.startsWith('/api/')) {
       if (pathname === '/' || STATIC_FILES.has(pathname)) {
-        asset(response, pathname, assetsRoot);
+        asset(response, pathname, assetsRoot, capability);
         return;
       }
       json(response, 404, { error: 'Inspector page not found.' });
@@ -183,13 +204,20 @@ export function createInspectorServer({ root, data = createInspectorData(root), 
   });
 }
 
-export function startInspector({ root, host = '127.0.0.1', port = 3000, ui = 'inspector' } = {}) {
+export function startInspector({
+  root,
+  host = '127.0.0.1',
+  port = 3000,
+  ui = 'inspector',
+  capability = null,
+  gateway = null,
+} = {}) {
   if (host !== '127.0.0.1') throw new Error('Inspector must listen on localhost only.');
   if (!Number.isInteger(port) || port < 0 || port > 65_535) {
     throw new Error(`Inspector port must be an integer between 0 and 65535: ${port}`);
   }
   const data = createInspectorData(root);
-  const server = createInspectorServer({ root: data.root, data, ui });
+  const server = createInspectorServer({ root: data.root, data, ui, capability, gateway });
   return new Promise((resolvePromise, reject) => {
     let ipv6Loopback = null;
     const onError = error => {
@@ -207,7 +235,7 @@ export function startInspector({ root, host = '127.0.0.1', port = 3000, ui = 'in
       // optional IPv6 loopback alias on the same port so the localhost URL is
       // reachable without exposing the Inspector beyond loopback interfaces.
       if (host === '127.0.0.1') {
-        const candidate = createInspectorServer({ root: data.root, data, ui });
+        const candidate = createInspectorServer({ root: data.root, data, ui, capability, gateway });
         try {
           await new Promise((resolveAlias, rejectAlias) => {
             const onAliasError = error => {
@@ -265,6 +293,8 @@ export function startInspector({ root, host = '127.0.0.1', port = 3000, ui = 'in
         host,
         port: boundPort,
         url: `http://localhost:${boundPort}`,
+        capability: capability || null,
+        actionEndpoint: gateway ? '/api/action' : null,
       });
     };
     server.once('error', onError);
@@ -278,7 +308,8 @@ export function startInspector({ root, host = '127.0.0.1', port = 3000, ui = 'in
 // the Inspector compatibility path and only selects the Workspace web assets.
 // Unlike the compatibility Inspector, the Workspace binds exactly one validated
 // Git repository root: unsafe, symlinked, or non-Git roots fail closed before a
-// listener is created.
+// listener is created. It also mounts the guarded browser-to-Runtime action
+// gateway (#46) with a server-issued per-launch capability.
 export function startWorkspace(options = {}) {
   const requested = resolve(options.root || process.cwd());
   const result = spawnSync('git', ['-C', requested, 'rev-parse', '--show-toplevel'], {
@@ -290,10 +321,19 @@ export function startWorkspace(options = {}) {
   if (result.error || result.status !== 0) {
     throw new Error(`Workspace must start inside an initialized Git repository: ${requested}`);
   }
+  const canonicalRoot = resolve(result.stdout.trim());
+  const capability = options.capability || createWorkspaceCapability();
+  const gateway = options.gateway || createActionGateway({
+    root: canonicalRoot,
+    capability,
+    maxBodyBytes: options.maxBodyBytes,
+  });
   return startInspector({
     ...options,
-    root: resolve(result.stdout.trim()),
+    root: canonicalRoot,
     ui: 'workspace',
+    capability,
+    gateway,
   });
 }
 
@@ -314,7 +354,7 @@ if (isInvokedDirectly()) {
     const started = ui === 'workspace'
       ? await startWorkspace({ root, port })
       : await startInspector({ root, port });
-    console.log(`Inspector running:\n\n${started.url}`);
+    console.log(`${ui === 'workspace' ? 'Workspace' : 'Inspector'} running:\n\n${started.url}`);
   } catch (error) {
     console.error(error.message || String(error));
     process.exitCode = 1;

--- a/inspector/web-workspace/app.js
+++ b/inspector/web-workspace/app.js
@@ -20,6 +20,28 @@ const state = {
   selectedTask: null,
 };
 
+// Server-issued per-launch capability for guarded browser actions (#46). The
+// read-only surfaces never use it; later control panels attach it to POST
+// /api/action requests as x-coordinate-agents-capability.
+const capabilityMeta = document.querySelector('meta[name="coordinate-agents-capability"]');
+const workspaceCapability = capabilityMeta?.content && capabilityMeta.content !== '__COORDINATE_AGENTS_CAPABILITY__'
+  ? capabilityMeta.content
+  : null;
+
+async function postAction(action, params, { correlationId = null } = {}) {
+  const response = await fetch('/api/action', {
+    method: 'POST',
+    cache: 'no-store',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(workspaceCapability ? { 'x-coordinate-agents-capability': workspaceCapability } : {}),
+      ...(correlationId ? { 'x-correlation-id': correlationId } : {}),
+    },
+    body: JSON.stringify({ action, params, correlationId }),
+  });
+  return { status: response.status, payload: await response.json() };
+}
+
 const elements = Object.fromEntries([
   'tasks', 'task-count', 'agent-flow', 'task-detail', 'detail-title', 'detail-summary',
   'timeline', 'detail-agent-flow', 'evidence', 'spec', 'sessions', 'session-count',

--- a/inspector/web-workspace/index.html
+++ b/inspector/web-workspace/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="color-scheme" content="dark">
     <meta name="description" content="Coordinate Agents Web Workspace: a localhost-only control plane for your local AI coding team.">
+    <meta name="coordinate-agents-capability" content="__COORDINATE_AGENTS_CAPABILITY__">
     <title>Coordinate Agents Workspace</title>
     <link rel="stylesheet" href="/styles.css">
   </head>

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   ],
   "scripts": {
     "test": "node --test --test-concurrency=4",
-    "test:core": "node --test --test-concurrency=4 test/workspace.test.mjs test/inspector.test.mjs test/cli-modules.test.mjs test/documentation.test.mjs test/repository-layout.test.mjs test/adapter-contract.test.mjs test/adapters.test.mjs test/adapter-conformance.test.mjs test/builtin-adapter-conformance.test.mjs test/adapter-acceptance-gate.test.mjs test/user-config.test.mjs test/intent-map-v1.test.mjs test/task-graph-contract.test.mjs test/task-graph-scheduler.test.mjs test/task-graph-persistence.test.mjs test/task-graph-intent-scheduler.test.mjs test/runtime-events.test.mjs test/task-graph-acceptance-gate.test.mjs test/release-workflow.test.mjs",
+    "test:core": "node --test --test-concurrency=4 test/action-gateway.test.mjs test/workspace.test.mjs test/inspector.test.mjs test/cli-modules.test.mjs test/documentation.test.mjs test/repository-layout.test.mjs test/adapter-contract.test.mjs test/adapters.test.mjs test/adapter-conformance.test.mjs test/builtin-adapter-conformance.test.mjs test/adapter-acceptance-gate.test.mjs test/user-config.test.mjs test/intent-map-v1.test.mjs test/task-graph-contract.test.mjs test/task-graph-scheduler.test.mjs test/task-graph-persistence.test.mjs test/task-graph-intent-scheduler.test.mjs test/runtime-events.test.mjs test/task-graph-acceptance-gate.test.mjs test/release-workflow.test.mjs",
     "sync:llms": "node scripts/sync-llms.mjs",
     "check:llms": "node scripts/sync-llms.mjs --check",
     "check": "node bin/coordinate-agents.mjs --help && npm run check:llms && npm test",

--- a/skills/coordinate-agents/scripts/runtime-services.mjs
+++ b/skills/coordinate-agents/scripts/runtime-services.mjs
@@ -29,7 +29,7 @@ import {
   runtimeTaskGraphReview,
   runtimeTaskGraphDispatch,
   runtimeTaskOperation,
-} from '../../../bin/coordinate-agents.mjs';
+} from '../../../lib/cli-core.mjs';
 import {
   runtimeSessionClose,
   runtimeSessionInspect,

--- a/test/action-gateway.test.mjs
+++ b/test/action-gateway.test.mjs
@@ -1,0 +1,317 @@
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import http from 'node:http';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawn, spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { startWorkspace, startInspector } from '../inspector/server/server.mjs';
+import { ACTION_ENDPOINT } from '../inspector/server/action-gateway.mjs';
+
+const root = process.cwd();
+const cli = join(root, 'bin', 'coordinate-agents.mjs');
+const busTool = join(root, 'skills', 'coordinate-agents', 'scripts', 'agent-bus.mjs');
+
+function git(repositoryRoot, args) {
+  const result = spawnSync('git', ['-C', repositoryRoot, ...args], { encoding: 'utf8', windowsHide: true });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  return result.stdout.trim();
+}
+
+function repository() {
+  const repositoryRoot = mkdtempSync(join(tmpdir(), 'coordinate-agents-gateway-'));
+  git(repositoryRoot, ['init', '-q']);
+  git(repositoryRoot, ['config', 'user.email', 'gateway-test@example.com']);
+  git(repositoryRoot, ['config', 'user.name', 'Gateway Test']);
+  writeFileSync(join(repositoryRoot, 'README.md'), '# Gateway fixture\n', 'utf8');
+  git(repositoryRoot, ['add', '-A']);
+  git(repositoryRoot, ['commit', '-qm', 'chore: gateway fixture baseline']);
+  const init = spawnSync(process.execPath, [busTool, 'init', '--root', repositoryRoot], { encoding: 'utf8', windowsHide: true });
+  assert.equal(init.status, 0, init.stderr || init.stdout);
+  return realpathSync(repositoryRoot);
+}
+
+async function freePort() {
+  const server = createServer();
+  await new Promise((resolvePromise, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolvePromise);
+  });
+  const port = server.address().port;
+  await new Promise(resolvePromise => server.close(resolvePromise));
+  return port;
+}
+
+async function closeServer(server) {
+  server.closeAllConnections?.();
+  await new Promise(resolvePromise => server.close(resolvePromise));
+}
+
+function snapshotTasks(directory) {
+  const tasks = join(directory, '.agent-bus', 'tasks');
+  if (!existsSync(tasks)) return [];
+  return readdirSync(tasks).filter(name => name.endsWith('.json')).sort();
+}
+
+function rawPost(port, { path = ACTION_ENDPOINT, body = '', headers = {} }) {
+  return new Promise((resolvePromise, reject) => {
+    const req = http.request({
+      host: '127.0.0.1',
+      port,
+      path,
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body), ...headers },
+    }, response => {
+      const chunks = [];
+      response.on('data', chunk => chunks.push(chunk));
+      response.on('end', () => resolvePromise({ status: response.statusCode, headers: response.headers, body: Buffer.concat(chunks).toString('utf8') }));
+    });
+    req.on('error', reject);
+    req.end(body);
+  });
+}
+
+async function capabilityFromPage(url) {
+  const page = await (await fetch(url)).text();
+  const meta = page.match(/name="coordinate-agents-capability" content="([^"]+)"/);
+  return meta ? meta[1] : null;
+}
+
+test('action gateway rejects unauthorized, malformed, disallowed, and unsafe requests before Runtime side effects', async () => {
+  const repositoryRoot = repository();
+  const started = await startWorkspace({ root: repositoryRoot, port: 0, maxBodyBytes: 4096 });
+  const { url, port, capability } = started;
+  try {
+    assert.ok(capability);
+    const base = url;
+    const endpoint = `${base}${ACTION_ENDPOINT}`;
+    const post = (body, headers = {}) => fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: typeof body === 'string' ? body : JSON.stringify(body),
+    });
+    const readError = async response => {
+      const payload = await response.json();
+      return { status: response.status, ...payload };
+    };
+
+    // Missing and incorrect capability.
+    let result = await readError(await post({ action: 'taskCreate', params: { title: 'x' } }));
+    assert.equal(result.status, 401);
+    assert.equal(result.error.code, 'ACTION_CAPABILITY_REQUIRED');
+    result = await readError(await post({ action: 'taskCreate', params: { title: 'x' } }, { 'x-coordinate-agents-capability': 'wrong-capability' }));
+    assert.equal(result.status, 401);
+
+    // Disallowed cross-origin request.
+    result = await readError(await post({ action: 'taskCreate', params: { title: 'x' } }, {
+      'x-coordinate-agents-capability': capability,
+      Origin: 'https://evil.example',
+    }));
+    assert.equal(result.status, 403);
+    assert.equal(result.error.code, 'ACTION_ORIGIN_DISALLOWED');
+
+    // Disallowed Host header.
+    const raw = await rawPost(port, {
+      body: JSON.stringify({ action: 'taskCreate', params: { title: 'x' } }),
+      headers: { 'x-coordinate-agents-capability': capability, Host: 'evil.example' },
+    });
+    assert.equal(raw.status, 403);
+    assert.match(raw.body, /ACTION_HOST_DISALLOWED/);
+
+    // Non-JSON content type.
+    result = await readError(await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'x-coordinate-agents-capability': capability, 'Content-Type': 'text/plain' },
+      body: 'hello',
+    }));
+    assert.equal(result.status, 415);
+    assert.equal(result.error.code, 'ACTION_CONTENT_TYPE_INVALID');
+
+    // Oversized body.
+    const oversized = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-coordinate-agents-capability': capability },
+      body: JSON.stringify({ action: 'taskCreate', params: { title: 'x'.repeat(8192) } }),
+    });
+    assert.equal(oversized.status, 413);
+
+    // Malformed and empty JSON bodies.
+    result = await readError(await post('{not json', { 'x-coordinate-agents-capability': capability }));
+    assert.equal(result.status, 400);
+    assert.equal(result.error.code, 'ACTION_BODY_INVALID');
+    result = await readError(await post('', { 'x-coordinate-agents-capability': capability }));
+    assert.equal(result.status, 400);
+
+    // Unknown action and unknown parameters.
+    result = await readError(await post({ action: 'noSuchAction', params: {} }, { 'x-coordinate-agents-capability': capability }));
+    assert.equal(result.status, 404);
+    assert.equal(result.error.code, 'ACTION_NOT_ALLOWED');
+    result = await readError(await post({ action: 'taskCreate', params: { title: 'x', sneaky: true } }, { 'x-coordinate-agents-capability': capability }));
+    assert.equal(result.status, 400);
+    assert.equal(result.error.code, 'ACTION_PARAMS_INVALID');
+
+    // Mismatched root is rejected; the bound root is accepted and honored.
+    result = await readError(await post({ action: 'taskCreate', params: { title: 'x', root: 'C:/somewhere/else' } }, { 'x-coordinate-agents-capability': capability }));
+    assert.equal(result.status, 403);
+    assert.equal(result.error.code, 'ACTION_ROOT_MISMATCH');
+    result = await readError(await post({ action: 'taskCreate', params: { title: 'Bound root ok', root: repositoryRoot } }, { 'x-coordinate-agents-capability': capability }));
+    assert.equal(result.status, 200);
+    assert.equal(result.ok, true);
+
+    // Every rejection above is side-effect free: only the one deliberate
+    // bound-root action may have created a durable Task record.
+    const tasks = snapshotTasks(repositoryRoot);
+    assert.equal(tasks.length, 1, 'Rejected gateway requests must not create Tasks');
+    assert.match(tasks[0], /^task-[0-9a-f-]+\.json$/);
+  } finally {
+    await closeServer(started.server);
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('guarded actions preserve Runtime identity, correlation, canonical errors, and deterministic-id replay safety', async () => {
+  const repositoryRoot = repository();
+  const started = await startWorkspace({ root: repositoryRoot, port: 0 });
+  const base = started.url;
+  try {
+    const capability = await capabilityFromPage(base);
+    assert.ok(capability, 'Workspace page must carry the server-issued capability');
+    const post = (payload, correlationId) => fetch(`${base}${ACTION_ENDPOINT}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-coordinate-agents-capability': capability, ...(correlationId ? { 'x-correlation-id': correlationId } : {}) },
+      body: JSON.stringify(payload),
+    });
+
+    // Deterministic-id create is idempotent: the Runtime rejects replays with
+    // TASK_STATE_CONFLICT and a single durable Task record remains.
+    const first = await (await post({ action: 'taskCreate', params: { title: 'Replay safe', id: 'task-gateway-replay' } }, 'corr-1')).json();
+    assert.equal(first.ok, true);
+    assert.equal(first.command, 'task.create');
+    assert.equal(first.action, 'taskCreate');
+    assert.equal(first.correlation, 'corr-1');
+    assert.equal(first.task?.id || first.id, 'task-gateway-replay');
+
+    const replay = await (await post({ action: 'taskCreate', params: { title: 'Replay safe', id: 'task-gateway-replay' } }, 'corr-1')).json();
+    assert.equal(replay.ok, false);
+    assert.equal(replay.command, 'task.create');
+    assert.equal(replay.error.code, 'TASK_STATE_CONFLICT');
+    assert.equal(replay.error.recoverable, true);
+    assert.equal(replay.correlation, 'corr-1');
+
+    const tasks = snapshotTasks(repositoryRoot);
+    assert.deepEqual(tasks, ['task-gateway-replay.json']);
+
+    // Concurrent replays serialize through the Runtime: exactly one Task is
+    // durably created and one of the two calls reports the conflict.
+    const [concurrentA, concurrentB] = await Promise.all([
+      post({ action: 'taskCreate', params: { title: 'Concurrent', id: 'task-gateway-concurrent' } }, 'corr-2'),
+      post({ action: 'taskCreate', params: { title: 'Concurrent', id: 'task-gateway-concurrent' } }, 'corr-2'),
+    ]);
+    const results = [await concurrentA.json(), await concurrentB.json()];
+    const okCount = results.filter(item => item.ok === true).length;
+    const conflictCount = results.filter(item => item.ok === false && item.error?.code === 'TASK_STATE_CONFLICT').length;
+    assert.equal(okCount + conflictCount, 2);
+    assert.equal(okCount, 1, 'Exactly one concurrent create may succeed');
+    assert.ok(snapshotTasks(repositoryRoot).includes('task-gateway-concurrent.json'));
+
+    // Read actions expose the Runtime identity fields and canonical results.
+    const status = await (await post({ action: 'taskStatus', params: { taskId: 'task-gateway-replay' } }, 'corr-3')).json();
+    assert.equal(status.ok, true);
+    assert.equal(status.correlation, 'corr-3');
+
+    const inspect = await (await post({ action: 'taskInspect', params: { taskId: 'task-gateway-replay' } }, 'corr-4')).json();
+    assert.equal(inspect.ok, true);
+    assert.equal(inspect.command, 'task.inspect');
+
+    // Unknown Task ids surface canonical Runtime errors, not gateway noise.
+    const missing = await (await post({ action: 'taskStatus', params: { taskId: 'task-gateway-missing' } })).json();
+    assert.equal(missing.ok, false);
+    assert.equal(missing.error.code, 'TASK_NOT_FOUND');
+
+    // Graph validation routes to the shared Runtime contract: a valid DAG is
+    // accepted and an invalid DAG returns the canonical validation error
+    // without creating a graph, worktree, or event.
+    const validGraph = {
+      schemaVersion: 1,
+      parentTask: { id: 'task-gateway-parent', title: 'Parent', planner: 'codex', reviewer: 'codex' },
+      subtasks: [{ id: 'sub', implementer: 'antigravity', spec: 'Do it.', dependsOn: [] }],
+      maxConcurrency: 1,
+    };
+    const validated = await (await post({ action: 'taskGraphValidate', params: { graph: validGraph } }, 'corr-5')).json();
+    assert.equal(validated.ok, true);
+    const invalid = await (await post({ action: 'taskGraphValidate', params: { graph: { ...validGraph, subtasks: [] } } })).json();
+    assert.equal(invalid.ok, false);
+    assert.equal(invalid.error.code, 'TASK_GRAPH_INVALID');
+    assert.equal(existsSync(join(repositoryRoot, '.agent-bus', 'task-graphs', 'task-gateway-parent.json')), false);
+
+    // GET and SSE read paths stay compatible and side-effect free.
+    const tasksBefore = readdirSync(join(repositoryRoot, '.agent-bus', 'tasks')).sort();
+    await fetch(`${base}/api/tasks`);
+    await fetch(`${base}/api/events?limit=20`);
+    const tasksAfter = readdirSync(join(repositoryRoot, '.agent-bus', 'tasks')).sort();
+    assert.deepEqual(tasksBefore, tasksAfter);
+  } finally {
+    await closeServer(started.server);
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('action gateway results match the CLI JSON contract for the same operation', async () => {
+  const repositoryRoot = repository();
+  const started = await startWorkspace({ root: repositoryRoot, port: 0 });
+  const base = started.url;
+  try {
+    const capability = await capabilityFromPage(base);
+    const cliResult = spawnSync(process.execPath, [cli, 'task', 'create', '--root', repositoryRoot, '--title', 'CLI parity', '--id', 'task-gateway-cli', '--json'], {
+      cwd: root,
+      encoding: 'utf8',
+      windowsHide: true,
+    });
+    assert.equal(cliResult.status, 0, cliResult.stderr);
+    const cliPayload = JSON.parse(cliResult.stdout);
+    assert.equal(cliPayload.ok, true);
+    assert.equal(cliPayload.command, 'task.create');
+
+    const gatewayResponse = await fetch(`${base}${ACTION_ENDPOINT}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-coordinate-agents-capability': capability },
+      body: JSON.stringify({ action: 'taskCreate', params: { title: 'CLI parity', id: 'task-gateway-gw' } }),
+    });
+    const gatewayPayload = await gatewayResponse.json();
+    assert.equal(gatewayPayload.ok, true);
+    assert.equal(gatewayPayload.command, cliPayload.command);
+    assert.equal(typeof gatewayPayload.ok, typeof cliPayload.ok);
+    assert.equal(typeof gatewayPayload.error, typeof cliPayload.error);
+  } finally {
+    await closeServer(started.server);
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('inspector compatibility mode keeps all non-GET traffic rejected with Allow: GET', async () => {
+  const repositoryRoot = repository();
+  const started = await startInspector({ root: repositoryRoot, port: 0 });
+  try {
+    assert.equal(started.actionEndpoint, null);
+    for (const endpoint of ['/api/tasks', '/api/repository', ACTION_ENDPOINT]) {
+      const response = await fetch(`${started.url}${endpoint}`, { method: 'POST' });
+      assert.equal(response.status, 405, `${endpoint} must stay read-only in Inspector mode`);
+      assert.equal(response.headers.get('allow'), 'GET');
+    }
+    const page = await (await fetch(started.url)).text();
+    assert.match(page, /Coordinate Agents Inspector/);
+    assert.equal(page.includes('coordinate-agents-capability'), false);
+  } finally {
+    await closeServer(started.server);
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What

Implements #46 (P0-01): a narrow guarded action boundary on the Workspace server. A single `POST /api/action` endpoint routes an explicit allow-list of operations to the shared `runtime-services.mjs` map used by CLI and MCP. The repository root is bound to the server process; every non-GET request requires a server-issued per-launch capability, loopback Host/Origin, bounded `application/json` body, allow-listed action name, and schema-valid params whose optional `root` must equal the bound root. Rejections occur before any Runtime side effect.

## Security and replay model

- Per-launch capability injected into the Workspace page as `meta[name=coordinate-agents-capability]`; validated with a timing-safe compare. Every other path remains a read-only GET surface (405 + `Allow: GET`).
- First allow-list (`taskCreate`, `taskStatus`, `taskInspect`, `taskGraphStatus`, `taskGraphInspect`, `taskGraphPlan`, `taskGraphValidate`, `recoverInspect`) deliberately excludes process-launching, Session-input, stop, cleanup, integration, and review operations that require explicit UI confirmation in later tickets (#50-#52).
- Responses preserve Runtime identity fields (`ok`, `command`), canonical error codes, recoverability, bounded/redacted diagnostics, and a `correlation` value; replay/concurrency safety relies on existing Runtime locks and deterministic-id deduplication (`taskCreate` replays return `TASK_STATE_CONFLICT`, exactly one durable record).
- `runtime-services.mjs` now imports canonical wrappers from `lib/cli-core.mjs` instead of the `bin` entry point, removing a top-level-await import cycle that deadlocked CLI-started Workspace processes.

## Compatibility

- GET/SSE read paths and the compatibility `inspector` command are unchanged (Inspector mode rejects every non-GET path).
- `test/action-gateway.test.mjs` adds focused HTTP tests: authorization failures, Origin/Host policy, content-type/body bounds, malformed JSON, unknown action, root mismatch, side-effect-free rejections, deterministic-id replay, concurrent creates, CLI/MCP result parity, and Inspector-mode 405s.
- Full `npm run test:core` (115 tests, ~21s) and MCP server tests pass.

Closes #46