### PR TITLE
feat(web): run Tasks and bounded Task Graph waves from the Workspace (#50)

### DIFF
--- a/docs/inspector.md
+++ b/docs/inspector.md
@@ -70,9 +70,10 @@ the guarded action endpoint below. Stop it with `Ctrl-C`.
 The Workspace exposes exactly one additive, guarded action endpoint for later
 controls: `POST /api/action`. It routes an explicit allow-list of structured
 operations to the same shared Runtime services used by CLI and MCP
-(`setupDiscover`, `setupConfigure`, `taskCreate`, `taskStatus`, `taskInspect`,
-`taskGraphStatus`, `taskGraphInspect`, `taskGraphPlan`, `taskGraphValidate`,
-`taskGraphCreate`, `recoverInspect`).
+(`setupDiscover`, `setupConfigure`, `taskCreate`, `taskDispatch`, `taskStatus`,
+`taskInspect`, `taskGraphStatus`, `taskGraphInspect`, `taskGraphPlan`,
+`taskGraphValidate`, `taskGraphCreate`, `taskGraphRun`, `taskGraphAdvance`,
+`recoverInspect`).
 The gateway never shells out, parses CLI output, proxies MCP, accepts an
 arbitrary operation name, or lets a request choose a different repository root.
 
@@ -148,6 +149,18 @@ canonical bound root path), followed by:
   (`task.graph-plan` facts: frontier, selected wave, write-intent conflicts,
   intent coverage, scope policy, risks, and estimated resources). Missing
   Intent Map coverage stays distinct from an explicitly empty write intent.
+- **Execution controls** — selecting a Task or Task Graph opens an explicit
+  control row that is never triggered by page load, GET, SSE reconnect, or a
+  double click. Dispatch, Run eligible wave, and Advance are armed only after
+  the user checks an understanding box (an Agent process may write to the
+  repository; failures are never retried automatically; no merge, push, tag,
+  publish, deploy, or release occurs). Graph Advance requires an explicit
+  bounded `maxWaves` (1–32) and Graph Run an optional bounded session-wait
+  (0–10000 ms). Results surface the same Task/subtask, Session, worktree,
+  commit, evidence, and stop facts as the shared Runtime operation; stale or
+  invalid state returns a conflict and views refresh from the authoritative
+  Runtime record via bounded SSE/refresh with `Last-Event-ID` resume. The
+  Workspace never modifies the user's checked-out worktree or remote refs.
 
 ## Endpoints
 

--- a/inspector/server/action-gateway.mjs
+++ b/inspector/server/action-gateway.mjs
@@ -124,6 +124,31 @@ const ACTION_DEFINITIONS = Object.freeze({
       intentMap: { type: 'object', max: 512 * 1024 },
     },
   },
+  taskDispatch: {
+    operation: 'taskDispatch',
+    command: 'task.dispatch',
+    params: {
+      taskId: { type: 'string', required: true, max: 128 },
+      spec: { type: 'string', max: 256 * 1024 },
+    },
+  },
+  taskGraphRun: {
+    operation: 'taskGraphRun',
+    command: 'task.graph-run',
+    params: {
+      taskId: { type: 'string', required: true, max: 128 },
+      sessionWaitMs: { type: 'integer', min: 0, max: 10_000 },
+    },
+  },
+  taskGraphAdvance: {
+    operation: 'taskGraphAdvance',
+    command: 'task.graph-advance',
+    params: {
+      taskId: { type: 'string', required: true, max: 128 },
+      maxWaves: { type: 'integer', required: true, min: 1, max: 32 },
+      sessionWaitMs: { type: 'integer', min: 0, max: 10_000 },
+    },
+  },
   recoverInspect: {
     operation: 'recoverInspect',
     command: 'recover.inspect',
@@ -227,6 +252,11 @@ function validateParams(definition, params) {
       if (!Array.isArray(value)) return `Parameter ${key} must be an array.`;
       if (value.length > rule.max || value.some(item => typeof item !== 'string' || item.length > (rule.itemMax || 512))) {
         return `Parameter ${key} exceeds the supported size limit.`;
+      }
+    } else if (rule.type === 'integer') {
+      if (!Number.isInteger(value)) return `Parameter ${key} must be an integer.`;
+      if (value < (rule.min ?? 0) || value > (rule.max ?? Number.MAX_SAFE_INTEGER)) {
+        return `Parameter ${key} is outside the supported range.`;
       }
     }
   }

