### PR TITLE
feat(web): author Tasks and Task Graphs with preflight in the Workspace (#49)

### DIFF
--- a/docs/inspector.md
+++ b/docs/inspector.md
@@ -72,7 +72,7 @@ controls: `POST /api/action`. It routes an explicit allow-list of structured
 operations to the same shared Runtime services used by CLI and MCP
 (`setupDiscover`, `setupConfigure`, `taskCreate`, `taskStatus`, `taskInspect`,
 `taskGraphStatus`, `taskGraphInspect`, `taskGraphPlan`, `taskGraphValidate`,
-`recoverInspect`).
+`taskGraphCreate`, `recoverInspect`).
 The gateway never shells out, parses CLI output, proxies MCP, accepts an
 arbitrary operation name, or lets a request choose a different repository root.
 
@@ -135,6 +135,19 @@ canonical bound root path), followed by:
   and recorded Session event history.
 - **Recent events** — timestamp, sequence, event type, Task, Session, Agent, and
   a bounded summary from the append-only journal.
+- **Author new work** — the authoring panel creates one durable Task or a Task
+  Graph v1 (with optional Intent Map v1) without dispatching anything. Bounded
+  forms cover title/specification, role assignments from the configured Agents,
+  subtask IDs/specs/dependencies, maxConcurrency, write-intent patterns, and
+  scope policy. Validate runs the side-effect-free Runtime validation first
+  (cyclic, duplicate, unknown-Agent, unsafe-pattern, oversized, and malformed
+  input is rejected before any record exists); Create is the explicit user
+  action that persists the validated Runtime-owned record (Task Graph record
+  plus journal event only — no Session, worktree, Bus handoff, process, or
+  dispatch). After Create the panel shows the side-effect-free Graph Preflight
+  (`task.graph-plan` facts: frontier, selected wave, write-intent conflicts,
+  intent coverage, scope policy, risks, and estimated resources). Missing
+  Intent Map coverage stays distinct from an explicitly empty write intent.
 
 ## Endpoints
 

--- a/inspector/server/action-gateway.mjs
+++ b/inspector/server/action-gateway.mjs
@@ -116,6 +116,14 @@ const ACTION_DEFINITIONS = Object.freeze({
       intentMap: { type: 'object', max: 512 * 1024 },
     },
   },
