### PR TITLE
feat(web): configure heterogeneous local Agents from the Workspace (#48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,8 @@ The Workspace binds exactly one Git repository and shows its identity (branch,
 HEAD, remote), Tasks and Task Graph parents, Agents, Sessions, recent Runtime
 events, and bounded Task/Graph detail. Overview and refresh are strictly
 read-only; a guarded `POST /api/action` endpoint routes an explicit allow-list
-of Runtime operations through the same services as CLI and MCP. The
+of Runtime operations — including transactional Agent discovery/configuration —
+through the same services as CLI and MCP. The
 `inspector` command stays available as the compatible read-only UI over the
 same GET contracts. The browser is never the source of truth. Learn more in
 [Inspector & Web Workspace](./docs/inspector.md) and

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -142,9 +142,9 @@ npx @hogancv/coordinate-agents@latest web --port 3000
 Workspace 在启动时绑定唯一一个 Git 仓库，展示其身份（分支、HEAD、远程）、
 普通 Task 与 Task Graph parent、Agents、Sessions、近期 Runtime 事件以及有界
 的 Task/Graph 详情。总览与刷新严格只读；受保护的 `POST /api/action` 端点把
-显式白名单内的 Runtime 操作路由到与 CLI/MCP 相同的服务。`inspector` 命令
-继续作为同一套 GET 契约上的兼容只读界面保留。浏览器页面始终不是事实源。
-详见 [Inspector 与 Web Workspace](./docs/inspector.md)
+显式白名单内的 Runtime 操作——包括事务式 Agent 发现与配置——路由到与
+CLI/MCP 相同的服务。`inspector` 命令继续作为同一套 GET 契约上的兼容只读
+界面保留。浏览器页面始终不是事实源。详见 [Inspector 与 Web Workspace](./docs/inspector.md)
 与 [Event Journal](./docs/event-journal.md)。
 
 ## Standalone npm Runtime

--- a/docs/inspector.md
+++ b/docs/inspector.md
@@ -70,8 +70,9 @@ the guarded action endpoint below. Stop it with `Ctrl-C`.
 The Workspace exposes exactly one additive, guarded action endpoint for later
 controls: `POST /api/action`. It routes an explicit allow-list of structured
 operations to the same shared Runtime services used by CLI and MCP
-(`taskCreate`, `taskStatus`, `taskInspect`, `taskGraphStatus`,
-`taskGraphInspect`, `taskGraphPlan`, `taskGraphValidate`, `recoverInspect`).
+(`setupDiscover`, `setupConfigure`, `taskCreate`, `taskStatus`, `taskInspect`,
+`taskGraphStatus`, `taskGraphInspect`, `taskGraphPlan`, `taskGraphValidate`,
+`recoverInspect`).
 The gateway never shells out, parses CLI output, proxies MCP, accepts an
 arbitrary operation name, or lets a request choose a different repository root.
 
@@ -116,6 +117,16 @@ The Workspace overview opens with the **bound repository** identity (repository
 name, current branch, HEAD commit, latest commit subject, origin remote, and the
 canonical bound root path), followed by:
 
+- **Agents** — the Agent setup panel shows installed coding CLI detection and
+  the Adapter registry on demand (manual Discover, no background scanning), with
+  distinct Agent / Adapter / executable identity and command-source badges
+  (project > user > adapter-default). A bounded form configures a project Agent,
+  Adapter, exact executable command, and workflow role through the guarded
+  `setupConfigure` transaction (validation first, atomic rollback on failure).
+  Configured runtime Agents show adapter, roles, status, and queue depth. The
+  panel states that loaded local Adapter modules are trusted local code, that
+  configuration grants no browser filesystem/process bypass, and that no
+  credential or secret is rendered or persisted.
 - **Tasks** — current Task title, status, round, and update time for ordinary Tasks, plus distinguishable Task Graph parent entries with subtask count, max concurrency, and subtask state tallies.
 - **Agent flow** — the configured Planner → Implementer → Reviewer topology,
   including each Agent's current Agent Bus state.