--- a/inspector/web-workspace/app.js
+++ b/inspector/web-workspace/app.js
@@ -62,6 +62,7 @@ const elements = Object.fromEntries([
   'author-graph-max', 'author-graph-intent', 'author-graph-scope', 'author-subtask-add',
   'author-subtask-rows', 'author-graph-validate', 'author-graph-create', 'author-graph-status',
   'author-graph-errors', 'author-graph-validated', 'author-graph-preflight',
+  'execution-panel', 'execution-title', 'execution-controls', 'execution-status', 'execution-result',
 ].map(id => [id, document.getElementById(id)]));
 
 function escapeHtml(value) {
@@ -771,6 +772,132 @@ function closeGraphMap() {
   if (state.graphDetail) renderGraphMap(state.graphDetail);
 }
 
+function setExecutionStatus(message, kind = 'info') {
+  const element = elements['execution-status'];
+  element.textContent = message;
+  element.className = `author-status ${kind}`;
+}
+
+function renderExecutionResult(label, payload) {
+  const region = elements['execution-result'];
+  region.hidden = false;
+  if (!payload || payload.ok !== true) {
+    const error = payload?.error || {};
+    region.innerHTML = `<div class="empty-state error-state"><strong>${escapeHtml(label)} failed</strong> — ${escapeHtml(error.code || 'ACTION_FAILED')}: ${escapeHtml(error.message || 'Request failed.')}${error.details ? `<div class="execution-detail">${escapeHtml(error.details)}</div>` : ''}</div>`;
+    setExecutionStatus(`${label} failed (${error.code || 'error'}). Refreshing authoritative Runtime state…`, 'error');
+    return;
+  }
+  const pick = keys => keys.map(key => payload[key]).find(value => value !== undefined && value !== null && value !== '');
+  const facts = [];
+  const show = (labelText, value) => {
+    if (value !== undefined && value !== null && value !== '') facts.push(`<div class="execution-fact"><span>${escapeHtml(labelText)}</span><code>${escapeHtml(Array.isArray(value) ? value.join(', ') : value)}</code></div>`);
+  };
+  show('Task / parent', pick(['taskId', 'parentTaskId', 'id']));
+  show('Subtasks', payload.subtaskIds || payload.subtasks?.length);
+  show('State', pick(['state', 'status']));
+  show('Session', pick(['sessionId', 'sessions']) && !Array.isArray(payload.sessions) ? pick(['sessionId']) : Array.isArray(payload.sessions) ? payload.sessions.length : undefined);
+  show('Commit', pick(['implementationCommit', 'commit', 'aggregateCommit']));
+  show('Waves executed', payload.wavesExecuted || payload.waveCount);
+  show('Stop reason', payload.stopReason);
+  show('Agent', pick(['agent', 'implementer']));
+  region.innerHTML = `<div class="execution-ok"><strong>${escapeHtml(label)} completed</strong><div class="execution-facts">${facts.join('') || '<div class="agent-muted">(no identity facts returned)</div>'}</div>${payload.error ? `<div class="execution-detail">${escapeHtml(payload.error.message || '')}</div>` : ''}</div>`;
+  setExecutionStatus(`${label} completed. Refreshing views…`, 'ok');
+}
+
+async function runExecutionAction(actionName, params, label) {
+  setExecutionStatus(`${label}: executing…`);
+  const region = elements['execution-result'];
+  region.hidden = true;
+  try {
+    const { status, payload } = await postAction(actionName, params);
+    renderExecutionResult(label, status === 200 ? payload : { ok: false, error: { code: `HTTP ${status}`, message: payload?.error?.message || payload?.error || 'Request failed.' } });
+  } catch (error) {
+    setExecutionStatus(`${label} request failed: ${error.message}`, 'error');
+  }
+  await refresh();
+}
+
+function executionConfirmRow(labelText) {
+  return `<label class="author-toggle execution-confirm-row"><input type="checkbox" class="execution-confirm" data-action-confirm> ${escapeHtml(labelText)}</label>`;
+}
+
+function bindExecutionControls(container, detail) {
+  const confirm = container.querySelector('.execution-confirm');
+  const runButtons = container.querySelectorAll('[data-run-action]');
+  const update = () => {
+    const armed = confirm ? confirm.checked : true;
+    runButtons.forEach(button => { button.disabled = !armed; });
+  };
+  confirm?.addEventListener('change', update);
+  update();
+  runButtons.forEach(button => {
+    button.addEventListener('click', async () => {
+      if (confirm && !confirm.checked) return;
+      button.disabled = true;
+      try {
+        await runExecutionAction(button.dataset.runAction, JSON.parse(button.dataset.params || '{}'), button.dataset.label || 'Execution');
+      } finally {
+        if (confirm) confirm.checked = false;
+        button.disabled = false;
+      }
+    });
+  });
+}
+
+function renderExecution(detail) {
+  const panel = elements['execution-panel'];
+  if (!detail) {
+    panel.hidden = true;
+    return;
+  }
+  panel.hidden = false;
+  elements['execution-result'].hidden = true;
+  setExecutionStatus('');
+  const graph = Boolean(detail.graph);
+  elements['execution-title'].textContent = graph ? `Execution · ${detail.title || detail.id}` : `Execution · ${detail.title || detail.id}`;
+  const confirmText = 'I understand: this explicitly launches an Agent process that may write to the repository; failures are never retried automatically and no merge, push, tag, publish, deploy, or release occurs.';
+  const id = detail.id;
+  let controls = '';
+  if (!graph) {
+    const dispatchable = ['CREATED', 'PLANNING', 'SPEC_READY', 'CHANGES_REQUESTED'].includes(detail.status);
+    controls = `
+      ${executionConfirmRow(confirmText)}
+      <button class="button" type="button" data-run-action="taskDispatch" data-label="Dispatch ${escapeHtml(id)}" data-params="${escapeHtml(JSON.stringify({ taskId: id }))}" ${dispatchable ? '' : 'disabled title="Current status prevents dispatch; the Runtime will still validate"'}>Dispatch task</button>
+      ${dispatchable ? '' : `<span class="agent-muted">status ${escapeHtml(detail.status)} — dispatch applies to created / planning / spec-ready / changes-requested Tasks with a specification.</span>`}`;
+  } else {
+    controls = `
+      ${executionConfirmRow(confirmText)}
+      <label class="execution-field">Session wait (ms, 0–10000)<input type="number" class="execution-session-wait" min="0" max="10000" value="2000"></label>
+      <button class="button" type="button" data-run-action="taskGraphRun" data-label="Run eligible wave of ${escapeHtml(id)}">Run eligible wave</button>
+      <label class="execution-field">maxWaves (1–32)<input type="number" class="execution-max-waves" min="1" max="32" value="1"></label>
+      <button class="button" type="button" data-run-action="taskGraphAdvance" data-label="Advance ${escapeHtml(id)}">Advance graph</button>`;
+  }
+  elements['execution-controls'].innerHTML = controls;
+  const waitInput = elements['execution-controls'].querySelector('.execution-session-wait');
+  const wavesInput = elements['execution-controls'].querySelector('.execution-max-waves');
+  if (waitInput) {
+    elements['execution-controls'].querySelectorAll('[data-run-action="taskGraphRun"]').forEach(button => {
+      button.dataset.params = JSON.stringify({ taskId: id, sessionWaitMs: Number(waitInput.value) || 0 });
+    });
+    waitInput.addEventListener('input', () => {
+      elements['execution-controls'].querySelectorAll('[data-run-action="taskGraphRun"]').forEach(button => {
+        button.dataset.params = JSON.stringify({ taskId: id, sessionWaitMs: Number(waitInput.value) || 0 });
+      });
+    });
+  }
+  if (wavesInput) {
+    const updateAdvance = () => {
+      elements['execution-controls'].querySelectorAll('[data-run-action="taskGraphAdvance"]').forEach(button => {
+        button.dataset.params = JSON.stringify({ taskId: id, maxWaves: Math.max(1, Math.min(32, Number(wavesInput.value) || 1)), sessionWaitMs: Number(waitInput?.value) || 0 });
+      });
+    };
+    updateAdvance();
+    wavesInput.addEventListener('input', updateAdvance);
+    waitInput?.addEventListener('input', updateAdvance);
+  }
+  bindExecutionControls(elements['execution-controls'], detail);
+}
+
 function renderGraphDetail(task) {
   const graph = Boolean(task?.graph);
   elements['graph-detail'].hidden = !graph;
@@ -830,6 +957,7 @@ function renderGraphDetail(task) {
 function renderTaskDetail(task) {
   if (!task) {
     elements['task-detail'].hidden = true;
+    renderExecution(null);
     return;
   }
   elements['task-detail'].hidden = false;
@@ -840,6 +968,7 @@ function renderTaskDetail(task) {
     <span>${escapeHtml(task.id)}</span>
     <span>Updated ${formatDate(task.updatedAt)}</span>
   `;
+  renderExecution(task);
   renderGraphDetail(task);
   renderTimeline(task.timeline);
   elements['detail-agent-flow'].innerHTML = (task.agentFlow || []).map((item, index) => {

--- a/inspector/web-workspace/index.html
+++ b/inspector/web-workspace/index.html
@@ -106,6 +106,18 @@
           <button id="close-detail" class="button ghost" type="button">Close</button>
         </div>
         <div id="detail-summary" class="detail-summary"></div>
+        <div id="execution-panel" class="execution-panel" hidden>
+          <div class="section-heading">
+            <div>
+              <p class="eyebrow">EXECUTION CONTROL · EXPLICIT ONLY</p>
+              <h2 id="execution-title">Execution</h2>
+            </div>
+            <span class="muted-label">never on page load or reconnect · no automatic retry</span>
+          </div>
+          <div id="execution-controls" class="execution-controls"></div>
+          <span id="execution-status" class="author-status" aria-live="polite"></span>
+          <div id="execution-result" class="execution-result" aria-live="polite" hidden></div>
+        </div>
         <section id="graph-detail" class="graph-detail" hidden>
           <section id="graph-map-region" class="graph-map-region">
             <div class="section-heading">

--- a/inspector/web-workspace/styles.css
+++ b/inspector/web-workspace/styles.css
@@ -309,3 +309,18 @@ h3 { margin-bottom: 1rem; color: var(--muted); font-size: .74rem; letter-spacing
 @media (max-width: 560px) {
   .subtask-row { grid-template-columns: 1fr; }
 }
+
+/* Execution controls (explicit dispatch / run / advance) */
+.execution-panel { margin-bottom: 1.5rem; padding: 1rem; border: 1px solid rgba(244, 201, 107, .3); border-radius: .8rem; background: rgba(244, 201, 107, .05); }
+.execution-panel .section-heading { margin-bottom: .6rem; }
+.execution-controls { display: flex; flex-wrap: wrap; align-items: center; gap: .7rem; margin-bottom: .4rem; }
+.execution-confirm-row { color: var(--text) !important; font-size: .76rem !important; font-weight: 500 !important; letter-spacing: 0 !important; text-transform: none !important; max-width: 60ch; }
+.execution-controls .button:disabled { opacity: .45; cursor: not-allowed; }
+.execution-field { display: flex; flex-direction: column; gap: .25rem; color: var(--muted); font-size: .66rem; font-weight: 700; letter-spacing: .05em; text-transform: uppercase; }
+.execution-field input { width: 8rem; padding: .4rem .5rem; border: 1px solid var(--line); border-radius: .45rem; color: var(--text); background: var(--panel-strong); }
+.execution-result { margin-top: .5rem; }
+.execution-ok { padding: .7rem .9rem; border: 1px solid rgba(87, 217, 154, .35); border-radius: .6rem; color: var(--green); background: rgba(87, 217, 154, .07); font-size: .8rem; }
+.execution-facts { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: .3rem .8rem; margin-top: .5rem; }
+.execution-fact { display: flex; justify-content: space-between; gap: .6rem; color: var(--muted); font-size: .74rem; }
+.execution-fact code { max-width: 70%; color: var(--text); overflow-wrap: anywhere; text-align: right; }
+.execution-detail { margin-top: .35rem; color: var(--muted); font-size: .72rem; overflow-wrap: anywhere; }

--- a/test/action-gateway.test.mjs
+++ b/test/action-gateway.test.mjs
@@ -318,6 +318,23 @@ test('inspector compatibility mode keeps all non-GET traffic rejected with Allow
   }
 });
 
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function safeRm(directory) {
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    try {
+      rmSync(directory, { recursive: true, force: true });
+      return;
+    } catch {
+      // Windows may briefly hold a handle on a fixture after a dispatch/run
+      // probe; retry, then leave the temp directory for OS cleanup.
+      await sleep(250);
+    }
+  }
+}
+
 function writeFakeExecutable(directory, name) {
   if (process.platform === 'win32') {
     // A .cmd wrapper is only a safe entrypoint with a .js/.cjs sibling; tests
@@ -563,5 +580,121 @@ test('Task and Task Graph authoring with preflight stays side-effect free until 
   } finally {
     await closeServer(started.server);
     rmSync(repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('execution controls are explicit, bounded, and fail closed without auto-dispatch (#50)', async () => {
+  const repositoryRoot = repository();
+  const isolatedHome = mkdtempSync(join(tmpdir(), 'coordinate-agents-exec-home-'));
+  const missingCommand = join(isolatedHome, 'definitely-missing-agent-cmd');
+  const originalHome = process.env.COORDINATE_AGENTS_HOME;
+  try {
+    // Isolate the machine user configuration so concurrent suites cannot leak
+    // a real executable into dispatch/run/advance probes; a user command that
+    // points at a missing absolute path fails deterministically.
+    mkdirSync(join(isolatedHome, '.coordinate-agents'), { recursive: true });
+    writeFileSync(join(isolatedHome, '.coordinate-agents', 'config.json'), `${JSON.stringify({
+      version: 1,
+      agents: {
+        codex: { command: missingCommand },
+        antigravity: { command: missingCommand },
+      },
+    }, null, 2)}\n`, 'utf8');
+    process.env.COORDINATE_AGENTS_HOME = isolatedHome;
+    const started = await startWorkspace({ root: repositoryRoot, port: 0 });
+    const base = started.url;
+    try {
+    const capability = await capabilityFromPage(base);
+    const post = payload => fetch(`${base}${ACTION_ENDPOINT}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-coordinate-agents-capability': capability },
+      body: JSON.stringify(payload),
+    });
+    const read = async response => ({ status: response.status, payload: await response.json() });
+    const taskRuntime = await import('../skills/coordinate-agents/scripts/task-runtime.mjs');
+    const graphRuntime = await import('../skills/coordinate-agents/scripts/task-graph-runtime.mjs');
+
+    // Dispatch without an approved specification returns a conflict and creates no Session.
+    const noSpec = taskRuntime.createTask(repositoryRoot, { id: 'task-exec-nospec', title: 'No spec yet' });
+    const conflict = await read(await post({ action: 'taskDispatch', params: { taskId: noSpec.id } }));
+    assert.equal(conflict.payload.ok, false);
+    assert.equal(conflict.payload.error.code, 'TASK_STATE_CONFLICT');
+    assert.match(conflict.payload.error.message, /specification/i);
+    assert.equal(existsSync(join(repositoryRoot, '.agent-bus', 'sessions')), false);
+
+    // A reviewed/APPROVED Task is not dispatchable (stale state): the Runtime
+    // returns a conflict and refreshes from the authoritative record.
+    const approvedTask = taskRuntime.createTask(repositoryRoot, { id: 'task-exec-approved', title: 'Dispatch fixture', spec: 'Implement the dispatch surface.' });
+    taskRuntime.setTaskStatus(repositoryRoot, approvedTask.id, 'PLANNING');
+    taskRuntime.setTaskStatus(repositoryRoot, approvedTask.id, 'SPEC_READY');
+    taskRuntime.setTaskStatus(repositoryRoot, approvedTask.id, 'IMPLEMENTING');
+    taskRuntime.setTaskStatus(repositoryRoot, approvedTask.id, 'REVIEWING', { evidence: [{ type: 'TESTS', id: 'e-1', relatedCommit: 'abc1234', details: 'ok' }] });
+    taskRuntime.recordReviewDecision(repositoryRoot, approvedTask.id, 'REVIEW_APPROVED', { feedback: 'approved' });
+    const stale = await read(await post({ action: 'taskDispatch', params: { taskId: approvedTask.id } }));
+    assert.equal(stale.payload.ok, false);
+    assert.equal(stale.payload.error.code, 'TASK_STATE_CONFLICT');
+    assert.match(stale.payload.error.message, /cannot be dispatched from APPROVED/);
+
+    // A SPEC_READY Task with a specification attempts dispatch and fails fast
+    // and recoverably on the missing executable, before any Session side effect.
+    const readyTask = taskRuntime.createTask(repositoryRoot, { id: 'task-exec-ready', title: 'Ready fixture', spec: 'Implement the ready surface.' });
+    taskRuntime.setTaskStatus(repositoryRoot, readyTask.id, 'SPEC_READY');
+    const missingExe = await read(await post({ action: 'taskDispatch', params: { taskId: readyTask.id } }));
+    assert.equal(missingExe.payload.ok, false, JSON.stringify(missingExe.payload.error || {}));
+    assert.equal(missingExe.payload.error.code, 'EXECUTABLE_NOT_FOUND');
+    assert.equal(missingExe.payload.error.recoverable, true);
+
+    // Advance bounds are enforced at the gateway before any Runtime call.
+    const graphId = 'task-exec-graph';
+    const createdGraph = await read(await post({
+      action: 'taskGraphCreate',
+      params: { graph: {
+        schemaVersion: 1,
+        parentTask: { id: graphId, title: 'Exec graph', spec: 'Run it.', planner: 'codex', reviewer: 'codex' },
+        subtasks: [{ id: 'w', implementer: 'antigravity', spec: 'Do w.', dependsOn: [] }],
+        maxConcurrency: 1,
+      } },
+    }));
+    assert.equal(createdGraph.payload.ok, true, JSON.stringify(createdGraph.payload.error || {}));
+    for (const maxWaves of [0, 33]) {
+      const outOfBounds = await read(await post({ action: 'taskGraphAdvance', params: { taskId: graphId, maxWaves } }));
+      assert.equal(outOfBounds.status, 400, `maxWaves ${maxWaves} must be rejected at the gateway`);
+      assert.equal(outOfBounds.payload.error.code, 'ACTION_PARAMS_INVALID');
+    }
+    // Advance executes as a bounded Runtime operation: wavesExecuted and a
+    // stop fact are returned and nothing spawns a Session or worktree when
+    // the Implementer executable is missing.
+    const advance = await read(await post({ action: 'taskGraphAdvance', params: { taskId: graphId, maxWaves: 1 } }));
+    assert.equal(advance.payload.ok, true, JSON.stringify(advance.payload.error || {}));
+    assert.equal(typeof advance.payload.wavesExecuted, 'number');
+    assert.ok('stop' in advance.payload);
+    assert.equal(existsSync(join(repositoryRoot, '.agent-bus', 'sessions')), false);
+    assert.equal(existsSync(join(repositoryRoot, '.agent-bus', 'worktrees')), false);
+
+    // Graph run on a CREATED graph is a bounded Runtime operation; with a
+    // missing executable it stops without spawning a Session or worktree.
+    const run = await read(await post({ action: 'taskGraphRun', params: { taskId: graphId, sessionWaitMs: 0 } }));
+    assert.equal(run.payload.ok, true, JSON.stringify(run.payload.error || {}));
+    assert.equal(existsSync(join(repositoryRoot, '.agent-bus', 'sessions')), false);
+    assert.equal(existsSync(join(repositoryRoot, '.agent-bus', 'worktrees')), false);
+
+    // Execution controls are render-only UI: assets ship but nothing auto-runs.
+    const page = await (await fetch(`${base}/`)).text();
+    assert.match(page, /id="execution-panel"/);
+    const js = await (await fetch(`${base}/app.js`)).text();
+    for (const expected of ['runExecutionAction', 'renderExecution', 'renderExecutionResult', 'taskDispatch', 'taskGraphRun', 'taskGraphAdvance', 'execution-confirm']) {
+      assert.ok(js.includes(expected), `Workspace app.js must expose execution support: ${expected}`);
+    }
+    const css = await (await fetch(`${base}/styles.css`)).text();
+    for (const expected of ['.execution-panel', '.execution-confirm-row', '.execution-fact', '.execution-ok']) {
+      assert.ok(css.includes(expected), `Workspace styles.css must style execution controls: ${expected}`);
+    }
+    } finally {
+      await closeServer(started.server);
+      await safeRm(repositoryRoot);
+    }
+  } finally {
+    process.env.COORDINATE_AGENTS_HOME = originalHome;
+    await safeRm(isolatedHome);
   }
 });