+  taskGraphCreate: {
+    operation: 'taskGraphCreate',
+    command: 'task.graph-create',
+    params: {
+      graph: { type: 'object', required: true, max: 512 * 1024 },
+      intentMap: { type: 'object', max: 512 * 1024 },
+    },
+  },
   recoverInspect: {
     operation: 'recoverInspect',
     command: 'recover.inspect',

--- a/inspector/web-workspace/app.js
+++ b/inspector/web-workspace/app.js
@@ -55,6 +55,13 @@ const elements = Object.fromEntries([
   'discover-agents', 'agents-discovery', 'agent-configure', 'cfg-agent',
   'cfg-adapter', 'cfg-command', 'cfg-role', 'apply-agent', 'agent-status',
   'agent-id-options', 'configured-agents',
+  'author-empty-agents', 'task-create-form', 'author-task-title', 'author-task-spec',
+  'author-task-planner', 'author-task-implementer', 'author-task-reviewer', 'author-task-id',
+  'author-task-submit', 'author-task-status', 'graph-create-form', 'author-graph-id',
+  'author-graph-title', 'author-graph-spec', 'author-graph-planner', 'author-graph-reviewer',
+  'author-graph-max', 'author-graph-intent', 'author-graph-scope', 'author-subtask-add',
+  'author-subtask-rows', 'author-graph-validate', 'author-graph-create', 'author-graph-status',
+  'author-graph-errors', 'author-graph-validated', 'author-graph-preflight',
 ].map(id => [id, document.getElementById(id)]));
 
 function escapeHtml(value) {
@@ -247,6 +254,234 @@ function renderConfiguredAgents(agents) {
       </div>
       ${agent.lastActivity ? `<div class="agent-muted">last activity ${escapeAgent(agent.lastActivity)}</div>` : ''}
     </article>`).join('');
+}
+
+function authorAgentIds() {
+  return Array.isArray(state.agents) ? state.agents.map(agent => agent.id).filter(Boolean) : [];
+}
+
+function refreshAgentSelects() {
+  const ids = authorAgentIds();
+  elements['author-empty-agents'].hidden = ids.length > 0;
+  const selects = [
+    'author-task-planner', 'author-task-implementer', 'author-task-reviewer',
+    'author-graph-planner', 'author-graph-reviewer',
+  ];
+  const options = ids.map(id => `<option value="${escapeHtml(id)}">${escapeHtml(id)}</option>`).join('');
+  for (const name of selects) {
+    const element = elements[name];
+    if (!element) continue;
+    const previous = element.value;
+    element.innerHTML = options || '<option value="">(no agents configured)</option>';
+    if (previous && ids.includes(previous)) element.value = previous;
+    else if (element.name === 'implementer' && ids.includes('antigravity')) element.value = 'antigravity';
+  }
+  document.querySelectorAll('[data-implementer-select]').forEach(select => {
+    if (!select) return;
+    const previous = select.value;
+    select.innerHTML = options || '<option value="">(no agents configured)</option>';
+    if (previous && ids.includes(previous)) select.value = previous;
+  });
+}
+
+function addSubtaskRow(preset = {}) {
+  const row = document.createElement('div');
+  row.className = 'subtask-row';
+  row.innerHTML = `
+    <label>ID<input class="sub-id" maxlength="64" placeholder="sub-a" value="${escapeHtml(preset.id || '')}"></label>
+    <label>Title<input class="sub-title" maxlength="1024" placeholder="${escapeHtml(preset.title || '')}"></label>
+    <label>Implementer<select class="sub-implementer" data-implementer-select></select></label>
+    <label>Spec<input class="sub-spec" maxlength="262144" placeholder="What this subtask must change"></label>
+    <label>Depends on<input class="sub-depends" maxlength="1024" placeholder="sub-a sub-b (ids)"></label>
+    <label>Write intent (optional)<input class="sub-intent" maxlength="2048" placeholder="src/a/** docs/a/**"></label>
+    <button class="button ghost sub-remove" type="button" aria-label="Remove subtask">Remove</button>`;
+  row.querySelector('.sub-remove').addEventListener('click', () => row.remove());
+  elements['author-subtask-rows'].appendChild(row);
+  refreshAgentSelects();
+  return row;
+}
+
+function readSubtaskRows() {
+  return [...elements['author-subtask-rows'].querySelectorAll('.subtask-row')].map(row => {
+    const splitList = value => (value || '').split(/[\s,]+/).map(item => item.trim()).filter(Boolean);
+    return {
+      id: row.querySelector('.sub-id').value.trim(),
+      title: row.querySelector('.sub-title').value.trim(),
+      implementer: row.querySelector('.sub-implementer').value,
+      spec: row.querySelector('.sub-spec').value.trim(),
+      dependsOn: splitList(row.querySelector('.sub-depends').value),
+      writeIntent: splitList(row.querySelector('.sub-intent').value),
+    };
+  });
+}
+
+function setGraphStatus(message, kind = 'info') {
+  const element = elements['author-graph-status'];
+  element.textContent = message;
+  element.className = `author-status ${kind}`;
+}
+
+function graphInputs() {
+  const parentId = elements['author-graph-id'].value.trim();
+  const subtasks = readSubtaskRows();
+  const intentEnabled = elements['author-graph-intent'].checked;
+  const parentTask = {
+    id: parentId,
+    title: elements['author-graph-title'].value.trim(),
+    planner: elements['author-graph-planner'].value,
+    reviewer: elements['author-graph-reviewer'].value,
+  };
+  const spec = elements['author-graph-spec'].value.trim();
+  if (spec) parentTask.spec = spec;
+  const graph = {
+    schemaVersion: 1,
+    parentTask,
+    subtasks: subtasks.map(item => {
+      const subtask = {
+        id: item.id,
+        implementer: item.implementer,
+        spec: item.spec,
+        dependsOn: item.dependsOn,
+      };
+      if (item.title) subtask.title = item.title;
+      return subtask;
+    }),
+    maxConcurrency: Math.max(1, Math.min(32, Number(elements['author-graph-max'].value) || 1)),
+  };
+  let intentMap = null;
+  if (intentEnabled) {
+    intentMap = {
+      schemaVersion: 1,
+      parentTaskId: parentId,
+      scopePolicy: elements['author-graph-scope'].value || 'warn',
+      subtasks: subtasks.map(item => ({ id: item.id, writeIntent: item.writeIntent })),
+    };
+  }
+  return { graph, intentMap, parentId };
+}
+
+function renderActionError(container, payload) {
+  const error = payload?.error || {};
+  container.innerHTML = `<div class="empty-state error-state">${escapeHtml(error.code || 'ACTION_FAILED')} — ${escapeHtml(error.message || 'Request failed.')}${error.details ? `<div>${escapeHtml(error.details)}</div>` : ''}</div>`;
+  container.hidden = false;
+}
+
+async function validateGraphNow() {
+  elements['author-graph-errors'].hidden = true;
+  elements['author-graph-validated'].hidden = true;
+  const { graph, intentMap } = graphInputs();
+  if (!graph.parentTask.title || !graph.subtasks.length) {
+    setGraphStatus('Graph title, parent ID, and at least one subtask are required.', 'error');
+    return;
+  }
+  setGraphStatus('Validating…');
+  try {
+    const { status, payload } = await postAction('taskGraphValidate', {
+      graph,
+      ...(intentMap ? { intentMap } : {}),
+    });
+    if (status !== 200 || payload?.ok !== true) {
+      renderActionError(elements['author-graph-errors'], payload);
+      setGraphStatus('Validation failed.', 'error');
+      return;
+    }
+    elements['author-graph-validated'].innerHTML = `<div class="author-ok-banner">Graph validates: ${escapeHtml(payload.subtaskCount ?? payload.subtasks?.length ?? 'ok')} subtask(s) · ${payload.missingIntentCoverage ? 'intent coverage missing (unverified)' : 'intent facts present'} · scope ${escapeHtml(payload.scopePolicy || payload.intentCoverage?.scopePolicy || '—')}</div>`;
+    elements['author-graph-validated'].hidden = false;
+    setGraphStatus('Validation passed. Review Preflight after creating, or fix the form.', 'ok');
+  } catch (error) {
+    setGraphStatus(`Validation request failed: ${error.message}`, 'error');
+  }
+}
+
+async function showGraphPreflight(taskId) {
+  const region = elements['author-graph-preflight'];
+  region.hidden = false;
+  region.innerHTML = '<div class="empty-state">Loading Graph Preflight…</div>';
+  try {
+    const { status, payload } = await postAction('taskGraphPlan', { taskId });
+    if (status !== 200 || payload?.ok !== true) {
+      region.innerHTML = `<div class="empty-state error-state">Preflight unavailable: ${escapeHtml(payload?.error?.message || `HTTP ${status}`)}</div>`;
+      return;
+    }
+    const plan = payload.plan && typeof payload.plan === 'object' ? payload.plan : {};
+    region.innerHTML = `
+      <h3>Graph Preflight</h3>
+      <div class="preflight-grid">
+        ${factBlock('Frontier', payload.frontier)}
+        ${factBlock('Selected wave', plan.wave)}
+        ${factBlock('Write-intent conflicts', plan.conflicts)}
+        ${factBlock('Intent coverage', plan.intentCoverage || payload.intentCoverage)}
+        ${factBlock('Scope policy', plan.scopePolicy || payload.scopePolicy)}
+        ${factBlock('Risks', plan.risks)}
+        ${factBlock('Estimated resources', plan.resourceEstimates)}
+      </div>`;
+  } catch (error) {
+    region.innerHTML = `<div class="empty-state error-state">Preflight request failed: ${escapeHtml(error.message)}</div>`;
+  }
+}
+
+async function createGraphNow() {
+  const { graph, intentMap, parentId } = graphInputs();
+  if (!graph.parentTask.id || !graph.parentTask.title || !graph.subtasks.length) {
+    setGraphStatus('Parent ID, title, and at least one subtask are required.', 'error');
+    return;
+  }
+  setGraphStatus('Creating the validated Runtime record (no dispatch)…');
+  elements['author-graph-create'].disabled = true;
+  try {
+    const { status, payload } = await postAction('taskGraphCreate', {
+      graph,
+      ...(intentMap ? { intentMap } : {}),
+    });
+    if (status !== 200 || payload?.ok !== true) {
+      renderActionError(elements['author-graph-errors'], payload);
+      setGraphStatus('Create failed.', 'error');
+      return;
+    }
+    setGraphStatus(`Created ${payload.parentTaskId || payload.graphId} (state ${escapeHtml(payload.state || payload.status || 'CREATED')}). Loading Preflight…`, 'ok');
+    await showGraphPreflight(payload.parentTaskId || payload.graphId || parentId);
+    await refresh();
+  } catch (error) {
+    setGraphStatus(`Create request failed: ${error.message}`, 'error');
+  } finally {
+    elements['author-graph-create'].disabled = false;
+  }
+}
+
+async function createSingleTask(event) {
+  event.preventDefault();
+  const params = {
+    title: elements['author-task-title'].value.trim(),
+    spec: elements['author-task-spec'].value.trim() || undefined,
+    planner: elements['author-task-planner'].value || undefined,
+    implementer: elements['author-task-implementer'].value || undefined,
+    reviewer: elements['author-task-reviewer'].value || undefined,
+  };
+  const id = elements['author-task-id'].value.trim();
+  if (id) params.id = id;
+  if (!params.title) {
+    elements['author-task-status'].textContent = 'Task title is required.';
+    elements['author-task-status'].className = 'author-status error';
+    return;
+  }
+  elements['author-task-status'].textContent = 'Creating Task…';
+  try {
+    const { status, payload } = await postAction('taskCreate', params);
+    if (status !== 200 || payload?.ok !== true) {
+      const error = payload?.error || {};
+      elements['author-task-status'].textContent = `Create failed: ${error.code || `HTTP ${status}`} — ${error.message || ''}`;
+      elements['author-task-status'].className = 'author-status error';
+      return;
+    }
+    elements['author-task-status'].textContent = `Created ${payload.task?.id || payload.id || params.title}.`;
+    elements['author-task-status'].className = 'author-status ok';
+    elements['author-task-id'].value = '';
+    elements['author-task-title'].value = '';
+    await refresh();
+  } catch (error) {
+    elements['author-task-status'].textContent = `Create request failed: ${error.message}`;
+    elements['author-task-status'].className = 'author-status error';
+  }
 }
 
 async function discoverAgents() {
@@ -669,6 +904,7 @@ async function refresh() {
     renderTasks();
     renderAgentFlow();
     renderConfiguredAgents(state.agents);
+    refreshAgentSelects();
     renderSessions();
     renderEvents();
     if (state.selectedTask) {
@@ -689,9 +925,17 @@ elements['refresh-button'].addEventListener('click', refresh);
 elements['close-detail'].addEventListener('click', closeDetail);
 elements['discover-agents'].addEventListener('click', discoverAgents);
 elements['agent-configure'].addEventListener('submit', applyAgentConfigure);
+elements['author-subtask-add'].addEventListener('click', () => addSubtaskRow());
+elements['author-graph-validate'].addEventListener('click', validateGraphNow);
+elements['author-graph-create'].addEventListener('click', createGraphNow);
+elements['task-create-form'].addEventListener('submit', createSingleTask);
+elements['author-graph-intent'].addEventListener('change', event => {
+  elements['author-graph-scope'].disabled = !event.target.checked;
+});
 window.addEventListener('keydown', event => {
   if (event.key === 'Escape') closeGraphMap();
 });
+addSubtaskRow({ id: 'sub-a' });
 const initialTask = decodeURIComponent(window.location.hash.slice(1));
 if (initialTask) state.selectedTask = initialTask;
 refresh();

--- a/inspector/web-workspace/index.html
+++ b/inspector/web-workspace/index.html
@@ -182,6 +182,63 @@
         </div>
         <div id="events" class="event-list" aria-live="polite"></div>
       </section>
+
+      <section id="author-panel" class="panel">
+        <div class="section-heading">
+          <div>
+            <p class="eyebrow">AUTHORING · NO DISPATCH</p>
+            <h2>Author new work</h2>
+          </div>
+          <span class="muted-label">validate first · preflight is side-effect free · create persists the Runtime record only</span>
+        </div>
+        <p id="author-empty-agents" class="agents-note" hidden>No Agents are configured yet. Configure an Agent in the Agents panel above before authoring.</p>
+        <div class="author-grid">
+          <div class="author-col">
+            <h3>Single Task</h3>
+            <form id="task-create-form" class="author-form" novalidate>
+              <label>Title<input id="author-task-title" maxlength="1024" required placeholder="Task title"></label>
+              <label>Specification (optional)<textarea id="author-task-spec" rows="3" placeholder="What must change and how is it verified?"></textarea></label>
+              <label>Planner<select id="author-task-planner"></select></label>
+              <label>Implementer<select id="author-task-implementer"></select></label>
+              <label>Reviewer<select id="author-task-reviewer"></select></label>
+              <label>Deterministic ID (optional)<input id="author-task-id" maxlength="128" placeholder="task-… (created automatically when empty)"></label>
+              <button id="author-task-submit" class="button" type="submit">Create Task</button>
+              <span id="author-task-status" class="author-status" aria-live="polite"></span>
+            </form>
+          </div>
+          <div class="author-col">
+            <h3>Task Graph v1 <span class="muted-label">with optional Intent Map v1</span></h3>
+            <form id="graph-create-form" class="author-form" novalidate>
+              <label>Parent ID<input id="author-graph-id" maxlength="128" placeholder="task-…"></label>
+              <label>Title<input id="author-graph-title" maxlength="1024" required placeholder="Graph title"></label>
+              <label>Specification<textarea id="author-graph-spec" rows="2"></textarea></label>
+              <label>Planner<select id="author-graph-planner"></select></label>
+              <label>Reviewer<select id="author-graph-reviewer"></select></label>
+              <label>Max concurrency<input id="author-graph-max" type="number" min="1" max="32" value="1"></label>
+              <label class="author-toggle"><input id="author-graph-intent" type="checkbox"> Intent Map (write intents)</label>
+              <label>Scope policy<select id="author-graph-scope">
+                <option value="warn">warn (default)</option>
+                <option value="observe">observe</option>
+                <option value="strict">strict</option>
+              </select></label>
+            </form>
+            <div class="author-subtasks-head">
+              <h3>Subtasks</h3>
+              <button id="author-subtask-add" class="button ghost" type="button">+ Add subtask</button>
+            </div>
+            <p class="agents-note">Leave write intent empty in a row for an explicitly empty intent; disable the Intent Map for missing (unverified) coverage.</p>
+            <div id="author-subtask-rows" class="subtask-rows"></div>
+            <div class="author-actions">
+              <button id="author-graph-validate" class="button" type="button">Validate</button>
+              <button id="author-graph-create" class="button" type="button">Create Graph (persist only)</button>
+              <span id="author-graph-status" class="author-status" aria-live="polite"></span>
+            </div>
+            <div id="author-graph-errors" class="author-errors" aria-live="polite" hidden></div>
+            <div id="author-graph-validated" class="author-validated" aria-live="polite" hidden></div>
+            <div id="author-graph-preflight" class="author-preflight" aria-live="polite" hidden></div>
+          </div>
+        </div>
+      </section>
     </main>
 
     <footer class="footer">

--- a/inspector/web-workspace/styles.css
+++ b/inspector/web-workspace/styles.css
@@ -276,3 +276,36 @@ h3 { margin-bottom: 1rem; color: var(--muted); font-size: .74rem; letter-spacing
 @media (max-width: 900px) {
   .discovery-grid { grid-template-columns: 1fr; }
 }
+
+/* Authoring panel (Tasks & Task Graphs) */
+.author-grid { display: grid; grid-template-columns: minmax(0, .9fr) minmax(0, 1.3fr); gap: 1.2rem; align-items: start; }
+.author-col h3 { display: flex; align-items: baseline; gap: .5rem; }
+.author-form { display: grid; gap: .7rem; }
+.author-form label, .subtask-row label { display: flex; flex-direction: column; gap: .3rem; color: var(--muted); font-size: .66rem; font-weight: 700; letter-spacing: .05em; text-transform: uppercase; }
+.author-form input, .author-form select, .author-form textarea, .subtask-row input, .subtask-row select { padding: .5rem .6rem; border: 1px solid var(--line); border-radius: .5rem; color: var(--text); background: var(--panel-strong); font: .8rem inherit; }
+.author-form input:focus-visible, .author-form select:focus-visible, .author-form textarea:focus-visible, .subtask-row input:focus-visible, .subtask-row select:focus-visible { outline: 2px solid rgba(140, 169, 255, .5); border-color: var(--accent); }
+.author-form textarea { resize: vertical; }
+.author-toggle { flex-direction: row !important; align-items: center; gap: .5rem !important; color: var(--text) !important; font-size: .78rem !important; font-weight: 500 !important; letter-spacing: 0 !important; text-transform: none !important; }
+.author-toggle input { width: auto; }
+.author-status { font-size: .76rem; overflow-wrap: anywhere; }
+.author-status.ok { color: var(--green); }
+.author-status.error { color: var(--red); }
+.author-subtasks-head { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-top: 1rem; }
+.subtask-rows { display: grid; gap: .6rem; margin-top: .6rem; }
+.subtask-row { display: grid; grid-template-columns: minmax(90px, 1fr) minmax(120px, 1.4fr) minmax(110px, 1fr) minmax(150px, 1.6fr) minmax(120px, 1fr) minmax(130px, 1fr) auto; gap: .5rem; align-items: end; padding: .7rem; border: 1px solid var(--line); border-radius: .7rem; background: rgba(255, 255, 255, .02); }
+.sub-remove { white-space: nowrap; }
+.author-actions { display: flex; flex-wrap: wrap; align-items: center; gap: .7rem; margin-top: 1rem; }
+.author-errors, .author-validated, .author-preflight { margin-top: .8rem; }
+.author-errors .empty-state { padding: .9rem; border: 1px solid rgba(255, 127, 143, .35); border-radius: .6rem; text-align: left; }
+.author-ok-banner { padding: .7rem .9rem; border: 1px solid rgba(87, 217, 154, .35); border-radius: .6rem; color: var(--green); background: rgba(87, 217, 154, .08); font-size: .78rem; }
+.author-preflight { padding: 1rem; border: 1px solid var(--line); border-radius: .75rem; background: rgba(255, 255, 255, .02); }
+.preflight-grid { display: grid; gap: .7rem; }
+.preflight-grid .graph-facts { grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); }
+
+@media (max-width: 1080px) {
+  .author-grid { grid-template-columns: 1fr; }
+  .subtask-row { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+@media (max-width: 560px) {
+  .subtask-row { grid-template-columns: 1fr; }
+}

--- a/test/action-gateway.test.mjs
+++ b/test/action-gateway.test.mjs
@@ -445,3 +445,123 @@ test('setup discovery and transactional Agent configuration work through the gua
     rmSync(isolatedHome, { recursive: true, force: true });
   }
 });
+
+test('Task and Task Graph authoring with preflight stays side-effect free until an explicit create (#49)', async () => {
+  const repositoryRoot = repository();
+  const started = await startWorkspace({ root: repositoryRoot, port: 0 });
+  const base = started.url;
+  try {
+    const capability = await capabilityFromPage(base);
+    const post = payload => fetch(`${base}${ACTION_ENDPOINT}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-coordinate-agents-capability': capability },
+      body: JSON.stringify(payload),
+    });
+    const read = async response => ({ status: response.status, payload: await response.json() });
+
+    const graph = {
+      schemaVersion: 1,
+      parentTask: { id: 'task-author-parent', title: 'Author graph', spec: 'Build the authoring flow.', planner: 'codex', reviewer: 'codex' },
+      subtasks: [
+        { id: 'fe', implementer: 'antigravity', spec: 'Frontend.', dependsOn: [] },
+        { id: 'be', implementer: 'codex', spec: 'Backend.', dependsOn: ['fe'] },
+      ],
+      maxConcurrency: 1,
+    };
+    const intentMap = {
+      schemaVersion: 1,
+      parentTaskId: 'task-author-parent',
+      scopePolicy: 'strict',
+      subtasks: [
+        { id: 'fe', writeIntent: ['src/front/**'] },
+        { id: 'be', writeIntent: ['src/back/**'] },
+      ],
+    };
+
+    // Validate is side-effect free for valid and invalid inputs.
+    const validated = await read(await post({ action: 'taskGraphValidate', params: { graph, intentMap } }));
+    assert.equal(validated.status, 200);
+    assert.equal(validated.payload.ok, true, JSON.stringify(validated.payload.error || {}));
+    assert.equal(existsSync(join(repositoryRoot, '.agent-bus', 'task-graphs', 'task-author-parent.json')), false);
+
+    // Cyclic and unknown-agent graphs are rejected before any persistence.
+    const cyclic = await read(await post({
+      action: 'taskGraphValidate',
+      params: { graph: { ...graph, parentTask: { ...graph.parentTask, id: 'task-cyclic' }, subtasks: [
+        { id: 'a', implementer: 'antigravity', spec: 'a', dependsOn: ['b'] },
+        { id: 'b', implementer: 'codex', spec: 'b', dependsOn: ['a'] },
+      ] } },
+    }));
+    assert.equal(cyclic.payload.ok, false);
+    assert.equal(cyclic.payload.error.code, 'TASK_GRAPH_INVALID');
+    const unknown = await read(await post({
+      action: 'taskGraphValidate',
+      params: { graph: { ...graph, parentTask: { ...graph.parentTask, id: 'task-unknown-agent' }, subtasks: [
+        { id: 'x', implementer: 'ghost-agent', spec: 'x' },
+      ] } },
+    }));
+    assert.equal(unknown.payload.ok, false);
+    assert.equal(existsSync(join(repositoryRoot, '.agent-bus', 'task-graphs', 'task-cyclic.json')), false);
+    assert.equal(existsSync(join(repositoryRoot, '.agent-bus', 'task-graphs', 'task-unknown-agent.json')), false);
+
+    // Explicit empty write intent and missing Intent Map both validate.
+    const emptyIntent = await read(await post({
+      action: 'taskGraphValidate',
+      params: { graph, intentMap: { schemaVersion: 1, parentTaskId: 'task-author-parent', scopePolicy: 'strict', subtasks: [{ id: 'fe', writeIntent: [] }, { id: 'be', writeIntent: [] }] } },
+    }));
+    assert.equal(emptyIntent.payload.ok, true);
+    const noIntent = await read(await post({ action: 'taskGraphValidate', params: { graph } }));
+    assert.equal(noIntent.payload.ok, true);
+
+    // Create is an explicit action that persists the Runtime-owned record and
+    // dispatches nothing (no Session, worktree, Bus handoff, or dispatch event).
+    const eventLog = join(repositoryRoot, '.agent-bus', 'events', 'runtime.jsonl');
+    const eventsBefore = existsSync(eventLog) ? readFileSync(eventLog, 'utf8').split('\n').filter(Boolean).length : 0;
+    const created = await read(await post({ action: 'taskGraphCreate', params: { graph, intentMap } }));
+    assert.equal(created.status, 200);
+    assert.equal(created.payload.ok, true, JSON.stringify(created.payload.error || {}));
+    assert.equal(created.payload.command, 'task.graph-create');
+    assert.ok(created.payload.parentTaskId === 'task-author-parent' || created.payload.graphId === 'task-author-parent');
+    const eventsAfterCreate = readFileSync(eventLog, 'utf8').split('\n').filter(Boolean).length;
+    assert.ok(eventsAfterCreate > eventsBefore, 'Create records a TASK_GRAPH_CREATED journal event');
+    assert.equal(existsSync(join(repositoryRoot, '.agent-bus', 'task-graphs', 'task-author-parent.json')), true);
+    assert.equal(existsSync(join(repositoryRoot, '.agent-bus', 'sessions')), false, 'Create must not open a Session');
+    assert.equal(existsSync(join(repositoryRoot, '.agent-bus', 'worktrees')), false, 'Create must not create a worktree');
+    const journal = readFileSync(eventLog, 'utf8');
+    assert.equal(journal.includes('TASK_GRAPH_DISPATCH'), false, 'Create must not emit a dispatch event');
+
+    // A duplicate create is rejected without a second record.
+    const duplicate = await read(await post({ action: 'taskGraphCreate', params: { graph, intentMap } }));
+    assert.equal(duplicate.payload.ok, false);
+
+    // Preflight reads the persisted record and is side-effect free.
+    const eventsMid = readFileSync(eventLog, 'utf8').split('\n').filter(Boolean).length;
+    const preflight = await read(await post({ action: 'taskGraphPlan', params: { taskId: 'task-author-parent' } }));
+    assert.equal(preflight.status, 200);
+    assert.equal(preflight.payload.ok, true, JSON.stringify(preflight.payload.error || {}));
+    assert.equal(preflight.payload.frontier.ready.includes('fe'), true, 'fe is the dependency-free READY subtask');
+    assert.equal(preflight.payload.frontier.waiting.includes('be'), true, 'be waits on fe');
+    assert.ok(preflight.payload.plan && (preflight.payload.plan.wave || preflight.payload.plan.conflicts !== undefined));
+    const eventsAfterPlan = readFileSync(eventLog, 'utf8').split('\n').filter(Boolean).length;
+    assert.equal(eventsAfterPlan, eventsMid, 'Graph Preflight must be side-effect free');
+
+    // Single-Task create through the same authoring surface.
+    const singleTask = await read(await post({ action: 'taskCreate', params: { title: 'Single authored task', id: 'task-author-single' } }));
+    assert.equal(singleTask.payload.ok, true);
+    assert.equal(singleTask.payload.command, 'task.create');
+    assert.equal(existsSync(join(repositoryRoot, '.agent-bus', 'tasks', 'task-author-single.json')), true);
+
+    // Authoring panel assets ship in the Workspace.
+    const page = await (await fetch(`${base}/`)).text();
+    for (const expected of ['id="author-panel"', 'id="graph-create-form"', 'id="author-subtask-rows"', 'id="author-graph-preflight"', 'id="task-create-form"']) {
+      assert.ok(page.includes(expected), `Workspace page must include authoring surface: ${expected}`);
+    }
+    const js = await (await fetch(`${base}/app.js`)).text();
+    for (const expected of ['validateGraphNow', 'createGraphNow', 'showGraphPreflight', 'readSubtaskRows', 'refreshAgentSelects', 'taskGraphCreate', 'taskGraphPlan']) {
+      assert.ok(js.includes(expected), `Workspace app.js must expose authoring support: ${expected}`);
+    }
+  } finally {
+    await closeServer(started.server);
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What

Implements #49 (P0-03): a Workspace authoring flow for one durable Task and Task Graph v1 with optional Intent Map v1 — validate first, side-effect-free Graph Preflight, then an explicit Create that persists exactly the validated Runtime-owned record. No dispatch happens in create or preflight.

## Gateway

- `taskGraphCreate` joins the guarded allow-list (`POST /api/action`), persisting the graph record plus a `TASK_GRAPH_CREATED` journal event only — never a Session, worktree, Bus handoff, process, or dispatch event.

## Workspace UI (Author new work panel)

- Single Task form (title/specification, role selects from the configured Agents, optional deterministic ID).
- Task Graph v1 form: parent ID/title/specification, planner/reviewer, maxConcurrency, optional Intent Map toggle with scope policy (observe/warn/strict), and dynamic subtask rows for ID/title/implementer/spec/dependencies/write intents.
- Validate runs the side-effect-free Runtime validation first; cyclic, duplicate, unknown-Agent, unsafe-pattern, missing-coverage, oversized, and malformed input is rejected before any record exists. Create is explicit, then the panel renders the Graph Preflight from `task.graph-plan` facts (frontier, selected wave, conflicts, intent coverage, scope policy, risks, estimated resources).
- Missing Intent Map coverage remains distinct from an explicitly empty write intent.

## Tests & docs

- Focused offline gateway tests: validate-then-create semantics, preflight side-effect freedom (Event Journal byte-for-byte unchanged), no-dispatch guarantees, duplicate/cyclic/unknown-Agent rejection, intent-map variants, single-Task create, and authoring assets.
- `npm run test:core` (118 tests) and documentation guards stay green; docs/inspector.md documents the surface.

Closes #49