### PR TITLE
feat(web): operate Sessions and recovery safely from the Workspace (#51)

### DIFF
--- a/docs/inspector.md
+++ b/docs/inspector.md
@@ -71,9 +71,11 @@ The Workspace exposes exactly one additive, guarded action endpoint for later
 controls: `POST /api/action`. It routes an explicit allow-list of structured
 operations to the same shared Runtime services used by CLI and MCP
 (`setupDiscover`, `setupConfigure`, `taskCreate`, `taskDispatch`, `taskStatus`,
-`taskInspect`, `taskGraphStatus`, `taskGraphInspect`, `taskGraphPlan`,
-`taskGraphValidate`, `taskGraphCreate`, `taskGraphRun`, `taskGraphAdvance`,
-`recoverInspect`).
+`taskInspect`, `taskStop`, `taskResume`, `taskGraphStatus`, `taskGraphInspect`,
+`taskGraphPlan`, `taskGraphValidate`, `taskGraphCreate`, `taskGraphRun`,
+`taskGraphAdvance`, `taskGraphStop`, `taskGraphRecover`, `taskGraphResume`,
+`taskGraphCleanup`, `sessionStatus`, `sessionInspect`, `sessionRead`,
+`sessionWrite`, `sessionClose`, `recoverInspect`).
 The gateway never shells out, parses CLI output, proxies MCP, accepts an
 arbitrary operation name, or lets a request choose a different repository root.
 
@@ -133,7 +135,16 @@ canonical bound root path), followed by:
   including each Agent's current Agent Bus state.
 - **Task detail & Task Graph topology** — for ordinary Tasks: sequence-ordered recorded event timeline, role assignments, specification, implementation commit, evidence, review history, and last error. For Task Graphs: an **interactive dependency map** (deterministic layered layout, one focusable node per bounded subtask, dependency arrows from each dependency to its dependent, state legend, keyboard focus/`Escape`, and a selected-node evidence panel with the same bounded authoritative facts as the graph API — Agent/Adapter/executable, Session/worktree/commit, Scope Audit, recovery, cleanup, and last error) above the text topology, frontier decisions, preflight waves, write-intent conflicts, integration facts, and review decisions. Large graphs degrade with a bounded deterministic truncation notice; the map renders no edges and no browser graph model of its own.
 - **Sessions** — Session state, timestamps, linked Tasks, bounded recent output,
-  and recorded Session event history.
+  and recorded Session event history. Active Runtime-owned Sessions show a
+  bounded input control (explicit submit only) and a Close control; arbitrary
+  PIDs, paths, commands, environment data, and unattached processes are always
+  rejected by the Runtime ownership checks. Recovery rows on Task/Graph detail
+  are state-aware and explicit: Stop, Recover, Resume, and Clean up worktrees
+  reuse the existing ownership and recovery semantics, are idempotency- and
+  conflict-aware, and never retry automatically, silently discard verified
+  commits/evidence/user files, or touch remote refs. Cleanup removes only
+  Runtime-owned Sessions/worktrees and reports cleanup failures without hiding
+  the primary failure.
 - **Recent events** — timestamp, sequence, event type, Task, Session, Agent, and
   a bounded summary from the append-only journal.
 - **Author new work** — the authoring panel creates one durable Task or a Task

--- a/inspector/server/action-gateway.mjs
+++ b/inspector/server/action-gateway.mjs
@@ -149,6 +149,64 @@ const ACTION_DEFINITIONS = Object.freeze({
       sessionWaitMs: { type: 'integer', min: 0, max: 10_000 },
     },
   },
