### PR TITLE
feat(web): integrate results and record review decisions in the Workspace (#52)

### DIFF
--- a/docs/inspector.md
+++ b/docs/inspector.md
@@ -71,10 +71,11 @@ The Workspace exposes exactly one additive, guarded action endpoint for later
 controls: `POST /api/action`. It routes an explicit allow-list of structured
 operations to the same shared Runtime services used by CLI and MCP
 (`setupDiscover`, `setupConfigure`, `taskCreate`, `taskDispatch`, `taskStatus`,
-`taskInspect`, `taskStop`, `taskResume`, `taskGraphStatus`, `taskGraphInspect`,
-`taskGraphPlan`, `taskGraphValidate`, `taskGraphCreate`, `taskGraphRun`,
-`taskGraphAdvance`, `taskGraphStop`, `taskGraphRecover`, `taskGraphResume`,
-`taskGraphCleanup`, `sessionStatus`, `sessionInspect`, `sessionRead`,
+`taskInspect`, `taskStop`, `taskResume`, `taskReview`, `taskGraphStatus`,
+`taskGraphInspect`, `taskGraphPlan`, `taskGraphValidate`, `taskGraphCreate`,
+`taskGraphRun`, `taskGraphAdvance`, `taskGraphStop`, `taskGraphRecover`,
+`taskGraphResume`, `taskGraphCleanup`, `taskGraphIntegrate`,
+`taskGraphReview`, `sessionStatus`, `sessionInspect`, `sessionRead`,
 `sessionWrite`, `sessionClose`, `recoverInspect`).
 The gateway never shells out, parses CLI output, proxies MCP, accepts an
 arbitrary operation name, or lets a request choose a different repository root.
@@ -172,6 +173,17 @@ canonical bound root path), followed by:
   invalid state returns a conflict and views refresh from the authoritative
   Runtime record via bounded SSE/refresh with `Last-Event-ID` resume. The
   Workspace never modifies the user's checked-out worktree or remote refs.
+- **Review & integrate** — Task/Graph detail offers an explicit integrate
+  action (applies verified subtask commits only to the Runtime-owned aggregate
+  review worktree) and a bounded review form that records
+  `REVIEW_APPROVED` / `CHANGES_REQUESTED` with feedback/evidence through the
+  shared Runtime operation; decisions are durable and visible after reload and
+  requested changes never trigger an automatic retry. The surface shows
+  commits, worktrees, Scope Audit, intent conflicts, recovery, integration,
+  Sessions, Event Journal, and review history with parent identity preserved,
+  and states plainly that review approval is not the human `RELEASE_APPROVED`
+  gate — the Workspace offers no merge, push, tag, publish, deploy, or release
+  control.
 
 ## Endpoints
 

--- a/inspector/server/action-gateway.mjs
+++ b/inspector/server/action-gateway.mjs
@@ -207,6 +207,31 @@ const ACTION_DEFINITIONS = Object.freeze({
     command: 'session.close',
     params: { sessionId: { type: 'string', required: true, max: 256 } },
   },
+  taskGraphIntegrate: {
+    operation: 'taskGraphIntegrate',
+    command: 'task.graph-integrate',
+    params: { taskId: { type: 'string', required: true, max: 128 } },
+  },
+  taskReview: {
+    operation: 'taskReview',
+    command: 'task.review',
+    params: {
+      taskId: { type: 'string', required: true, max: 128 },
+      decision: { type: 'string', required: true, max: 32, enum: ['REVIEW_APPROVED', 'CHANGES_REQUESTED'] },
+      feedback: { type: 'string', max: 16 * 1024 },
+      evidence: { type: 'object', max: 64 * 1024 },
+    },
+  },
+  taskGraphReview: {
+    operation: 'taskGraphReview',
+    command: 'task.graph-review',
+    params: {
+      taskId: { type: 'string', required: true, max: 128 },
+      decision: { type: 'string', required: true, max: 32, enum: ['REVIEW_APPROVED', 'CHANGES_REQUESTED'] },
+      feedback: { type: 'string', max: 16 * 1024 },
+      evidence: { type: 'object', max: 64 * 1024 },
+    },
+  },
   recoverInspect: {
     operation: 'recoverInspect',
     command: 'recover.inspect',
@@ -317,6 +342,7 @@ function validateParams(definition, params) {
         return `Parameter ${key} is outside the supported range.`;
       }
     }
+    if (Array.isArray(rule.enum) && !rule.enum.includes(value)) return `Parameter ${key} has an unsupported value.`;
   }
   return null;
 }