### PR DESCRIPTION
Implements #50 (P0-05): explicit Workspace controls for single-Task dispatch and the existing bounded Task Graph execution operations.

- Gateway: `taskDispatch`, `taskGraphRun`, `taskGraphAdvance` join the guarded allow-list; bounded `sessionWaitMs` (0-10000) and `maxWaves` (1-32) are enforced before any Runtime call (integer param validation added).
- UI: execution rows render only in selected Task/Graph detail, never fire on page load / GET / SSE reconnect / stale state / double click; Dispatch/Run/Advance arm only after an explicit understanding checkbox (process-launch side effects, no automatic retry, no merge/push/tag/publish/deploy/release). Advance needs explicit maxWaves; Run accepts bounded session-wait.
- Results surface the same Task/subtask/Session/worktree/commit/evidence/stop identities as CLI/MCP; invalid or stale state returns a conflict and views refresh from the authoritative Runtime record via bounded SSE with Last-Event-ID resume.
- Tests (isolated HOME against concurrent-suite executable leakage): no-spec dispatch conflict, stale APPROVED dispatch conflict, SPEC_READY dispatch fast-fails recoverably on a missing executable with no Session side effect, gateway maxWaves bounds, advance/run stop without Sessions/worktrees, render-only UI assets. `npm run test:core` (119 tests) green.

Closes #50