+  taskStop: {
+    operation: 'taskStop',
+    command: 'task.stop',
+    params: { taskId: { type: 'string', required: true, max: 128 } },
+  },
+  taskResume: {
+    operation: 'taskResume',
+    command: 'task.resume',
+    params: { taskId: { type: 'string', required: true, max: 128 } },
+  },
+  taskGraphStop: {
+    operation: 'taskGraphStop',
+    command: 'task.graph-stop',
+    params: { taskId: { type: 'string', required: true, max: 128 }, subtaskId: { type: 'string', max: 128 } },
+  },
+  taskGraphRecover: {
+    operation: 'taskGraphRecover',
+    command: 'task.graph-recover',
+    params: { taskId: { type: 'string', required: true, max: 128 }, subtaskId: { type: 'string', max: 128 } },
+  },
+  taskGraphResume: {
+    operation: 'taskGraphResume',
+    command: 'task.graph-resume',
+    params: { taskId: { type: 'string', required: true, max: 128 }, subtaskId: { type: 'string', max: 128 } },
+  },
+  taskGraphCleanup: {
+    operation: 'taskGraphCleanup',
+    command: 'task.graph-cleanup',
+    params: { taskId: { type: 'string', required: true, max: 128 } },
+  },
+  sessionStatus: {
+    operation: 'sessionStatus',
+    command: 'session.status',
+    params: { sessionId: { type: 'string', required: true, max: 256 } },
+  },
+  sessionInspect: {
+    operation: 'sessionInspect',
+    command: 'session.inspect',
+    params: { sessionId: { type: 'string', required: true, max: 256 } },
+  },
+  sessionRead: {
+    operation: 'sessionRead',
+    command: 'session.read',
+    params: { sessionId: { type: 'string', required: true, max: 256 }, limit: { type: 'integer', min: 1, max: 2000 } },
+  },
+  sessionWrite: {
+    operation: 'sessionWrite',
+    command: 'session.write',
+    params: {
+      sessionId: { type: 'string', required: true, max: 256 },
+      input: { type: 'string', required: true, max: 16 * 1024 },
+    },
+  },
+  sessionClose: {
+    operation: 'sessionClose',
+    command: 'session.close',
+    params: { sessionId: { type: 'string', required: true, max: 256 } },
+  },
   recoverInspect: {
     operation: 'recoverInspect',
     command: 'recover.inspect',

--- a/inspector/web-workspace/app.js
+++ b/inspector/web-workspace/app.js
@@ -574,6 +574,15 @@ function renderSessions() {
       <div class="session-meta"><span>Created ${formatDate(session.createdAt)}</span><span>Last activity ${formatDate(session.lastActivity)}</span></div>
       <pre class="session-output">${escapeHtml(session.recentOutput || 'No recent output available.')}</pre>
       ${session.taskIds?.length ? `<div class="session-tasks">Tasks: ${session.taskIds.map(escapeHtml).join(', ')}</div>` : ''}
+      ${['starting', 'running', 'idle', 'busy'].includes(session.status) ? `
+      <div class="session-controls">
+        <form class="session-input-form" data-session="${escapeHtml(session.sessionId)}">
+          <input class="session-input-text" maxlength="4096" placeholder="Bounded input to this owned Session…">
+          <button class="button" type="submit">Send input</button>
+        </form>
+        <button class="button ghost session-close-btn" type="button" data-session="${escapeHtml(session.sessionId)}">Close Session</button>
+      </div>` : ''}
+      <span class="session-control-status" data-session="${escapeHtml(session.sessionId)}" aria-live="polite"></span>
       <div class="session-history">
         <span class="history-label">${session.historySource === 'recorded' ? 'Recorded Events' : 'Derived / Legacy History'}</span>
         ${(session.events || []).slice(-8).map(event => `<div><code>${event.sequence ? `#${escapeHtml(event.sequence)}` : '—'}</code><strong>${escapeHtml(event.event)}</strong><time>${formatDate(event.timestamp)}</time></div>`).join('')}
@@ -772,6 +781,81 @@ function closeGraphMap() {
   if (state.graphDetail) renderGraphMap(state.graphDetail);
 }
 
+function recoveryControls(detail) {
+  const graph = Boolean(detail?.graph);
+  const state = detail?.state || detail?.status;
+  const buttons = [];
+  const add = (action, label, taskId, extra = '') => buttons.push(
+    `<button class="button ghost" type="button" data-run-action="${action}" data-label="${escapeHtml(label)}" data-params="${escapeHtml(JSON.stringify({ taskId: taskId || detail.id }))}">${escapeHtml(label)}</button>${extra}`);
+  if (!graph) {
+    if (['IMPLEMENTING', 'WAITING_IMPLEMENTER'].includes(state)) add('taskStop', 'Stop Task', detail.id);
+    if (['ERROR', 'STOPPED'].includes(state)) add('taskResume', 'Resume Task', detail.id);
+  } else {
+    const note = `<span class="agent-muted">state ${escapeHtml(state || 'unknown')}</span>`;
+    if (state === 'RUNNING') add('taskGraphStop', 'Stop graph', detail.id, note);
+    if (['FAILED', 'RECOVERING'].includes(state)) add('taskGraphRecover', 'Recover graph', detail.id, note);
+    if (['FAILED', 'STOPPED', 'BLOCKED', 'RECOVERING'].includes(state)) add('taskGraphResume', 'Resume graph', detail.id, note);
+    if (['STOPPED', 'FAILED', 'SUCCEEDED', 'APPROVED'].includes(state)) add('taskGraphCleanup', 'Clean up worktrees', detail.id, note);
+    if (!buttons.length) return `<span class="agent-muted">${escapeHtml(state || '')} — no automatic recovery action; review the Runtime facts and act explicitly.</span>`;
+  }
+  return buttons.length ? `<span class="recovery-sep">Recovery & ownership</span>${buttons.join(' ')}` : '';
+}
+
+function setSessionControlStatus(sessionId, message, kind = 'info') {
+  const target = elements.sessions.querySelector(`.session-control-status[data-session="${CSS.escape(sessionId)}"]`);
+  if (!target) return;
+  target.textContent = message;
+  target.className = `session-control-status ${kind}`;
+}
+
+async function submitSessionInput(form) {
+  const sessionId = form.dataset.session;
+  const input = form.querySelector('.session-input-text');
+  const text = input.value.trim();
+  if (!text) return;
+  input.value = '';
+  setSessionControlStatus(sessionId, 'Sending bounded input…');
+  try {
+    const { status, payload } = await postAction('sessionWrite', { sessionId, input: text });
+    if (status !== 200 || payload?.ok !== true) {
+      setSessionControlStatus(sessionId, `Input rejected: ${payload?.error?.code || `HTTP ${status}`} — ${payload?.error?.message || ''}`, 'error');
+      return;
+    }
+    setSessionControlStatus(sessionId, 'Input accepted.', 'ok');
+    await refresh();
+  } catch (error) {
+    setSessionControlStatus(sessionId, `Input failed: ${error.message}`, 'error');
+  }
+}
+
+async function closeOwnedSession(sessionId) {
+  setSessionControlStatus(sessionId, 'Closing Session…');
+  try {
+    const { status, payload } = await postAction('sessionClose', { sessionId });
+    if (status !== 200 || payload?.ok !== true) {
+      setSessionControlStatus(sessionId, `Close rejected: ${payload?.error?.code || `HTTP ${status}`} — ${payload?.error?.message || ''}`, 'error');
+      return;
+    }
+    setSessionControlStatus(sessionId, 'Session closed.', 'ok');
+    await refresh();
+  } catch (error) {
+    setSessionControlStatus(sessionId, `Close failed: ${error.message}`, 'error');
+  }
+}
+
+function bindSessionActions(container) {
+  if (!container) return;
+  container.querySelectorAll('.session-input-form').forEach(form => {
+    form.addEventListener('submit', event => {
+      event.preventDefault();
+      submitSessionInput(form);
+    });
+  });
+  container.querySelectorAll('.session-close-btn').forEach(button => {
+    button.addEventListener('click', () => closeOwnedSession(button.dataset.session));
+  });
+}
+
 function setExecutionStatus(message, kind = 'info') {
   const element = elements['execution-status'];
   element.textContent = message;
@@ -872,7 +956,7 @@ function renderExecution(detail) {
       <label class="execution-field">maxWaves (1–32)<input type="number" class="execution-max-waves" min="1" max="32" value="1"></label>
       <button class="button" type="button" data-run-action="taskGraphAdvance" data-label="Advance ${escapeHtml(id)}">Advance graph</button>`;
   }
-  elements['execution-controls'].innerHTML = controls;
+  elements['execution-controls'].innerHTML = controls + recoveryControls(detail);
   const waitInput = elements['execution-controls'].querySelector('.execution-session-wait');
   const wavesInput = elements['execution-controls'].querySelector('.execution-max-waves');
   if (waitInput) {
@@ -1035,6 +1119,7 @@ async function refresh() {
     renderConfiguredAgents(state.agents);
     refreshAgentSelects();
     renderSessions();
+    bindSessionActions(elements.sessions);
     renderEvents();
     if (state.selectedTask) {
       try { renderTaskDetail(await fetchJson(`/api/tasks/${encodeURIComponent(state.selectedTask)}`)); } catch { /* The list remains useful if a task is removed during refresh. */ }

--- a/inspector/web-workspace/styles.css
+++ b/inspector/web-workspace/styles.css
@@ -324,3 +324,12 @@ h3 { margin-bottom: 1rem; color: var(--muted); font-size: .74rem; letter-spacing
 .execution-fact { display: flex; justify-content: space-between; gap: .6rem; color: var(--muted); font-size: .74rem; }
 .execution-fact code { max-width: 70%; color: var(--text); overflow-wrap: anywhere; text-align: right; }
 .execution-detail { margin-top: .35rem; color: var(--muted); font-size: .72rem; overflow-wrap: anywhere; }
+
+/* Session console & recovery controls */
+.session-controls { display: flex; flex-wrap: wrap; align-items: center; gap: .5rem; margin-top: .7rem; }
+.session-input-form { display: flex; flex: 1 1 18rem; gap: .45rem; }
+.session-input-text { flex: 1; min-width: 0; padding: .45rem .55rem; border: 1px solid var(--line); border-radius: .5rem; color: var(--text); background: var(--panel-strong); font: .74rem inherit; }
+.session-control-status { display: block; margin-top: .45rem; font-size: .72rem; overflow-wrap: anywhere; }
+.session-control-status.ok { color: var(--green); }
+.session-control-status.error { color: var(--red); }
+.recovery-sep { width: 100%; margin-top: .4rem; color: var(--yellow); font-size: .62rem; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }

--- a/test/action-gateway.test.mjs
+++ b/test/action-gateway.test.mjs
@@ -698,3 +698,99 @@ test('execution controls are explicit, bounded, and fail closed without auto-dis
     await safeRm(isolatedHome);
   }
 });
+
+test('Session console and recovery controls stay explicit, owned, and idempotent (#51)', async () => {
+  const repositoryRoot = repository();
+  const isolatedHome = mkdtempSync(join(tmpdir(), 'coordinate-agents-recovery-home-'));
+  const missingCommand = join(isolatedHome, 'definitely-missing-agent-cmd');
+  const originalHome = process.env.COORDINATE_AGENTS_HOME;
+  try {
+    mkdirSync(join(isolatedHome, '.coordinate-agents'), { recursive: true });
+    const userConfigBody = JSON.stringify({
+      version: 1,
+      agents: { codex: { command: missingCommand }, antigravity: { command: missingCommand } },
+    }, null, 2) + "\n";
+    writeFileSync(join(isolatedHome, '.coordinate-agents', 'config.json'), userConfigBody, 'utf8');
+    process.env.COORDINATE_AGENTS_HOME = isolatedHome;
+    const started = await startWorkspace({ root: repositoryRoot, port: 0 });
+    const base = started.url;
+    try {
+      const capability = await capabilityFromPage(base);
+      const post = payload => fetch(base + ACTION_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-coordinate-agents-capability': capability },
+        body: JSON.stringify(payload),
+      });
+      const read = async response => ({ status: response.status, payload: await response.json() });
+      const taskRuntime = await import('../skills/coordinate-agents/scripts/task-runtime.mjs');
+
+      const graphId = 'task-recovery-graph';
+      const createdGraph = await read(await post({
+        action: 'taskGraphCreate',
+        params: { graph: {
+          schemaVersion: 1,
+          parentTask: { id: graphId, title: 'Recovery graph', spec: 's', planner: 'codex', reviewer: 'codex' },
+          subtasks: [{ id: 'a', implementer: 'antigravity', spec: 'do', dependsOn: [] }],
+          maxConcurrency: 1,
+        } },
+      }));
+      assert.equal(createdGraph.payload.ok, true, JSON.stringify(createdGraph.payload.error || {}));
+
+      // Recovery/cleanup controls are idempotent and facts-first on a graph
+      // that has never run: no Session or worktree is created.
+      for (const action of ['taskGraphRecover', 'taskGraphResume', 'taskGraphStop', 'taskGraphCleanup']) {
+        const result = await read(await post({ action, params: { taskId: graphId } }));
+        assert.equal(result.payload.ok, true, action + ' must be idempotent-safe on a fresh graph: ' + JSON.stringify(result.payload.error || {}));
+      }
+      assert.equal(existsSync(join(repositoryRoot, '.agent-bus', 'sessions')), false);
+      assert.equal(existsSync(join(repositoryRoot, '.agent-bus', 'worktrees')), false);
+
+      // Single-Task stop on a fresh Task is conflict-aware.
+      const freshTask = taskRuntime.createTask(repositoryRoot, { id: 'task-recovery-single', title: 'Fresh', spec: 's' });
+      const stopResult = await read(await post({ action: 'taskStop', params: { taskId: freshTask.id } }));
+      assert.equal(stopResult.payload.ok, true, JSON.stringify(stopResult.payload.error || {}));
+      const stoppedRecord = taskRuntime.readTask(repositoryRoot, freshTask.id);
+      assert.equal(stoppedRecord.status, 'STOPPED', 'Stop marks the owned Task STOPPED without auto retry');
+
+      // Session controls reject unknown Sessions with canonical errors and
+      // never write or spawn anything.
+      const sessionProbes = [
+        ['sessionStatus', {}],
+        ['sessionInspect', {}],
+        ['sessionRead', { limit: 50 }],
+        ['sessionClose', {}],
+      ];
+      for (const entry of sessionProbes) {
+        const action = entry[0];
+        const extra = entry[1];
+        const result = await read(await post({ action, params: Object.assign({ sessionId: 'session_never_owned' }, extra) }));
+        assert.equal(result.payload.ok, false, action + ' must reject an unknown Session');
+        assert.equal(result.payload.error.code, 'SESSION_NOT_FOUND', action + ' must report SESSION_NOT_FOUND');
+      }
+      const writeProbe = await read(await post({ action: 'sessionWrite', params: { sessionId: 'session_never_owned', input: 'hi' } }));
+      assert.equal(writeProbe.payload.ok, false);
+      assert.equal(writeProbe.payload.error.code, 'SESSION_NOT_FOUND');
+      const sessionsDir = join(repositoryRoot, '.agent-bus', 'sessions');
+      const sessionRecords = existsSync(sessionsDir) ? readdirSync(sessionsDir).filter(name => name.endsWith('.json')) : [];
+      assert.equal(sessionRecords.length, 0, 'Rejected Session input must not create any Session record');
+
+      // Session and recovery assets ship in the Workspace.
+      const page = await (await fetch(base + '/')).text();
+      assert.match(page, /id="sessions"/);
+      const js = await (await fetch(base + '/app.js')).text();
+      for (const expected of ['recoveryControls', 'bindSessionActions', 'submitSessionInput', 'closeOwnedSession', 'sessionWrite', 'sessionClose', 'taskGraphCleanup', 'taskResume', 'session-card']) {
+        assert.ok(js.includes(expected), 'Workspace app.js must expose session/recovery support: ' + expected);
+      }
+      const css = await (await fetch(base + '/styles.css')).text();
+      for (const expected of ['.session-controls', '.session-input-form', '.session-control-status', '.recovery-sep']) {
+        assert.ok(css.includes(expected), 'Workspace styles.css must style session/recovery: ' + expected);
+      }
+      } finally {
+        await closeServer(started.server);
+        await safeRm(repositoryRoot);
+      }
+  } finally {
+    process.env.COORDINATE_AGENTS_HOME = originalHome;
+    await safeRm(isolatedHome);
+  }
+});


### PR DESCRIPTION
Implements #51 (P0-06): the Workspace Session console and explicit recovery controls for Runtime-owned Tasks and Task Graphs.

- Gateway: taskStop/taskResume, taskGraphStop/taskGraphRecover/taskGraphResume/taskGraphCleanup, and sessionStatus/sessionInspect/sessionRead/sessionWrite/sessionClose join the guarded allow-list (bounded input caps, bounded read limits).
- UI: active owned Session cards get bounded input (explicit submit) and Close controls; Task/Graph detail gains state-aware Recovery rows (Stop / Recover / Resume / Clean up worktrees) behind the same explicit confirmation used for execution; ownership, idempotency, and conflict semantics come from the Runtime; no automatic retry, no silent discard of commits/evidence/user files, no remote-ref mutation.
- Tests: facts-first idempotent recovery on a never-run graph (no Sessions/worktrees), Stop marks an owned fresh Task STOPPED, unknown Session controls return SESSION_NOT_FOUND without creating records, asset checks. `npm run test:core` (120 tests) green.

Closes #51