--- a/inspector/web-workspace/app.js
+++ b/inspector/web-workspace/app.js
@@ -63,6 +63,7 @@ const elements = Object.fromEntries([
   'author-subtask-rows', 'author-graph-validate', 'author-graph-create', 'author-graph-status',
   'author-graph-errors', 'author-graph-validated', 'author-graph-preflight',
   'execution-panel', 'execution-title', 'execution-controls', 'execution-status', 'execution-result',
+  'review-panel', 'review-controls', 'review-status', 'review-result',
 ].map(id => [id, document.getElementById(id)]));
 
 function escapeHtml(value) {
@@ -982,6 +983,131 @@ function renderExecution(detail) {
   bindExecutionControls(elements['execution-controls'], detail);
 }
 
+function setReviewStatus(message, kind = 'info') {
+  const element = elements['review-status'];
+  element.textContent = message;
+  element.className = `author-status ${kind}`;
+}
+
+function reviewParams(detail) {
+  const decision = elements['review-controls'].querySelector('.review-decision')?.value;
+  const feedback = elements['review-controls'].querySelector('.review-feedback')?.value.trim() || undefined;
+  const evidenceText = elements['review-controls'].querySelector('.review-evidence')?.value.trim() || '';
+  let evidence;
+  if (evidenceText) {
+    try {
+      evidence = JSON.parse(evidenceText);
+      if (typeof evidence !== 'object' || evidence === null || Array.isArray(evidence)) throw new Error('object');
+    } catch {
+      setReviewStatus('Review evidence must be valid JSON object text.', 'error');
+      return null;
+    }
+  }
+  const params = { taskId: detail.id, decision };
+  if (feedback) params.feedback = feedback;
+  if (evidence) params.evidence = evidence;
+  return params;
+}
+
+async function submitReview(detail) {
+  const params = reviewParams(detail);
+  if (!params) return;
+  if (!params.decision) {
+    setReviewStatus('Choose a review decision.', 'error');
+    return;
+  }
+  const action = Boolean(detail.graph) ? 'taskGraphReview' : 'taskReview';
+  const label = Boolean(detail.graph) ? 'Graph review' : 'Task review';
+  setReviewStatus(`${label}: recording decision…`);
+  try {
+    const { status, payload } = await postAction(action, params);
+    if (status !== 200 || payload?.ok !== true) {
+      const error = payload?.error || {};
+      setReviewStatus(`${label} rejected: ${error.code || `HTTP ${status}`} — ${error.message || ''}${error.details ? ` (${error.details})` : ''}`, 'error');
+      return;
+    }
+    setReviewStatus(`${label} recorded (${payload.review?.decision || payload.status || params.decision}). Durable after reload.`, 'ok');
+    await refresh();
+  } catch (error) {
+    setReviewStatus(`${label} request failed: ${error.message}`, 'error');
+  }
+}
+
+async function integrateGraph(detail) {
+  setReviewStatus('Integrating verified subtask commits into the Runtime-owned aggregate review worktree…');
+  try {
+    const { status, payload } = await postAction('taskGraphIntegrate', { taskId: detail.id });
+    if (status !== 200 || payload?.ok !== true) {
+      const error = payload?.error || {};
+      setReviewStatus(`Integration rejected: ${error.code || `HTTP ${status}`} — ${error.message || ''}${error.details ? ` (${error.details})` : ''}`, 'error');
+      return;
+    }
+    const region = elements['review-result'];
+    region.hidden = false;
+    region.innerHTML = `<div class="execution-ok"><strong>Integration complete</strong>
+      <div class="execution-facts">
+        ${factBlock('Aggregate commit', payload.integration?.aggregateCommit || payload.aggregateCommit)}
+        ${factBlock('Applied refs', payload.integration?.appliedCommits)}
+        ${factBlock('Review worktree', payload.integration?.worktreePath)}
+        ${factBlock('Branch', payload.integration?.branch)}
+        ${factBlock('Conflicts', payload.integration?.conflicts)}
+      </div></div>`;
+    setReviewStatus('Integration recorded. Review the aggregate facts, then record a decision.', 'ok');
+    await refresh();
+  } catch (error) {
+    setReviewStatus(`Integration request failed: ${error.message}`, 'error');
+  }
+}
+
+function renderReview(detail) {
+  const panel = elements['review-panel'];
+  if (!detail) {
+    panel.hidden = true;
+    return;
+  }
+  panel.hidden = false;
+  elements['review-result'].hidden = true;
+  setReviewStatus('');
+  const graph = Boolean(detail.graph);
+  const state = detail.state || detail.status;
+  const reviewable = graph
+    ? ['RUNNING', 'SUCCEEDED', 'APPROVED', 'REVIEW_APPROVED', 'CHANGES_REQUESTED'].includes(state)
+    : ['REVIEWING', 'CHANGES_REQUESTED'].includes(state);
+  const controls = [];
+  controls.push(`<label class="author-toggle review-confirm-row"><input type="checkbox" class="review-confirm"> I understand: integration/review targets Runtime-owned artifacts only; review approval is not release approval; no merge, push, tag, publish, deploy, or release happens here.</label>`);
+  if (graph) {
+    controls.push(`<button class="button" type="button" id="review-integrate">Integrate verified subtasks</button>`);
+  }
+  controls.push(`<div class="review-form">
+    <label>Decision<select class="review-decision">
+      <option value="REVIEW_APPROVED">REVIEW_APPROVED</option>
+      <option value="CHANGES_REQUESTED">CHANGES_REQUESTED</option>
+    </select></label>
+    <label>Feedback<textarea class="review-feedback" rows="3" maxlength="16384" placeholder="Bounded review feedback…"></textarea></label>
+    <label>Evidence (optional JSON object)<textarea class="review-evidence" rows="2" maxlength="65536" placeholder="{ &quot;tests&quot;: &quot;passed&quot; }"></textarea></label>
+    <button class="button" type="button" id="review-submit" ${reviewable ? '' : 'disabled title="Current state is not reviewable; review applies to reviewed/changes-requested Tasks or running/succeeded graphs"'}>Record review decision</button>
+    <span class="agent-muted">state ${escapeHtml(state || 'unknown')}</span>
+  </div>`);
+  elements['review-controls'].innerHTML = controls.join('');
+  const confirm = elements['review-controls'].querySelector('.review-confirm');
+  const integrate = elements['review-controls'].querySelector('#review-integrate');
+  const submit = elements['review-controls'].querySelector('#review-submit');
+  const arm = () => {
+    if (integrate) integrate.disabled = !confirm.checked;
+    if (submit) submit.disabled = !confirm.checked || !reviewable;
+  };
+  confirm.addEventListener('change', arm);
+  arm();
+  integrate?.addEventListener('click', () => {
+    integrate.disabled = true;
+    integrateGraph(detail).finally(() => { if (confirm) confirm.checked = false; arm(); });
+  });
+  submit?.addEventListener('click', () => {
+    submit.disabled = true;
+    submitReview(detail).finally(() => { if (confirm) confirm.checked = false; arm(); });
+  });
+}
+
 function renderGraphDetail(task) {
   const graph = Boolean(task?.graph);
   elements['graph-detail'].hidden = !graph;
@@ -1042,6 +1168,7 @@ function renderTaskDetail(task) {
   if (!task) {
     elements['task-detail'].hidden = true;
     renderExecution(null);
+    renderReview(null);
     return;
   }
   elements['task-detail'].hidden = false;
@@ -1053,6 +1180,7 @@ function renderTaskDetail(task) {
     <span>Updated ${formatDate(task.updatedAt)}</span>
   `;
   renderExecution(task);
+  renderReview(task);
   renderGraphDetail(task);
   renderTimeline(task.timeline);
   elements['detail-agent-flow'].innerHTML = (task.agentFlow || []).map((item, index) => {

--- a/inspector/web-workspace/index.html
+++ b/inspector/web-workspace/index.html
@@ -118,6 +118,23 @@
           <span id="execution-status" class="author-status" aria-live="polite"></span>
           <div id="execution-result" class="execution-result" aria-live="polite" hidden></div>
         </div>
+        <div id="review-panel" class="review-panel" hidden>
+          <div class="section-heading">
+            <div>
+              <p class="eyebrow">REVIEW & INTEGRATE</p>
+              <h2>Review & integrate</h2>
+            </div>
+            <span class="muted-label">review approval is never release approval</span>
+          </div>
+          <p class="agents-note">Integration applies verified subtask commits only to the Runtime-owned aggregate
+            review worktree — never to your checked-out worktree or remote refs. Recording a review decision is
+            durable and visible after reload; requested changes never trigger an automatic retry. This Workspace
+            offers no merge, push, tag, publish, deploy, or release control: releasing requires the separate human
+            <code>RELEASE_APPROVED</code> gate.</p>
+          <div id="review-controls" class="review-controls"></div>
+          <span id="review-status" class="author-status" aria-live="polite"></span>
+          <div id="review-result" class="review-result" aria-live="polite" hidden></div>
+        </div>
         <section id="graph-detail" class="graph-detail" hidden>
           <section id="graph-map-region" class="graph-map-region">
             <div class="section-heading">

--- a/inspector/web-workspace/styles.css
+++ b/inspector/web-workspace/styles.css
@@ -333,3 +333,15 @@ h3 { margin-bottom: 1rem; color: var(--muted); font-size: .74rem; letter-spacing
 .session-control-status.ok { color: var(--green); }
 .session-control-status.error { color: var(--red); }
 .recovery-sep { width: 100%; margin-top: .4rem; color: var(--yellow); font-size: .62rem; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
+
+/* Review & integrate panel */
+.review-panel { margin-bottom: 1.5rem; padding: 1rem; border: 1px solid rgba(140, 169, 255, .3); border-radius: .8rem; background: rgba(140, 169, 255, .05); }
+.review-panel .agents-note { margin-bottom: .8rem; }
+.review-controls { display: flex; flex-wrap: wrap; align-items: center; gap: .7rem; margin-bottom: .4rem; }
+.review-confirm-row { max-width: 64ch; color: var(--text) !important; font-size: .76rem !important; font-weight: 500 !important; letter-spacing: 0 !important; text-transform: none !important; }
+.review-form { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: .7rem; width: 100%; margin-top: .4rem; }
+.review-form label { display: flex; flex-direction: column; gap: .3rem; color: var(--muted); font-size: .66rem; font-weight: 700; letter-spacing: .05em; text-transform: uppercase; }
+.review-form select, .review-form textarea { padding: .5rem .6rem; border: 1px solid var(--line); border-radius: .5rem; color: var(--text); background: var(--panel-strong); font: .8rem inherit; }
+.review-form textarea { resize: vertical; }
+.review-form .button:disabled { opacity: .45; cursor: not-allowed; }
+.review-result { margin-top: .5rem; }

--- a/test/action-gateway.test.mjs
+++ b/test/action-gateway.test.mjs
@@ -794,3 +794,90 @@ test('Session console and recovery controls stay explicit, owned, and idempotent
     await safeRm(isolatedHome);
   }
 });
+
+test('review and integrate controls are explicit, conflict-aware, and never release (#52)', async () => {
+  const repositoryRoot = repository();
+  const isolatedHome = mkdtempSync(join(tmpdir(), 'coordinate-agents-review-home-'));
+  const missingCommand = join(isolatedHome, 'definitely-missing-agent-cmd');
+  const originalHome = process.env.COORDINATE_AGENTS_HOME;
+  try {
+    mkdirSync(join(isolatedHome, '.coordinate-agents'), { recursive: true });
+    const body = JSON.stringify({ version: 1, agents: { codex: { command: missingCommand }, antigravity: { command: missingCommand } } }, null, 2) + "\n";
+    writeFileSync(join(isolatedHome, '.coordinate-agents', 'config.json'), body, 'utf8');
+    process.env.COORDINATE_AGENTS_HOME = isolatedHome;
+    const started = await startWorkspace({ root: repositoryRoot, port: 0 });
+    const base = started.url;
+    try {
+      const capability = await capabilityFromPage(base);
+      const post = payload => fetch(base + ACTION_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-coordinate-agents-capability': capability },
+        body: JSON.stringify(payload),
+      });
+      const read = async response => ({ status: response.status, payload: await response.json() });
+      const taskRuntime = await import('../skills/coordinate-agents/scripts/task-runtime.mjs');
+
+      const graphId = 'task-review-graph';
+      const created = await read(await post({
+        action: 'taskGraphCreate',
+        params: { graph: {
+          schemaVersion: 1,
+          parentTask: { id: graphId, title: 'Review graph', spec: 's', planner: 'codex', reviewer: 'codex' },
+          subtasks: [{ id: 'a', implementer: 'antigravity', spec: 'do', dependsOn: [] }],
+          maxConcurrency: 1,
+        } },
+      }));
+      assert.equal(created.payload.ok, true, JSON.stringify(created.payload.error || {}));
+
+      // Unsupported review decisions are rejected by the gateway before any Runtime call.
+      for (const decision of ['NOPE', 'APPROVE', '']) {
+        const bad = await read(await post({ action: 'taskReview', params: { taskId: 'task-x', decision } }));
+        assert.equal(bad.status, 400, 'decision ' + decision + ' must be rejected at the gateway');
+        assert.equal(bad.payload.error.code, 'ACTION_PARAMS_INVALID');
+      }
+
+      // Integration on a graph without verified subtask completion is a conflict,
+      // and review of that graph fails with the same Runtime gate; no user
+      // checkout or remote ref is touched.
+      const integrate = await read(await post({ action: 'taskGraphIntegrate', params: { taskId: graphId } }));
+      assert.equal(integrate.payload.ok, false, JSON.stringify(integrate.payload.error || {}));
+      assert.equal(integrate.payload.error.code, 'TASK_STATE_CONFLICT');
+      const review = await read(await post({ action: 'taskGraphReview', params: { taskId: graphId, decision: 'REVIEW_APPROVED', feedback: 'ok' } }));
+      assert.equal(review.payload.ok, false);
+      const porcelain = spawnSync('git', ['status', '--porcelain'], { cwd: repositoryRoot, encoding: 'utf8', windowsHide: true });
+      assert.equal(porcelain.stdout.trim(), '', 'Integration/review attempts must not touch the user checkout');
+      const gitBranch = spawnSync('git', ['branch', '--list', '--remote'], { cwd: repositoryRoot, encoding: 'utf8', windowsHide: true });
+      assert.equal(gitBranch.stdout.trim(), '', 'No remote refs are created by review controls');
+
+      // Single-Task review is state-aware: a fresh Task is not reviewable.
+      const freshTask = taskRuntime.createTask(repositoryRoot, { id: 'task-review-single', title: 'Fresh', spec: 's' });
+      const taskReview = await read(await post({ action: 'taskReview', params: { taskId: freshTask.id, decision: 'REVIEW_APPROVED', feedback: 'looks good' } }));
+      assert.equal(taskReview.payload.ok, false);
+      assert.ok(taskReview.payload.error.code, 'Single-Task review must be gated by Runtime state');
+
+      // Review UI explicitly separates review approval from RELEASE_APPROVED and
+      // ships no release control.
+      const page = await (await fetch(base + '/')).text();
+      assert.match(page, /id="review-panel"/);
+      const js = await (await fetch(base + '/app.js')).text();
+      assert.ok(page.includes('RELEASE_APPROVED'), 'Review UI text must name the human RELEASE_APPROVED gate');
+      for (const expected of ['renderReview', 'integrateGraph', 'submitReview', 'reviewParams', 'taskGraphIntegrate', 'taskGraphReview', 'taskReview']) {
+        assert.ok(js.includes(expected), 'Workspace app.js must expose review/integrate support: ' + expected);
+      }
+      const htmlLower = (await (await fetch(base + '/')).text()).toLowerCase();
+      for (const forbidden of ['>merge<', '>push<', '>publish<', '>deploy<', '>release<', '>tag<']) {
+        assert.equal(htmlLower.includes(forbidden), false, 'Review UI must not offer release-like controls: ' + forbidden);
+      }
+      const css = await (await fetch(base + '/styles.css')).text();
+      for (const expected of ['.review-panel', '.review-form', '.review-confirm-row', '.review-result']) {
+        assert.ok(css.includes(expected), 'Workspace styles.css must style review: ' + expected);
+      }
+      } finally {
+        await closeServer(started.server);
+        await safeRm(repositoryRoot);
+      }
+  } finally {
+    process.env.COORDINATE_AGENTS_HOME = originalHome;
+    await safeRm(isolatedHome);
+  }
+});


### PR DESCRIPTION
Implements #52 (P0-07): evidence and review surface completing the Web-first delivery loop.

- Gateway: `taskGraphIntegrate`, `taskReview`, `taskGraphReview` join the allow-list; validator gains enum support (unsupported decisions rejected 400 before any Runtime call); feedback/evidence bounded.
- UI: Review & integrate panel on Task/Graph detail — explicit integrate of verified subtask commits into the Runtime-owned aggregate review worktree only; bounded review form records REVIEW_APPROVED/CHANGES_REQUESTED durably (visible after reload); requested changes never auto-retry; commits/worktrees/scope/conflicts/recovery/integration/Sessions/journal/review history remain readable.
- The UI states review approval is not the human RELEASE_APPROVED gate and ships no merge/push/tag/publish/deploy/release control.
- Tests: unsupported decisions rejected, incomplete-graph integrate/review return Runtime conflicts without touching the user checkout or creating remote refs, state-gated single-Task review, asset + release-gate assertions. `npm run test:core` (121 tests) green.

Closes #52