--- a/inspector/server/action-gateway.mjs
+++ b/inspector/server/action-gateway.mjs
@@ -36,13 +36,31 @@ const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
 const CORRELATION_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
 
 /**
- * First explicit Workspace action allow-list. Every entry maps to one shared
- * Runtime operation and is deliberately free of process-launching,
- * Session-input, stop, cleanup, integration, and review side effects; those
- * operations require explicit UI confirmation and arrive in later tickets.
- * `taskCreate` keeps its deterministic-id conflict as the replay guard.
+ * Workspace action allow-list. Every entry maps to one shared Runtime
+ * operation. Discovery is read-only; `setupConfigure` is the transactional
+ * project Agent/role configuration path and is deliberately the only
+ * configuration-write action in this slice. Process-launching, Session-input,
+ * stop, cleanup, integration, and review operations require explicit UI
+ * confirmation and arrive in later tickets. `taskCreate` keeps its
+ * deterministic-id conflict as the replay guard.
  */
 const ACTION_DEFINITIONS = Object.freeze({
+  setupDiscover: {
+    operation: 'setupDiscover',
+    command: 'setup',
+    params: {},
+  },
+  setupConfigure: {
+    operation: 'setupConfigure',
+    command: 'setup.configure',
+    params: {
+      agent: { type: 'string', required: true, max: 64 },
+      command: { type: 'string', required: true, max: 512 },
+      adapter: { type: 'string', max: 128 },
+      role: { type: 'string', max: 32 },
+      args: { type: 'array', max: 64, itemMax: 512 },
+    },
+  },
   taskCreate: {
     operation: 'taskCreate',
     command: 'task.create',
@@ -197,6 +215,11 @@ function validateParams(definition, params) {
         return `Parameter ${key} must be an object.`;
       }
       if (Buffer.byteLength(JSON.stringify(value)) > rule.max) return `Parameter ${key} exceeds the supported size limit.`;
+    } else if (rule.type === 'array') {
+      if (!Array.isArray(value)) return `Parameter ${key} must be an array.`;
+      if (value.length > rule.max || value.some(item => typeof item !== 'string' || item.length > (rule.itemMax || 512))) {
+        return `Parameter ${key} exceeds the supported size limit.`;
+      }
     }
   }
   return null;

--- a/inspector/web-workspace/app.js
+++ b/inspector/web-workspace/app.js
@@ -17,6 +17,7 @@ const state = {
   sessions: [],
   events: [],
   repository: null,
+  discovery: null,
   selectedTask: null,
   selectedSubtask: null,
   graphDetail: null,
@@ -51,6 +52,9 @@ const elements = Object.fromEntries([
   'graph-frontier', 'graph-conflicts', 'graph-integration', 'repository',
   'repo-name', 'repo-branch', 'repo-facts', 'graph-map-region', 'graph-map',
   'graph-node-detail', 'graph-map-note', 'graph-legend',
+  'discover-agents', 'agents-discovery', 'agent-configure', 'cfg-agent',
+  'cfg-adapter', 'cfg-command', 'cfg-role', 'apply-agent', 'agent-status',
+  'agent-id-options', 'configured-agents',
 ].map(id => [id, document.getElementById(id)]));
 
 function escapeHtml(value) {
@@ -130,6 +134,169 @@ function renderRepository() {
   facts.push(`<div class="repo-fact repo-fact-wide"><span>Bound root</span><code>${escapeHtml(repository.root || '—')}</code></div>`);
   if (repository.error) facts.push(`<div class="repo-fact repo-fact-wide"><span>Repository facts</span><code>${escapeHtml(repository.error)}</code></div>`);
   elements['repo-facts'].innerHTML = facts.join('');
+}
+
+function commandSourceClass(source) {
+  const value = `${source || ''}`.toLowerCase();
+  if (value.startsWith('project')) return 'project';
+  if (value.startsWith('user')) return 'user';
+  return 'adapter';
+}
+
+function setAgentStatus(message, kind = 'info') {
+  const element = elements['agent-status'];
+  element.textContent = message;
+  element.className = `agent-status ${kind}`;
+}
+
+function escapeAgent(value) {
+  return escapeHtml(value ?? '');
+}
+
+function fillConfigureForm(entry) {
+  const agentId = entry.configuredAgent || entry.agent || entry.command || '';
+  elements['cfg-agent'].value = agentId;
+  elements['cfg-command'].value = entry.command || '';
+  if (entry.adapter) elements['cfg-adapter'].value = entry.adapter;
+  elements['cfg-role'].value = 'implementer';
+  elements['agent-configure'].scrollIntoView({ behavior: 'smooth', block: 'center' });
+  elements['cfg-agent'].focus();
+}
+
+function renderAgentsDiscovery(snapshot) {
+  if (!snapshot) {
+    elements['agents-discovery'].innerHTML = '<div class="empty-state">No discovery snapshot available.</div>';
+    return;
+  }
+  const agents = Array.isArray(snapshot.agents) ? snapshot.agents : [];
+  const adapters = Array.isArray(snapshot.adapters) ? snapshot.adapters : [];
+  const options = [];
+  for (const agent of agents) {
+    const identity = agent.configuredAgent || agent.command || '';
+    if (identity) options.push(`<option value="${escapeHtml(identity)}"></option>`);
+  }
+  elements['agent-id-options'].innerHTML = options.join('');
+
+  const agentRows = agents.map(agent => {
+    const available = agent.available === true;
+    const identity = agent.configuredAgent || agent.command || '?';
+    return `<article class="agent-row">
+      <div class="agent-row-main">
+        <strong>${escapeAgent(identity)}</strong>
+        <span class="status-pill ${available ? 'idle' : 'error'}">${available ? 'available' : 'unavailable'}</span>
+        ${agent.configured ? '<span class="history-label">configured</span>' : ''}
+        ${agent.adapter ? `<span class="agent-muted">adapter ${escapeAgent(agent.adapter)}</span>` : ''}
+        ${agent.command ? `<span class="agent-muted">command <code>${escapeAgent(agent.command)}</code></span>` : ''}
+      </div>
+      <div class="agent-row-detail">${escapeAgent(agent.details || agent.code || '')}</div>
+      <button class="button ghost agent-fill" type="button" data-json="${escapeHtml(JSON.stringify({ agent: identity, command: agent.command, adapter: agent.adapter || '' }))}">Configure this command</button>
+    </article>`;
+  }).join('') || '<div class="empty-state">No coding CLIs detected on this machine.</div>';
+
+  const adapterBlocks = adapters.map(adapter => {
+    const capabilities = Object.entries(adapter.capabilities || {})
+      .filter(([, value]) => value === true)
+      .map(([key]) => escapeHtml(key))
+      .join(', ');
+    const configured = (adapter.configuredAgents || []).map(item => `
+      <div class="configured-agent-row">
+        <code>${escapeAgent(item.id)}</code>
+        <span class="agent-muted">adapter ${escapeAgent(item.adapter || adapter.id)}</span>
+        <code>${escapeAgent(item.command || '—')}</code>
+        <span class="source-badge ${commandSourceClass(item.commandSource)}">${escapeAgent(item.commandSource || 'adapter-default')}</span>
+      </div>`).join('') || '<span class="agent-muted">not configured in this project</span>';
+    return `<article class="adapter-card">
+      <div class="adapter-card-heading">
+        <strong>${escapeAgent(adapter.id)}</strong>
+        <span class="history-label">${adapter.builtin ? 'built-in' : 'registered local adapter'}</span>
+        <span class="agent-muted">contract v${escapeAgent(adapter.contractVersion)}</span>
+      </div>
+      <div class="agent-muted">${capabilities || 'no capabilities'}</div>
+      <div class="configured-agents-list">${configured}</div>
+    </article>`;
+  }).join('');
+
+  elements['agents-discovery'].innerHTML = `
+    <div class="discovery-grid">
+      <div><h3>Detected coding CLIs</h3><div class="discovery-list">${agentRows}</div></div>
+      <div><h3>Adapters & command sources</h3><div class="discovery-list">${adapterBlocks || '<div class="empty-state">No adapters registered.</div>'}</div></div>
+    </div>`;
+  elements['agents-discovery'].querySelectorAll('.agent-fill').forEach(button => {
+    button.addEventListener('click', () => {
+      try { fillConfigureForm(JSON.parse(button.dataset.json)); } catch { /* ignore malformed presets */ }
+    });
+  });
+}
+
+function renderConfiguredAgents(agents) {
+  const list = Array.isArray(agents) ? agents : [];
+  if (list.length === 0) {
+    elements['configured-agents'].innerHTML = '<div class="empty-state">No Agents are registered in this repository yet.</div>';
+    return;
+  }
+  elements['configured-agents'].innerHTML = list.map(agent => `
+    <article class="configured-agent">
+      <div class="configured-agent-head">
+        <strong>${escapeAgent(agent.id)}</strong>
+        <span class="status-pill ${statusClass(agent.status)}">${escapeAgent(statusLabel(agent.status))}</span>
+      </div>
+      <div class="configured-agent-facts">
+        <span>adapter <code>${escapeAgent(agent.adapter || '—')}</code></span>
+        <span>roles <code>${escapeAgent(agent.roles?.join(', ') || 'unassigned')}</code></span>
+        <span>queue ${escapeAgent(agent.queue?.new || 0)} new · ${escapeAgent(agent.queue?.processing || 0)} processing</span>
+      </div>
+      ${agent.lastActivity ? `<div class="agent-muted">last activity ${escapeAgent(agent.lastActivity)}</div>` : ''}
+    </article>`).join('');
+}
+
+async function discoverAgents() {
+  setAgentStatus('Discovering local coding CLIs…');
+  try {
+    const { status, payload } = await postAction('setupDiscover', {});
+    if (status !== 200 || payload?.ok !== true) {
+      const code = payload?.error?.code || `HTTP ${status}`;
+      elements['agents-discovery'].innerHTML = `<div class="empty-state error-state">Discovery failed (${escapeHtml(code)}): ${escapeHtml(payload?.error?.message || 'unknown error')}</div>`;
+      setAgentStatus('Discovery failed.', 'error');
+      return;
+    }
+    state.discovery = payload;
+    renderAgentsDiscovery(payload);
+    setAgentStatus('Discovery complete. Configure a command below or pick “Configure this command”.', 'ok');
+  } catch (error) {
+    setAgentStatus(`Discovery request failed: ${error.message}`, 'error');
+  }
+}
+
+async function applyAgentConfigure(event) {
+  event.preventDefault();
+  const params = {
+    agent: elements['cfg-agent'].value.trim(),
+    adapter: elements['cfg-adapter'].value,
+    command: elements['cfg-command'].value.trim(),
+    role: elements['cfg-role'].value,
+  };
+  if (!params.agent || !params.command) {
+    setAgentStatus('Agent ID and executable command are required.', 'error');
+    return;
+  }
+  setAgentStatus('Applying configuration…');
+  elements['apply-agent'].disabled = true;
+  try {
+    const { status, payload } = await postAction('setupConfigure', params);
+    if (status !== 200 || payload?.ok !== true) {
+      const error = payload?.error || {};
+      setAgentStatus(`Configuration failed: ${error.code || `HTTP ${status}`} — ${error.message || 'unknown error'}${error.details ? ` (${error.details})` : ''}`, 'error');
+      return;
+    }
+    const configured = payload.agent || {};
+    setAgentStatus(`Configured ${configured.id} (${configured.adapter}) → ${configured.command} [${configured.commandSource}] · workflow ${Object.keys(payload.workflow || {}).join(', ')}`, 'ok');
+    await discoverAgents();
+    await refresh();
+  } catch (error) {
+    setAgentStatus(`Configuration request failed: ${error.message}`, 'error');
+  } finally {
+    elements['apply-agent'].disabled = false;
+  }
 }
 
 function agentFor(id) {
@@ -501,6 +668,7 @@ async function refresh() {
     state.events = events;
     renderTasks();
     renderAgentFlow();
+    renderConfiguredAgents(state.agents);
     renderSessions();
     renderEvents();
     if (state.selectedTask) {
@@ -519,6 +687,8 @@ async function refresh() {
 
 elements['refresh-button'].addEventListener('click', refresh);
 elements['close-detail'].addEventListener('click', closeDetail);
+elements['discover-agents'].addEventListener('click', discoverAgents);
+elements['agent-configure'].addEventListener('submit', applyAgentConfigure);
 window.addEventListener('keydown', event => {
   if (event.key === 'Escape') closeGraphMap();
 });

--- a/inspector/web-workspace/index.html
+++ b/inspector/web-workspace/index.html
@@ -35,6 +35,45 @@
         <div id="repo-facts" class="repo-facts" aria-live="polite"></div>
       </section>
 
+      <section id="agents-panel" class="panel agents-panel">
+        <div class="section-heading">
+          <div>
+            <p class="eyebrow">AGENT SETUP</p>
+            <h2>Agents</h2>
+          </div>
+          <button id="discover-agents" class="button" type="button">Discover CLIs</button>
+        </div>
+        <p class="agents-note">Configure a local coding Agent, its Adapter, and its exact executable
+          command. Resolution order stays project command → user command → Adapter default. Detection
+          runs only when you click Discover; the Workspace never performs automatic login, remote lookup,
+          package download, or arbitrary process launch.</p>
+        <div id="agents-discovery" class="agents-discovery" aria-live="polite">
+          <div class="empty-state">Click “Discover CLIs” to inspect installed coding CLIs and registered Adapters.</div>
+        </div>
+        <form id="agent-configure" class="agent-form" novalidate>
+          <label>Agent ID<input id="cfg-agent" name="agent" list="agent-id-options" maxlength="64" placeholder="e.g. codex / antigravity" required></label>
+          <datalist id="agent-id-options"></datalist>
+          <label>Adapter<select id="cfg-adapter" name="adapter">
+            <option value="codex-cli">codex-cli (built-in)</option>
+            <option value="antigravity-cli">antigravity-cli (built-in)</option>
+            <option value="generic-cli">generic-cli</option>
+          </select></label>
+          <label>Executable command<input id="cfg-command" name="command" maxlength="512" placeholder="exact command, e.g. agy-proxy" required></label>
+          <label>Workflow role<select id="cfg-role" name="role">
+            <option value="implementer">implementer</option>
+            <option value="planner">planner</option>
+            <option value="reviewer">reviewer</option>
+          </select></label>
+          <button id="apply-agent" class="button" type="submit">Apply configuration</button>
+          <span id="agent-status" class="agent-status" aria-live="polite"></span>
+        </form>
+        <h3>Configured runtime agents</h3>
+        <div id="configured-agents" class="configured-agents" aria-live="polite"></div>
+        <p class="agents-scope-note">Only explicitly registered or loaded local Adapter modules are treated
+          as trusted local code; configuring an Agent grants no browser filesystem or process sandbox
+          bypass. The Workspace never renders or persists credentials, tokens, cookies, or secrets.</p>
+      </section>
+
       <section class="hero-grid">
         <div class="hero-card">
           <div class="section-heading">

--- a/inspector/web-workspace/styles.css
+++ b/inspector/web-workspace/styles.css
@@ -235,3 +235,44 @@ h3 { margin-bottom: 1rem; color: var(--muted); font-size: .74rem; letter-spacing
 .graph-node-detail .graph-dependencies { margin-bottom: .7rem; }
 .graph-node-detail .graph-node-meta { margin-bottom: .7rem; }
 .graph-node-detail .graph-facts { grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+
+/* Agents setup panel */
+.agents-panel .section-heading { margin-bottom: .5rem; }
+.agents-note { margin-bottom: 1rem; color: var(--muted); font-size: .76rem; line-height: 1.5; max-width: 72ch; }
+.agents-discovery { margin-bottom: 1.1rem; }
+.discovery-grid { display: grid; grid-template-columns: minmax(0, 1.1fr) minmax(320px, .9fr); gap: 1rem; }
+.discovery-list { display: grid; gap: .6rem; }
+.agent-row, .adapter-card { padding: .8rem; border: 1px solid var(--line); border-radius: .7rem; background: rgba(255, 255, 255, .025); }
+.agent-row-main { display: flex; flex-wrap: wrap; align-items: center; gap: .5rem; }
+.agent-row-main strong { font-size: .9rem; }
+.agent-row-detail { margin: .4rem 0; color: var(--muted); font-size: .72rem; overflow-wrap: anywhere; }
+.agent-muted { color: var(--muted); font-size: .72rem; }
+.agent-muted code { color: var(--text); }
+.agent-fill { margin-top: .4rem; padding: .3rem .6rem; font-size: .7rem; }
+.adapter-card-heading { display: flex; flex-wrap: wrap; align-items: center; gap: .5rem; margin-bottom: .3rem; }
+.configured-agents-list { display: grid; gap: .25rem; margin-top: .5rem; }
+.configured-agent-row { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem .6rem; font-size: .72rem; }
+.configured-agent-row code { color: var(--text); }
+.source-badge { padding: .1rem .4rem; border-radius: 999px; font-size: .6rem; font-weight: 700; letter-spacing: .04em; text-transform: uppercase; }
+.source-badge.project { color: var(--green); background: rgba(87, 217, 154, .12); }
+.source-badge.user { color: var(--accent); background: rgba(140, 169, 255, .14); }
+.source-badge.adapter { color: var(--muted); background: rgba(160, 180, 230, .1); }
+.agent-form { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: .7rem; padding: 1rem; border: 1px solid var(--line); border-radius: .8rem; background: rgba(255, 255, 255, .02); margin-bottom: 1.2rem; }
+.agent-form label { display: flex; flex-direction: column; gap: .35rem; color: var(--muted); font-size: .68rem; font-weight: 700; letter-spacing: .05em; text-transform: uppercase; }
+.agent-form input, .agent-form select { padding: .5rem .6rem; border: 1px solid var(--line); border-radius: .5rem; color: var(--text); background: var(--panel-strong); font: .8rem inherit; }
+.agent-form input:focus-visible, .agent-form select:focus-visible { outline: 2px solid rgba(140, 169, 255, .5); border-color: var(--accent); }
+.agent-form .button { align-self: end; }
+.agent-status { grid-column: 1 / -1; font-size: .76rem; overflow-wrap: anywhere; }
+.agent-status.ok { color: var(--green); }
+.agent-status.error { color: var(--red); }
+.configured-agents { display: grid; gap: .6rem; }
+.configured-agent { padding: .8rem; border: 1px solid var(--line); border-radius: .7rem; background: rgba(255, 255, 255, .025); }
+.configured-agent-head { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-bottom: .45rem; }
+.configured-agent-head strong { font-size: .9rem; }
+.configured-agent-facts { display: flex; flex-wrap: wrap; gap: .3rem 1rem; color: var(--muted); font-size: .74rem; }
+.configured-agent-facts code { color: var(--text); }
+.agents-scope-note { margin: .9rem 0 0; padding: .7rem .9rem; border: 1px solid rgba(244, 201, 107, .25); border-radius: .6rem; color: var(--muted); background: rgba(244, 201, 107, .06); font-size: .72rem; line-height: 1.5; }
+
+@media (max-width: 900px) {
+  .discovery-grid { grid-template-columns: 1fr; }
+}

--- a/test/action-gateway.test.mjs
+++ b/test/action-gateway.test.mjs
@@ -2,7 +2,9 @@ import assert from 'node:assert/strict';
 import { createServer } from 'node:http';
 import http from 'node:http';
 import {
+  chmodSync,
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
@@ -11,7 +13,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { delimiter, join } from 'node:path';
 import { spawn, spawnSync } from 'node:child_process';
 import test from 'node:test';
 import { startWorkspace, startInspector } from '../inspector/server/server.mjs';
@@ -313,5 +315,133 @@ test('inspector compatibility mode keeps all non-GET traffic rejected with Allow
   } finally {
     await closeServer(started.server);
     rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+function writeFakeExecutable(directory, name) {
+  if (process.platform === 'win32') {
+    // A .cmd wrapper is only a safe entrypoint with a .js/.cjs sibling; tests
+    // configure the absolute .cmd path so detection does not depend on where.exe.
+    writeFileSync(join(directory, `${name}.cmd`), '@echo off\r\nnode "%~dp0${name}.js" %*\r\n', 'utf8');
+    writeFileSync(join(directory, `${name}.js`), 'console.log("1.0.0");\n', 'utf8');
+    return join(directory, `${name}.cmd`);
+  }
+  const path = join(directory, name);
+  writeFileSync(path, '#!/bin/sh\necho 1.0.0\n', 'utf8');
+  chmodSync(path, 0o755);
+  return path;
+}
+
+test('setup discovery and transactional Agent configuration work through the guarded gateway (#48)', async () => {
+  const repositoryRoot = repository();
+  const fakeBin = mkdtempSync(join(tmpdir(), 'coordinate-agents-gateway-bin-'));
+  const isolatedHome = mkdtempSync(join(tmpdir(), 'coordinate-agents-gateway-home-'));
+  const systemPath = process.platform === 'win32' ? join(process.env.SystemRoot || 'C://Windows', 'System32') : '';
+  const originalPath = process.env.PATH;
+  const originalHome = process.env.COORDINATE_AGENTS_HOME;
+  try {
+    writeFakeExecutable(fakeBin, 'claude');
+    writeFakeExecutable(fakeBin, 'agy');
+    const claudeCommand = process.platform === 'win32' ? join(fakeBin, 'claude.cmd') : join(fakeBin, 'claude');
+    const agyProxyCommand = process.platform === 'win32' ? join(fakeBin, 'agy-proxy.cmd') : join(fakeBin, 'agy-proxy');
+    process.env.COORDINATE_AGENTS_HOME = isolatedHome;
+    process.env.PATH = [fakeBin, originalPath].filter(Boolean).join(delimiter);
+
+    const started = await startWorkspace({ root: repositoryRoot, port: 0 });
+    const base = started.url;
+    try {
+      const capability = await capabilityFromPage(base);
+      const post = payload => fetch(`${base}${ACTION_ENDPOINT}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-coordinate-agents-capability': capability },
+        body: JSON.stringify(payload),
+      });
+
+      // Read-only discovery exposes the shared setup snapshot without side effects.
+      const discoveryResponse = await (await post({ action: 'setupDiscover', params: {} })).json();
+      assert.equal(discoveryResponse.ok, true);
+      assert.equal(discoveryResponse.command, 'setup');
+      assert.ok(Array.isArray(discoveryResponse.agents));
+      assert.ok(Array.isArray(discoveryResponse.adapters));
+      assert.ok(discoveryResponse.agents.some(agent => typeof agent.command === 'string'));
+      const configBefore = readFileSync(join(repositoryRoot, '.agent-bus', 'config.json'), 'utf8');
+
+      // Transactional configure: exact command is preserved, role assigned,
+      // user command source reported, project config registers the adapter.
+      const configureResponse = await (await post({
+        action: 'setupConfigure',
+        params: { agent: 'claude', command: claudeCommand, adapter: 'generic-cli', role: 'implementer', args: ['--print', '{prompt}'] },
+      })).json();
+      assert.equal(configureResponse.ok, true, JSON.stringify(configureResponse.error || {}));
+      assert.equal(configureResponse.command, 'setup.configure');
+      assert.equal(configureResponse.agent.id, 'claude');
+      assert.equal(configureResponse.agent.command, claudeCommand);
+      assert.equal(configureResponse.agent.adapter, 'generic-cli');
+      assert.equal(configureResponse.agent.commandSource, 'user');
+      assert.deepEqual(configureResponse.workflow, { implementer: 'claude' });
+
+      const projectConfig = JSON.parse(readFileSync(join(repositoryRoot, '.agent-bus', 'config.json'), 'utf8'));
+      assert.ok(projectConfig.agents.some(agent => agent.id === 'claude' && agent.adapter === 'generic-cli'));
+      assert.equal(projectConfig.workflow.implementer, 'claude');
+      const userConfig = JSON.parse(readFileSync(join(isolatedHome, '.coordinate-agents', 'config.json'), 'utf8'));
+      assert.equal(userConfig.agents.claude.command, claudeCommand);
+
+      // Discovery after configure reflects the new registration.
+      const rediscovery = await (await post({ action: 'setupDiscover', params: {} })).json();
+      assert.equal(rediscovery.ok, true);
+      assert.ok(rediscovery.adapters.some(adapter => adapter.configuredAgents?.some(item => item.id === 'claude')));
+
+      // A failed configure rolls back both project and user configuration.
+      const projectBeforeRollback = readFileSync(join(repositoryRoot, '.agent-bus', 'config.json'), 'utf8');
+      const rollback = await (await post({
+        action: 'setupConfigure',
+        params: { agent: 'antigravity', command: agyProxyCommand, adapter: 'antigravity-cli', role: 'planner' },
+      })).json();
+      assert.equal(rollback.ok, false);
+      assert.equal(rollback.error.code, 'EXECUTABLE_NOT_FOUND');
+      assert.equal(rollback.error.recoverable, true);
+      const projectAfterRollback = readFileSync(join(repositoryRoot, '.agent-bus', 'config.json'), 'utf8');
+      assert.equal(projectAfterRollback, projectBeforeRollback, 'Failed configuration must not mutate project config');
+      assert.equal(existsSync(join(isolatedHome, '.coordinate-agents', 'config.json')), true);
+
+      // Failed detection leaves an existing user config unchanged.
+      const userBefore = readFileSync(join(isolatedHome, '.coordinate-agents', 'config.json'), 'utf8');
+      const badConfigure = await (await post({
+        action: 'setupConfigure',
+        params: { agent: 'codex', command: 'definitely-missing-command-xyz', adapter: 'generic-cli', role: 'reviewer' },
+      })).json();
+      assert.equal(badConfigure.ok, false);
+      const userAfter = readFileSync(join(isolatedHome, '.coordinate-agents', 'config.json'), 'utf8');
+      assert.equal(userAfter, userBefore, 'Failed configuration must not mutate user config');
+      assert.equal(readFileSync(join(repositoryRoot, '.agent-bus', 'config.json'), 'utf8'), projectBeforeRollback);
+
+      // No credential or environment secret is echoed in any response.
+      const serialized = JSON.stringify([discoveryResponse, configureResponse, rollback, badConfigure]);
+      for (const secret of ['token=', 'Authorization', process.env.PATH]) {
+        assert.equal(serialized.includes(secret), false, `Gateway responses must not echo secrets: ${secret}`);
+      }
+
+      // Workspace ships the Agents panel assets.
+      const page = await (await fetch(`${base}/`)).text();
+      assert.match(page, /id="agents-panel"/);
+      assert.match(page, /id="discover-agents"/);
+      assert.match(page, /id="agent-configure"/);
+      const js = await (await fetch(`${base}/app.js`)).text();
+      for (const expected of ['renderAgentsDiscovery', 'renderConfiguredAgents', 'discoverAgents', 'applyAgentConfigure', 'setupDiscover', 'setupConfigure', 'configured-agent-row', 'source-badge']) {
+        assert.ok(js.includes(expected), `Workspace app.js must expose Agents setup support: ${expected}`);
+      }
+      const css = await (await fetch(`${base}/styles.css`)).text();
+      for (const expected of ['.agents-panel', '.agent-form', '.agent-row', '.adapter-card', '.source-badge', '.configured-agent']) {
+        assert.ok(css.includes(expected), `Workspace styles.css must style Agents setup: ${expected}`);
+      }
+    } finally {
+      await closeServer(started.server);
+    }
+  } finally {
+    process.env.PATH = originalPath;
+    process.env.COORDINATE_AGENTS_HOME = originalHome;
+    rmSync(repositoryRoot, { recursive: true, force: true });
+    rmSync(fakeBin, { recursive: true, force: true });
+    rmSync(isolatedHome, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## What

Implements #48 (P0-02): the Workspace Agents page and its end-to-end configuration path over the existing Adapter Contract v1 and setup Runtime operations.

## Gateway

- `setupDiscover` (read-only shared setup snapshot) and `setupConfigure` (transactional project Agent/adapter/role configuration) join the guarded allow-list on `POST /api/action`.
- The params schema adds an array type so generic-CLI args templates (`['--print', '{prompt}']`) pass the bounded gateway validation; configure keeps the existing validation-before-write and atomic rollback semantics of the Runtime setup transaction.

## Workspace UI

- New Agents panel: detection results and the Adapter registry render only on an explicit Discover click (no background scanning, login, remote lookup, package download, or arbitrary process launch).
- Agent / Adapter / executable identity stays distinct; command-source badges show project > user > adapter-default precedence; configured runtime Agents list adapter, roles, status, and queue depth.
- Bounded form configures an Agent, Adapter, exact executable command, and workflow role; success and failure states surface actionable bounded errors.
- The panel states that loaded local Adapter modules are trusted local code, that configuration grants no browser filesystem/process-sandbox bypass, and that no credential, token, cookie, or secret is rendered or persisted.

## Tests & docs

- Focused offline gateway test proves discovery/configure parity with CLI/MCP contracts, transactional rollback on failure (project and user config unchanged), exact command preservation, role assignment, command-source reporting, and no secret echo; assets assertions cover the panel.
- `npm run test:core` (117 tests) and documentation guards stay green. README(.zh-CN) and docs/inspector.md document the Agents surface and the extended allow-list.

Closes #48