### PR TITLE
feat(web): rebuild the Workspace as a chat-first three-column workbench

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,3 @@
-# Runtime and coordination bus
-.agent-bus/
-
-# Dependencies and build outputs
-node_modules/
-dist/
-coverage/
-
-# Environment files
-.env
-.env.*
-!.env.example
-
-# Logs and debug
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-
-# Release tarballs
-*.tgz
-
-# OS artifacts
-.DS_Store
-Thumbs.db
+# WorkBuddy local data and UI verification artifacts
+/.workbuddy/
+/ui-shots/

--- a/README.md
+++ b/README.md
@@ -152,21 +152,25 @@ project command > user command > adapter default precedence.
 ## Local Inspector
 
 The **Web Workspace** is the primary local browser entry. From any initialized
-Git repository with an Agent Bus it starts a loopback-only, read-only project
-overview — no Codex Plugin, global installation, or remote service required:
+Git repository with an Agent Bus it starts a loopback-only, chat-first
+workbench — no Codex Plugin, global installation, or remote service required:
 
 ```sh
 npx @hogancv/coordinate-agents@latest web --port 3000
 ```
 
-The Workspace binds exactly one Git repository and shows its identity (branch,
-HEAD, remote), Tasks and Task Graph parents, Agents, Sessions, recent Runtime
-events, and bounded Task/Graph detail. Overview and refresh are strictly
-read-only; a guarded `POST /api/action` endpoint routes an explicit allow-list
-of Runtime operations — including transactional Agent discovery/configuration —
-through the same services as CLI and MCP. The
-`inspector` command stays available as the compatible read-only UI over the
-same GET contracts. The browser is never the source of truth. Learn more in
+The Workspace is a three-column AI-chat interface with full `zh-CN` / `en-US`
+bilingual UI (top-right toggle, persisted in `localStorage`). It binds exactly
+one Git repository and shows its identity (branch, HEAD, remote), and presents
+Tasks and Task Graph parents as truthful conversation timelines built from the
+authoritative Runtime records, with Agents, Sessions, recent Runtime events,
+and bounded Task/Graph detail in the sidebar, context panel, and drawers.
+Chat rendering and refresh are strictly read-only; a guarded `POST /api/action`
+endpoint routes an explicit allow-list of Runtime operations — including
+transactional Agent discovery/configuration — through the same services as CLI
+and MCP. The `inspector` command stays available as the compatible read-only UI
+over the same GET contracts. The browser is never the source of truth; no
+agent thoughts, replies, or statuses are ever invented. Learn more in
 [Inspector & Web Workspace](./docs/inspector.md) and
 [Event Journal](./docs/event-journal.md).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -139,12 +139,16 @@ Setup discovery 以及现有 MCP setup/Task 工具会暴露同一个、向后兼
 npx @hogancv/coordinate-agents@latest web --port 3000
 ```
 
-Workspace 在启动时绑定唯一一个 Git 仓库，展示其身份（分支、HEAD、远程）、
-普通 Task 与 Task Graph parent、Agents、Sessions、近期 Runtime 事件以及有界
-的 Task/Graph 详情。总览与刷新严格只读；受保护的 `POST /api/action` 端点把
-显式白名单内的 Runtime 操作——包括事务式 Agent 发现与配置——路由到与
-CLI/MCP 相同的服务。`inspector` 命令继续作为同一套 GET 契约上的兼容只读
-界面保留。浏览器页面始终不是事实源。详见 [Inspector 与 Web Workspace](./docs/inspector.md)
+Workspace 是完整支持 `zh-CN` / `en-US` 双语的**三栏 AI 聊天式工作台**
+（右上角语言切换，`localStorage` 持久化）。启动时绑定唯一一个 Git 仓库，
+展示其身份（分支、HEAD、远程）；普通 Task 与 Task Graph parent 以基于权威
+Runtime 记录的**真实对话时间线**呈现，Agents、Sessions、近期 Runtime 事件
+与有界的 Task/Graph 详情分布在侧栏、上下文面板与抽屉中。聊天渲染与刷新
+严格只读；受保护的 `POST /api/action` 端点把显式白名单内的 Runtime
+操作——包括事务式 Agent 发现与配置——路由到与 CLI/MCP 相同的服务。
+`inspector` 命令继续作为同一套 GET 契约上的兼容只读界面保留。浏览器页面
+始终不是事实源，也绝不虚构任何 Agent 思考、回复或状态。详见
+[Inspector 与 Web Workspace](./docs/inspector.md)
 与 [Event Journal](./docs/event-journal.md)。
 
 ## Standalone npm Runtime

--- a/docs/inspector.md
+++ b/docs/inspector.md
@@ -7,13 +7,15 @@ description: A localhost-only Web Workspace for Coordinate Agents with read-only
 # Web Workspace and Local Inspector
 
 The **Web Workspace** is the primary local browser entry for Coordinate Agents.
-It starts a loopback-only project overview for one selected Git repository and
-answers "what is happening?" without requiring Codex Plugin, a global
-installation, or a remote service. Overview, refresh, selection, and event
-replay are strictly read-only; a guarded action endpoint routes a small,
-explicit allow-list of operations to the shared Runtime without making the
-browser a second state owner. The **Inspector** command remains a behaviorally
-compatible read-only UI over the same server and data adapter.
+It starts a loopback-only, **chat-first workbench** for one selected Git
+repository — a three-column AI-chat layout with full `zh-CN` / `en-US`
+bilingual UI — that answers "what is happening?" without requiring Codex
+Plugin, a global installation, or a remote service. Chat rendering, refresh,
+selection, and event replay are strictly read-only; a guarded action endpoint
+routes a small, explicit allow-list of operations to the shared Runtime
+without making the browser a second state owner. The **Inspector** command
+remains a behaviorally compatible read-only UI over the same server and data
+adapter.
 
 Both surfaces are intentionally not a SaaS console, a replacement for Codex, or
 a second Task workflow. Read paths never send Agent messages, control Sessions,
@@ -115,15 +117,52 @@ The documented read-only Inspector command keeps its behavior and GET contract:
 npx @hogancv/coordinate-agents inspector --port 3000
 ```
 
-## Pages and panels
+## Pages and layout
 
-The Workspace overview opens with the **bound repository** identity (repository
-name, current branch, HEAD commit, latest commit subject, origin remote, and the
-canonical bound root path), followed by:
+The Workspace is a **chat-first, three-column workbench** (a normal AI chat
+product layout, not a dashboard of debug panels). It supports full `en-US` /
+`zh-CN` bilingual UI with a top-right **中文 / English** toggle; the choice is
+persisted in `localStorage` (`coordinate-agents.locale`) and applies instantly
+without a reload. Locale defaults to `zh-CN` for `zh-*` browser languages and
+`en-US` otherwise. Every visible string (navigation, buttons, form labels,
+empty/loading/toast states, status badges, timestamps) is localised through one
+I18N dictionary; user-supplied data (Task titles/specifications, IDs, commits,
+paths, Agent IDs, code, logs) is never translated or rewritten, and unknown
+backend statuses/events fall back to a localised generic label while preserving
+the original code.
 
-- **Agents** — the Agent setup panel shows installed coding CLI detection and
-  the Adapter registry on demand (manual Discover, no background scanning), with
-  distinct Agent / Adapter / executable identity and command-source badges
+- **Left Sidebar** — Coordinate Agents brand, the **bound repository** chip
+  (repository name, current branch or detached HEAD; expandable details show
+  HEAD short SHA/subject/date, origin remote, and canonical bound root), a
+  **New task** button, the Chat / Tasks / Agents / Sessions / Activity
+  navigation, and a Recent list of Tasks and Sessions with the current
+  selection highlighted. On screens ≤ 1024 px the sidebar becomes an
+  off-canvas drawer opened from the top bar.
+- **Chat (default view)** — a welcome card explains what the workspace can do.
+  Selecting a Task or Task Graph turns the centre column into a truthful
+  conversation timeline rebuilt from the authoritative Runtime record: the Task
+  card (title, ID, status, specification text), each recorded status/event
+  transition with Agent and Session identity, Session output, review decisions,
+  and last error, plus actions you actually performed in this browser session.
+  Nothing is fabricated — no invented agent thoughts, replies, or statuses.
+- **Composer** — a bounded multi-line input (Enter creates, Shift+Enter adds a
+  new line), an Agent select (populated from the configured Agents), and a Mode
+  select. Single-task mode creates one durable Task through the guarded
+  `taskCreate` action and opens it in the chat; Task Graph mode opens the
+  Authoring drawer pre-filled with the title and specification. Clear feedback
+  is shown when no Agent is configured, while a request is in flight, and on
+  success or failure.
+- **Right Context panel** — a compact summary of the selected Task/Graph
+  (state, roles, subtask/concurrency facts) or the workspace counts, plus entry
+  buttons that open the detail drawers. Agent flow (Planner → Implementer →
+  Reviewer topology with current Agent Bus state) stays visible here. The panel
+  is collapsed by default on narrow screens and slides in as a drawer.
+- **Tasks view** — all durable Tasks and Task Graph parents (title, status,
+  round, update time; graphs show subtask count, max concurrency, and state
+  tallies), plus counts.
+- **Agents view** — the Agent setup panel shows installed coding CLI detection
+  and the Adapter registry on demand (manual Discover, no background scanning),
+  with distinct Agent / Adapter / executable identity and command-source badges
   (project > user > adapter-default). A bounded form configures a project Agent,
   Adapter, exact executable command, and workflow role through the guarded
   `setupConfigure` transaction (validation first, atomic rollback on failure).
@@ -131,59 +170,71 @@ canonical bound root path), followed by:
   panel states that loaded local Adapter modules are trusted local code, that
   configuration grants no browser filesystem/process bypass, and that no
   credential or secret is rendered or persisted.
-- **Tasks** — current Task title, status, round, and update time for ordinary Tasks, plus distinguishable Task Graph parent entries with subtask count, max concurrency, and subtask state tallies.
-- **Agent flow** — the configured Planner → Implementer → Reviewer topology,
-  including each Agent's current Agent Bus state.
-- **Task detail & Task Graph topology** — for ordinary Tasks: sequence-ordered recorded event timeline, role assignments, specification, implementation commit, evidence, review history, and last error. For Task Graphs: an **interactive dependency map** (deterministic layered layout, one focusable node per bounded subtask, dependency arrows from each dependency to its dependent, state legend, keyboard focus/`Escape`, and a selected-node evidence panel with the same bounded authoritative facts as the graph API — Agent/Adapter/executable, Session/worktree/commit, Scope Audit, recovery, cleanup, and last error) above the text topology, frontier decisions, preflight waves, write-intent conflicts, integration facts, and review decisions. Large graphs degrade with a bounded deterministic truncation notice; the map renders no edges and no browser graph model of its own.
-- **Sessions** — Session state, timestamps, linked Tasks, bounded recent output,
-  and recorded Session event history. Active Runtime-owned Sessions show a
-  bounded input control (explicit submit only) and a Close control; arbitrary
+- **Sessions view** — Session state, timestamps, linked Tasks, bounded recent
+  output, and recorded Session event history. Active Runtime-owned Sessions show
+  a bounded input control (explicit submit only) and a Close control; arbitrary
   PIDs, paths, commands, environment data, and unattached processes are always
-  rejected by the Runtime ownership checks. Recovery rows on Task/Graph detail
-  are state-aware and explicit: Stop, Recover, Resume, and Clean up worktrees
-  reuse the existing ownership and recovery semantics, are idempotency- and
-  conflict-aware, and never retry automatically, silently discard verified
-  commits/evidence/user files, or touch remote refs. Cleanup removes only
-  Runtime-owned Sessions/worktrees and reports cleanup failures without hiding
-  the primary failure.
-- **Recent events** — timestamp, sequence, event type, Task, Session, Agent, and
-  a bounded summary from the append-only journal.
-- **Author new work** — the authoring panel creates one durable Task or a Task
-  Graph v1 (with optional Intent Map v1) without dispatching anything. Bounded
-  forms cover title/specification, role assignments from the configured Agents,
-  subtask IDs/specs/dependencies, maxConcurrency, write-intent patterns, and
-  scope policy. Validate runs the side-effect-free Runtime validation first
-  (cyclic, duplicate, unknown-Agent, unsafe-pattern, oversized, and malformed
-  input is rejected before any record exists); Create is the explicit user
-  action that persists the validated Runtime-owned record (Task Graph record
-  plus journal event only — no Session, worktree, Bus handoff, process, or
-  dispatch). After Create the panel shows the side-effect-free Graph Preflight
+  rejected by the Runtime ownership checks.
+- **Activity view** — the recent Event Journal feed (timestamp, sequence, event
+  type, Task, Session, Agent, and a bounded summary; recorded vs Derived /
+  Legacy History labels; click a Task id to jump to it).
+- **Detail drawer (Task & graph)** — opened from the Context panel: for
+  ordinary Tasks the sequence-ordered recorded event timeline, role
+  assignments, specification, implementation commit, evidence, review history,
+  and last error; for Task Graphs the **interactive dependency map**
+  (deterministic layered layout, one focusable node per bounded subtask,
+  dependency arrows, state legend, keyboard focus/`Escape`, and a selected-node
+  evidence panel with the same bounded authoritative facts as the graph API —
+  Agent/Adapter/executable, Session/worktree/commit, Scope Audit, recovery,
+  cleanup, and last error) above the text topology, frontier decisions,
+  preflight waves, write-intent conflicts, integration facts, and review
+  decisions. Large graphs degrade with a bounded deterministic truncation
+  notice; the map renders no edges and no browser graph model of its own. The
+  drawer also hosts the **Execution controls** and **Review & integrate**:
+  - **Execution controls** are never triggered by page load, GET, SSE
+    reconnect, or a double click. Dispatch, Run eligible wave, and Advance are
+    armed only after the user checks an understanding box (an Agent process may
+    write to the repository; failures are never retried automatically; no
+    merge, push, tag, publish, deploy, or release occurs). Graph Advance
+    requires an explicit bounded `maxWaves` (1–32) and Graph Run an optional
+    bounded session-wait (0–10000 ms). Results surface the same Task/subtask,
+    Session, worktree, commit, evidence, and stop facts as the shared Runtime
+    operation; stale or invalid state returns a conflict and views refresh from
+    the authoritative Runtime record via bounded SSE/refresh with `Last-Event-ID`
+    resume. State-aware Recovery rows (Stop, Recover, Resume, Clean up
+    worktrees) reuse the existing ownership and recovery semantics, are
+    idempotency- and conflict-aware, and never retry automatically, silently
+    discard verified commits/evidence/user files, or touch remote refs. Cleanup
+    removes only Runtime-owned Sessions/worktrees. The Workspace never modifies
+    the user's checked-out worktree or remote refs.
+  - **Review & integrate** — an explicit integrate action (applies verified
+    subtask commits only to the Runtime-owned aggregate review worktree) and a
+    bounded review form that records `REVIEW_APPROVED` / `CHANGES_REQUESTED`
+    with feedback/evidence through the shared Runtime operation; decisions are
+    durable and visible after reload and requested changes never trigger an
+    automatic retry. The surface shows commits, worktrees, Scope Audit, intent
+    conflicts, recovery, integration, Sessions, Event Journal, and review
+    history with parent identity preserved, and states plainly that review
+    approval is not the human `RELEASE_APPROVED` gate — the Workspace offers no
+    merge, push, tag, publish, deploy, or release control.
+- **Authoring drawer** — opened from **New task** (or the Composer in Task
+  Graph mode): creates one durable Task or a Task Graph v1 (with optional
+  Intent Map v1) without dispatching anything. Bounded forms cover
+  title/specification, role assignments from the configured Agents, subtask
+  IDs/specs/dependencies, maxConcurrency, write-intent patterns, and scope
+  policy. Validate runs the side-effect-free Runtime validation first (cyclic,
+  duplicate, unknown-Agent, unsafe-pattern, oversized, and malformed input is
+  rejected before any record exists); Create is the explicit user action that
+  persists the validated Runtime-owned record (Task Graph record plus journal
+  event only — no Session, worktree, Bus handoff, process, or dispatch). After
+  Create the drawer shows the side-effect-free Graph Preflight
   (`task.graph-plan` facts: frontier, selected wave, write-intent conflicts,
   intent coverage, scope policy, risks, and estimated resources). Missing
   Intent Map coverage stays distinct from an explicitly empty write intent.
-- **Execution controls** — selecting a Task or Task Graph opens an explicit
-  control row that is never triggered by page load, GET, SSE reconnect, or a
-  double click. Dispatch, Run eligible wave, and Advance are armed only after
-  the user checks an understanding box (an Agent process may write to the
-  repository; failures are never retried automatically; no merge, push, tag,
-  publish, deploy, or release occurs). Graph Advance requires an explicit
-  bounded `maxWaves` (1–32) and Graph Run an optional bounded session-wait
-  (0–10000 ms). Results surface the same Task/subtask, Session, worktree,
-  commit, evidence, and stop facts as the shared Runtime operation; stale or
-  invalid state returns a conflict and views refresh from the authoritative
-  Runtime record via bounded SSE/refresh with `Last-Event-ID` resume. The
-  Workspace never modifies the user's checked-out worktree or remote refs.
-- **Review & integrate** — Task/Graph detail offers an explicit integrate
-  action (applies verified subtask commits only to the Runtime-owned aggregate
-  review worktree) and a bounded review form that records
-  `REVIEW_APPROVED` / `CHANGES_REQUESTED` with feedback/evidence through the
-  shared Runtime operation; decisions are durable and visible after reload and
-  requested changes never trigger an automatic retry. The surface shows
-  commits, worktrees, Scope Audit, intent conflicts, recovery, integration,
-  Sessions, Event Journal, and review history with parent identity preserved,
-  and states plainly that review approval is not the human `RELEASE_APPROVED`
-  gate — the Workspace offers no merge, push, tag, publish, deploy, or release
-  control.
+
+Drawers support `Escape` to close and keep keyboard focus; the Context panel
+and Sidebar collapse to drawers on narrow screens (≤ 1180 px and ≤ 1024 px
+respectively).
 
 ## Endpoints
 
@@ -231,10 +282,11 @@ evidence. The Workspace is a control-plane view, not a secret store.
   incomplete; old history is never fabricated or backfilled.
 - Recorded ordering uses repository-monotonic sequence values rather than
   timestamps.
-- There is no authentication beyond the local per-launch capability, remote
-  access, chat, multi-tenant mode, cloud sync, or benchmark/evaluation
+- There is no authentication beyond the local per-launch capability, no remote
+  access, no multi-tenant mode, no cloud sync, and no benchmark/evaluation
   dashboard. Workspace mutations are limited to the allow-listed actions above;
   process-launching, Session-input, stop, cleanup, integration, and review
-  controls (with explicit UI confirmation) arrive in later tickets.
+  controls are always behind an explicit UI confirmation and never run on page
+  load, reconnect, or refresh.
 - `coordinate-agents web` requires an initialized Git repository root; the
   compatibility `inspector` command keeps its existing validation behavior.

--- a/inspector/web-workspace/app.js
+++ b/inspector/web-workspace/app.js
@@ -1,3 +1,742 @@
+/* Coordinate Agents Web Workspace — chat-first control plane.
+ *
+ * All visible UI strings live in the I18N dictionaries below. Raw user data
+ * (titles, specifications, IDs, commits, paths, logs, Agent IDs, error codes)
+ * is never translated or rewritten. Unknown statuses/event types fall back to
+ * a localised generic label while preserving the original code.
+ */
+
+/* ------------------------------------------------------------------ */
+/* I18N                                                               */
+/* ------------------------------------------------------------------ */
+const LOCALE_KEY = 'coordinate-agents.locale';
+
+const I18N = {
+  'en-US': {
+    'nav.newTask': 'New task',
+    'nav.chat': 'Chat',
+    'nav.tasks': 'Tasks',
+    'nav.agents': 'Agents',
+    'nav.sessions': 'Sessions',
+    'nav.activity': 'Activity',
+    'nav.recent': 'Recent',
+    'view.chat': 'Chat',
+    'view.tasks': 'Tasks',
+    'view.agents': 'Agents',
+    'view.sessions': 'Sessions',
+    'view.activity': 'Activity',
+    'view.subtitleWorkspace': 'Workspace for your local AI coding team',
+    'view.subtitleChat': 'Task conversations and workspace events',
+    'view.subtitleTasks': 'All durable Tasks and Task Graphs in this repository',
+    'view.subtitleAgents': 'Configure local coding Agents, Adapters and executables',
+    'view.subtitleSessions': 'Execution Sessions owned by the Runtime',
+    'view.subtitleActivity': 'Append-only Event Journal',
+    'view.tasksTitle': 'Tasks',
+    'view.activityTitle': 'Recent events',
+    'view.activityHint': 'recorded events · legacy fallback',
+    'view.sessionsTitle': 'Sessions',
+    'repo.loading': 'Loading repository…',
+    'repo.details': 'Repository details',
+    'repo.hideDetails': 'Hide details',
+    'repo.detached': 'detached',
+    'repo.head': 'HEAD',
+    'repo.latestOn': 'Latest commit on {branch}',
+    'repo.latest': 'Latest commit',
+    'repo.committed': 'Committed',
+    'repo.remote': 'Remote',
+    'repo.noOrigin': 'no origin remote',
+    'repo.boundRoot': 'Bound root',
+    'repo.noCommits': 'no commits yet',
+    'repo.factsError': 'Repository facts',
+    'repo.repo': 'Repository',
+    'status.connected': 'localhost · live',
+    'composer.placeholder': 'Describe a task for your local AI team… (Enter to create, Shift+Enter for a new line)',
+    'composer.agent': 'Agent',
+    'composer.mode': 'Mode',
+    'composer.modeTask': 'Single task',
+    'composer.modeGraph': 'Task Graph…',
+    'composer.send': 'Send',
+    'composer.openGraph': 'Open graph form',
+    'composer.enterHint': 'Enter to create a Task · Shift+Enter for a new line',
+    'composer.noAgents': 'No Agents configured — tasks still create, but add Agents in the Agents view to assign roles.',
+    'composer.titleRequired': 'Describe the task first (title is required).',
+    'composer.creating': 'Creating Task…',
+    'composer.created': 'Created {title} · {id}',
+    'composer.failed': 'Create failed: {message}',
+    'composer.graphHint': 'Graph mode opens the authoring form; validate, preview, then create explicitly.',
+    'composer.sent': 'Request sent — Runtime accepted.',
+    'context.title': 'Context',
+    'context.agentFlow': 'Agent flow',
+    'context.selectionHint': 'Select a Task or Session to inspect it here.',
+    'context.openDetails': 'Details & topology',
+    'context.execution': 'Execution',
+    'context.review': 'Review & integrate',
+    'context.close': 'Close',
+    'context.newTask': 'New task',
+    'context.browseAgents': 'Configure Agents',
+    'context.recentTasks': '{n} Tasks',
+    'context.recentSessions': '{n} Sessions',
+    'context.taskStatus': 'Task',
+    'context.graphStatus': 'Task Graph',
+    'drawer.taskDetail': 'Task & graph details',
+    'drawer.close': 'Close',
+    'welcome.title': 'Coordinate Agents Workspace',
+    'welcome.subtitle': 'A local, browser-only control plane for the AI coding team running on this machine.',
+    'welcome.whatYouCan': 'What you can do here',
+    'welcome.w1': 'Describe work in the composer and create durable Tasks or Task Graphs.',
+    'welcome.w2': 'Watch real Task, Agent, Session and Runtime events as a conversation timeline.',
+    'welcome.w3': 'Configure your local Agents and their executables.',
+    'welcome.w4': 'Explicitly dispatch, advance, recover, integrate and review — nothing runs automatically.',
+    'welcome.hint': 'Everything shown is read from the local Runtime records; the Workspace never invents agent thoughts, replies, or status.',
+    'welcome.startTask': 'Describe a task below',
+    'welcome.configAgents': 'Configure Agents',
+    'empty.tasks': 'No Tasks found in this project.',
+    'empty.events': 'No Runtime events found.',
+    'empty.sessions': 'No Execution Sessions recorded.',
+    'empty.recent': 'Nothing here yet — create a Task from the composer.',
+    'empty.detailTimeline': 'No Task events recorded yet.',
+    'empty.subtasks': 'No persisted subtasks.',
+    'empty.graphNoReadable': 'Task Graph record has no readable subtasks.',
+    'empty.selectNode': 'Select a map node to inspect its bounded Runtime evidence.',
+    'empty.discovery': 'No discovery snapshot available.',
+    'empty.discoveryAgents': 'No coding CLIs detected on this machine.',
+    'empty.discoveryAdapters': 'No adapters registered.',
+    'empty.configuredAgents': 'No Agents are registered in this repository yet.',
+    'empty.dependencies': 'none',
+    'empty.noSpec': 'No specification recorded.',
+    'empty.noEvidence': 'No review decisions recorded.',
+    'graph.map': 'Graph map',
+    'graph.frontier': 'Frontier & preflight wave',
+    'graph.conflicts': 'Conflicts & scope audit',
+    'graph.integration': 'Integration & review',
+    'graph.topology': 'Task Graph topology',
+    'graph.largeGraph': 'Large graph: rendering the first {max} of {total} subtasks in deterministic order; the complete bounded topology remains below.',
+    'graph.nodeLabel': 'Subtask {id}: {title} ({state})',
+    'lb.Depends on': 'Depends on',
+    'lb.Dependency edges': 'Dependency edges',
+    'lb.Evidence records': 'Evidence records',
+    'lb.Adapters & command sources': 'Adapters & command sources',
+    'lb.Detected coding CLIs': 'Detected coding CLIs',
+    'detail.timelineTitle': 'Event timeline',
+    'detail.agentFlowTitle': 'Agent flow',
+    'detail.evidenceTitle': 'Evidence & review',
+    'detail.specTitle': 'Specification',
+    'msg.agent': 'Agent',
+    'msg.session': 'Session',
+    'msg.round': 'Round {round}',
+    'msg.graph': 'Task Graph',
+    'msg.updated': 'Updated {time}',
+    'msg.created': 'Created {time}',
+    'msg.lastActivity': 'Last activity {time}',
+    'msg.graphSubtask': '{n} subtasks',
+    'msg.reviewApproved': 'Review approved',
+    'msg.reviewRequested': 'Changes requested',
+    'msg.actionRecorded': 'You ran {action}',
+    'msg.actionDone': '{action} completed',
+    'msg.actionFailed': '{action} failed',
+    'msg.actionRunning': '{action} running…',
+    'msg.actionWillRefresh': 'Refreshing authoritative Runtime state…',
+    'msg.unknownEvent': 'Unknown event',
+    'msg.unknownStatus': 'Unknown status',
+    'msg.noFeedback': 'No feedback',
+    'msg.graphNoConflict': 'No conflict or scope facts recorded.',
+    'msg.graphNoIntegration': 'Integration and review have not been recorded.',
+    'msg.recordedEvent': 'Recorded Event',
+    'msg.legacyHistory': 'Derived / Legacy History',
+    'msg.subtasks': 'subtasks',
+    'msg.concurrency': 'concurrency {n}',
+    'msg.output': 'Session output',
+    'msg.noOutput': 'No recent output available.',
+    'msg.reviewDecision': 'Recorded review decision',
+    'msg.sessionInput': 'Send input to Session',
+    'msg.feedback': 'Feedback',
+    'chat.action': 'Action',
+    'chat.user': 'You',
+    'chat.runtime': 'Runtime',
+    'toast.copied': 'Copied.',
+    'tooltip.copy': 'Copy',
+    'tasks.cardRound': 'R{round}',
+    'execution.titleTask': 'Execution · {title}',
+    'execution.titleGraph': 'Execution · {title}',
+    'execution.confirm': 'I understand: this explicitly launches an Agent process that may write to the repository; failures are never retried automatically and no merge, push, tag, publish, deploy, or release occurs.',
+    'execution.dispatch': 'Dispatch task',
+    'execution.dispatchFor': 'Dispatch {id}',
+    'execution.notDispatchable': 'status {status} — dispatch applies to created / planning / spec-ready / changes-requested Tasks with a specification.',
+    'execution.sessionWait': 'Session wait (ms, 0–10000)',
+    'execution.runWave': 'Run eligible wave',
+    'execution.runFor': 'Run eligible wave of {id}',
+    'execution.maxWaves': 'maxWaves (1–32)',
+    'execution.advance': 'Advance graph',
+    'execution.advanceFor': 'Advance {id}',
+    'execution.executing': '{label}: executing…',
+    'execution.failed': '{label} failed',
+    'execution.completed': '{label} completed',
+    'execution.stopTask': 'Stop Task',
+    'execution.resumeTask': 'Resume Task',
+    'execution.stopGraph': 'Stop graph',
+    'execution.recoverGraph': 'Recover graph',
+    'execution.resumeGraph': 'Resume graph',
+    'execution.cleanup': 'Clean up worktrees',
+    'execution.noRecovery': '{state} — no automatic recovery action; review the Runtime facts and act explicitly.',
+    'execution.recoverySep': 'Recovery & ownership',
+    'execution.requestFailed': '{label} request failed: {message}',
+    'execution.noSessionFacts': '(no identity facts returned)',
+    'review.title': 'Review & integrate',
+    'review.releaseLabel': 'review approval is never release approval',
+    'review.note': 'Integration applies verified subtask commits only to the Runtime-owned aggregate review worktree — never to your checked-out worktree or remote refs. Recording a review decision is durable and visible after reload; requested changes never trigger an automatic retry. This Workspace offers no merge, push, tag, publish, deploy, or release control: releasing requires the separate human RELEASE_APPROVED gate.',
+    'review.integrate': 'Integrate verified subtasks',
+    'review.decision': 'Decision',
+    'review.feedback': 'Feedback',
+    'review.evidence': 'Evidence (optional JSON object)',
+    'review.record': 'Record review decision',
+    'review.notReviewable': 'Current state is not reviewable; review applies to reviewed/changes-requested Tasks or running/succeeded graphs',
+    'review.state': 'state {state}',
+    'review.confirm': 'I understand: integration/review targets Runtime-owned artifacts only; review approval is not release approval; no merge, push, tag, publish, deploy, or release happens here.',
+    'review.recording': '{label}: recording decision…',
+    'review.recorded': '{label} recorded ({decision}). Durable after reload.',
+    'review.rejected': '{label} rejected: {message}',
+    'review.integrating': 'Integrating verified subtask commits into the Runtime-owned aggregate review worktree…',
+    'review.integrated': 'Integration recorded. Review the aggregate facts, then record a decision.',
+    'review.integrationFailed': 'Integration rejected: {message}',
+    'review.integrationComplete': 'Integration complete',
+    'review.evidenceInvalid': 'Review evidence must be valid JSON object text.',
+    'review.chooseDecision': 'Choose a review decision.',
+    'author.title': 'Author new work',
+    'author.panelTitle': 'Author new work',
+    'author.hint': 'validate first · preflight is side-effect free · create persists the Runtime record only',
+    'author.emptyAgents': 'No Agents are configured yet. Configure an Agent in the Agents view before authoring.',
+    'author.singleTask': 'Single Task',
+    'author.taskTitleLabel': 'Title',
+    'author.specLabel': 'Specification',
+    'author.taskIdLabel': 'Deterministic ID (optional)',
+    'author.createTask': 'Create Task',
+    'author.graphTitle': 'Task Graph v1',
+    'author.intentMapHint': 'with optional Intent Map v1',
+    'author.parentId': 'Parent ID',
+    'author.graphTitleLabel': 'Title',
+    'author.maxConcurrency': 'Max concurrency',
+    'author.intentMap': 'Intent Map (write intents)',
+    'author.scopePolicy': 'Scope policy',
+    'author.scopeWarn': 'warn (default)',
+    'author.scopeObserve': 'observe',
+    'author.scopeStrict': 'strict',
+    'author.subtasks': 'Subtasks',
+    'author.addSubtask': '+ Add subtask',
+    'author.subtaskHint': 'Leave write intent empty in a row for an explicitly empty intent; disable the Intent Map for missing (unverified) coverage.',
+    'author.validate': 'Validate',
+    'author.createGraph': 'Create Graph (persist only)',
+    'agents.title': 'Agents',
+    'agents.discover': 'Discover CLIs',
+    'agents.note': 'Configure a local coding Agent, its Adapter, and its exact executable command. Resolution order stays project command → user command → Adapter default. Detection runs only when you click Discover; the Workspace never performs automatic login, remote lookup, package download, or arbitrary process launch.',
+    'agents.discoverHint': 'Click “Discover CLIs” to inspect installed coding CLIs and registered Adapters.',
+    'agents.agentId': 'Agent ID',
+    'agents.agentIdPh': 'e.g. codex / antigravity',
+    'agents.adapter': 'Adapter',
+    'agents.command': 'Executable command',
+    'agents.commandPh': 'exact command, e.g. agy-proxy',
+    'agents.role': 'Workflow role',
+    'agents.apply': 'Apply configuration',
+    'agents.configured': 'Configured runtime agents',
+    'agents.scopeNote': 'Only explicitly registered or loaded local Adapter modules are treated as trusted local code; configuring an Agent grants no browser filesystem or process sandbox bypass. The Workspace never renders or persists credentials, tokens, cookies, or secrets.',
+    'agents.configureThis': 'Configure this command',
+    'agents.discovering': 'Discovering local coding CLIs…',
+    'agents.discoveryFailed': 'Discovery failed ({code}): {message}',
+    'agents.discoveryOk': 'Discovery complete. Configure a command below or pick “Configure this command”.',
+    'agents.configuring': 'Applying configuration…',
+    'agents.configFailed': 'Configuration failed: {message}',
+    'agents.configOk': 'Configured {id} ({adapter}) → {command} [{source}] · workflow {roles}',
+    'agents.required': 'Agent ID and executable command are required.',
+    'agents.adapterOf': 'adapter {adapter}',
+    'agents.commandOf': 'command {command}',
+    'agents.configuredPill': 'configured',
+    'agents.available': 'available',
+    'agents.unavailable': 'unavailable',
+    'agents.notConfiguredHere': 'not configured in this project',
+    'agents.builtin': 'built-in',
+    'agents.localAdapter': 'registered local adapter',
+    'agents.noCapabilities': 'no capabilities',
+    'agents.roles': 'roles',
+    'agents.unassigned': 'unassigned',
+    'agents.queue': 'queue {new} new · {processing} processing',
+    'agents.lastActivity': 'last activity {activity}',
+    'agents.unregistered': 'unregistered',
+    'roles.planner': 'Planner',
+    'roles.implementer': 'Implementer',
+    'roles.reviewer': 'Reviewer',
+    'roles.unassigned': 'unassigned',
+    'roles.noneConfigured': '(no agents configured)',
+    'session.send': 'Send input',
+    'session.inputPh': 'Bounded input to this owned Session…',
+    'session.close': 'Close Session',
+    'session.closing': 'Closing Session…',
+    'session.closed': 'Session closed.',
+    'session.closeRejected': 'Close rejected: {message}',
+    'session.sending': 'Sending bounded input…',
+    'session.sent': 'Input accepted.',
+    'session.rejected': 'Input rejected: {message}',
+    'session.tasks': 'Tasks: {tasks}',
+    'session.recorded': 'Recorded Events',
+    'session.derived': 'Derived / Legacy History',
+    'status.creator': 'created',
+    'date.justNow': 'just now',
+    'generic.ok': 'Ok',
+    'generic.error': 'Error',
+    'generic.details': 'Details',
+    'generic.validating': 'Validating…',
+    'generic.loading': 'Loading…',
+    'generic.failed': 'failed',
+    'author.validated': 'Graph validates: {count} subtask(s)',
+    'author.missingIntent': 'intent coverage missing (unverified)',
+    'author.intentPresent': 'intent facts present',
+    'author.validatedOk': 'Validation passed. Review Preflight after creating, or fix the form.',
+    'author.preflightFailed': 'Preflight unavailable',
+    'author.preflightTitle': 'Graph Preflight',
+    'author.creatingGraph': 'Creating the validated Runtime record (no dispatch)…',
+    'author.createFailed': 'Create failed.',
+    'author.createdGraph': 'Created {id}',
+    'author.loadingPreflight': 'Loading Preflight…',
+    'execution.factTask': 'Task / parent',
+    'execution.factSubtasks': 'Subtasks',
+    'execution.factState': 'State',
+    'execution.factSession': 'Session',
+    'execution.factCommit': 'Commit',
+    'execution.factWaves': 'Waves executed',
+    'execution.factStop': 'Stop reason',
+    'execution.factAgent': 'Agent',
+    'generic.copy': 'Copy',
+    'subtask.dependsOn': 'Depends on',
+    'subtask.writeIntent': 'Write intent (optional)',
+    'subtask.remove': 'Remove',
+  },
+  'zh-CN': {
+    'nav.newTask': '新建任务',
+    'nav.chat': '聊天',
+    'nav.tasks': '任务',
+    'nav.agents': 'Agents',
+    'nav.sessions': '会话',
+    'nav.activity': '活动',
+    'nav.recent': '最近',
+    'view.chat': '聊天',
+    'view.tasks': '任务',
+    'view.agents': 'Agents',
+    'view.sessions': '会话',
+    'view.activity': '活动',
+    'view.subtitleWorkspace': '本机 AI 编码团队工作台',
+    'view.subtitleChat': '任务对话与工作区事件',
+    'view.subtitleTasks': '仓库内所有持久化 Task 与 Task Graph',
+    'view.subtitleAgents': '配置本地编码 Agent、Adapter 与可执行命令',
+    'view.subtitleSessions': '由 Runtime 持有的执行会话',
+    'view.subtitleActivity': '只追加的 Event Journal',
+    'view.tasksTitle': '任务',
+    'view.activityTitle': '最近事件',
+    'view.activityHint': '已记录事件 · 旧版回溯',
+    'view.sessionsTitle': '执行会话',
+    'repo.loading': '正在加载仓库…',
+    'repo.details': '仓库详情',
+    'repo.hideDetails': '收起详情',
+    'repo.detached': '游离 HEAD',
+    'repo.head': 'HEAD',
+    'repo.latestOn': '{branch} 上的最新提交',
+    'repo.latest': '最新提交',
+    'repo.committed': '提交时间',
+    'repo.remote': '远程',
+    'repo.noOrigin': '无 origin 远程',
+    'repo.boundRoot': '绑定根目录',
+    'repo.noCommits': '尚无提交',
+    'repo.factsError': '仓库信息',
+    'repo.repo': '仓库',
+    'status.connected': 'localhost · 实时',
+    'composer.placeholder': '向你的本机 AI 团队描述一项任务…（Enter 发送，Shift+Enter 换行）',
+    'composer.agent': 'Agent',
+    'composer.mode': '模式',
+    'composer.modeTask': '单个任务',
+    'composer.modeGraph': '任务图…',
+    'composer.send': '发送',
+    'composer.openGraph': '打开图表单',
+    'composer.enterHint': 'Enter 创建任务 · Shift+Enter 换行',
+    'composer.noAgents': '尚未配置 Agent —— 仍可创建任务；在 Agents 视图配置后即可分配角色。',
+    'composer.titleRequired': '请先描述任务（标题必填）。',
+    'composer.creating': '正在创建任务…',
+    'composer.created': '已创建 {title} · {id}',
+    'composer.failed': '创建失败：{message}',
+    'composer.graphHint': '图模式会打开创作表单；先验证与预检，再显式创建。',
+    'composer.sent': '请求已发送 —— Runtime 已接受。',
+    'context.title': '上下文',
+    'context.agentFlow': 'Agent 流转',
+    'context.selectionHint': '选中一个 Task 或 Session 在此查看。',
+    'context.openDetails': '详情与拓扑',
+    'context.execution': '执行控制',
+    'context.review': '评审与集成',
+    'context.close': '关闭',
+    'context.newTask': '新建任务',
+    'context.browseAgents': '配置 Agents',
+    'context.recentTasks': '{n} 个任务',
+    'context.recentSessions': '{n} 个会话',
+    'context.taskStatus': '任务',
+    'context.graphStatus': '任务图',
+    'drawer.taskDetail': '任务与图详情',
+    'drawer.close': '关闭',
+    'welcome.title': 'Coordinate Agents Workspace',
+    'welcome.subtitle': '为本机 AI 编码团队打造的本地、纯浏览器控制台。',
+    'welcome.whatYouCan': '这里可以做什么',
+    'welcome.w1': '在下方 Composer 描述工作，创建持久化 Task 或 Task Graph。',
+    'welcome.w2': '把真实的 Task、Agent、Session 与 Runtime 事件当作对话时间线查看。',
+    'welcome.w3': '配置本地 Agent 及其可执行命令。',
+    'welcome.w4': '显式派发、推进、恢复、集成与评审 —— 一切都不会自动运行。',
+    'welcome.hint': '所有内容都来自本地 Runtime 记录；Workspace 不会虚构任何 Agent 思考、回复或状态。',
+    'welcome.startTask': '在下方描述一项任务',
+    'welcome.configAgents': '配置 Agents',
+    'empty.tasks': '此项目中暂无 Task。',
+    'empty.events': '暂无 Runtime 事件。',
+    'empty.sessions': '暂无执行会话记录。',
+    'empty.recent': '暂无内容 —— 在 Composer 创建一项任务吧。',
+    'empty.detailTimeline': '该任务尚无事件记录。',
+    'empty.subtasks': '暂无持久化子任务。',
+    'empty.graphNoReadable': 'Task Graph 记录中没有可读子任务。',
+    'empty.selectNode': '选择一个地图节点以查看其有界 Runtime 证据。',
+    'empty.discovery': '暂无发现快照。',
+    'empty.discoveryAgents': '未在本机检测到编码 CLI。',
+    'empty.discoveryAdapters': '未注册任何 Adapter。',
+    'empty.configuredAgents': '仓库中尚未注册 Agent。',
+    'empty.dependencies': '无',
+    'empty.noSpec': '未记录规格说明。',
+    'empty.noEvidence': '暂无评审决策记录。',
+    'graph.map': '依赖图',
+    'graph.frontier': '前沿与预检波次',
+    'graph.conflicts': '冲突与范围审计',
+    'graph.integration': '集成与评审',
+    'graph.topology': 'Task Graph 拓扑',
+    'graph.largeGraph': '大图：按确定性顺序渲染 {total} 个子任务中的前 {max} 个；完整有界拓扑仍在下方。',
+    'graph.nodeLabel': '子任务 {id}：{title}（{state}）',
+    'lb.Depends on': '依赖',
+    'lb.Dependency edges': '依赖边',
+    'lb.Evidence records': '证据记录',
+    'lb.Adapters & command sources': 'Adapter 与命令来源',
+    'lb.Detected coding CLIs': '检测到的编码 CLI',
+    'detail.timelineTitle': '事件时间线',
+    'detail.agentFlowTitle': 'Agent 流转',
+    'detail.evidenceTitle': '证据与评审',
+    'detail.specTitle': '规格说明',
+    'msg.agent': 'Agent',
+    'msg.session': '会话',
+    'msg.round': '第 {round} 轮',
+    'msg.graph': '任务图',
+    'msg.updated': '更新于 {time}',
+    'msg.created': '创建于 {time}',
+    'msg.lastActivity': '最近活动 {time}',
+    'msg.graphSubtask': '{n} 个子任务',
+    'msg.reviewApproved': '评审通过',
+    'msg.reviewRequested': '已请求修改',
+    'msg.actionRecorded': '你执行了 {action}',
+    'msg.actionDone': '{action} 已完成',
+    'msg.actionFailed': '{action} 失败',
+    'msg.actionRunning': '{action} 进行中…',
+    'msg.actionWillRefresh': '正在刷新权威 Runtime 状态…',
+    'msg.unknownEvent': '未知事件',
+    'msg.unknownStatus': '未知状态',
+    'msg.noFeedback': '无反馈',
+    'msg.graphNoConflict': '未记录冲突或范围事实。',
+    'msg.graphNoIntegration': '尚未记录集成与评审。',
+    'msg.recordedEvent': '已记录事件',
+    'msg.legacyHistory': '派生 / 旧版历史',
+    'msg.subtasks': '个子任务',
+    'msg.concurrency': '并发 {n}',
+    'msg.output': '会话输出',
+    'msg.noOutput': '暂无最近输出。',
+    'msg.reviewDecision': '已记录的评审决策',
+    'msg.sessionInput': '向会话发送输入',
+    'msg.feedback': '反馈',
+    'chat.action': '操作',
+    'chat.user': '你',
+    'chat.runtime': 'Runtime',
+    'toast.copied': '已复制。',
+    'tooltip.copy': '复制',
+    'tasks.cardRound': '第 {round} 轮',
+    'execution.titleTask': '执行 · {title}',
+    'execution.titleGraph': '执行 · {title}',
+    'execution.confirm': '我理解：此操作会显式启动一个可写入仓库的 Agent 进程；失败绝不会自动重试，也不会发生任何 merge、push、tag、publish、deploy 或 release。',
+    'execution.dispatch': '派发任务',
+    'execution.dispatchFor': '派发 {id}',
+    'execution.notDispatchable': '状态 {status} —— 派发适用于已创建 / 规划中 / 规格就绪 / 已请求修改且含规格说明的任务。',
+    'execution.sessionWait': '会话等待（毫秒，0–10000）',
+    'execution.runWave': '运行可执行波次',
+    'execution.runFor': '运行 {id} 的可执行波次',
+    'execution.maxWaves': '波次数上限（1–32）',
+    'execution.advance': '推进图',
+    'execution.advanceFor': '推进 {id}',
+    'execution.executing': '{label}：执行中…',
+    'execution.failed': '{label} 失败',
+    'execution.completed': '{label} 完成',
+    'execution.stopTask': '停止任务',
+    'execution.resumeTask': '恢复任务',
+    'execution.stopGraph': '停止图',
+    'execution.recoverGraph': '恢复图',
+    'execution.resumeGraph': '恢复图',
+    'execution.cleanup': '清理 worktree',
+    'execution.noRecovery': '{state} —— 无自动恢复动作；请查看 Runtime 事实后显式操作。',
+    'execution.recoverySep': '恢复与归属',
+    'execution.requestFailed': '{label} 请求失败：{message}',
+    'execution.noSessionFacts': '（无身份事实返回）',
+    'review.title': '评审与集成',
+    'review.releaseLabel': '评审通过不等于发布批准',
+    'review.note': '集成只把已验证的子任务提交应用到 Runtime 持有的聚合评审 worktree——绝不触及你的工作区或远程引用。评审决策持久可见，重载后仍在；请求的修改绝不会自动重试。本 Workspace 不提供任何 merge、push、tag、publish、deploy 或 release 控件：发布必须走独立的人工 RELEASE_APPROVED 闸门。',
+    'review.integrate': '集成已验证子任务',
+    'review.decision': '决策',
+    'review.feedback': '反馈',
+    'review.evidence': '证据（可选 JSON 对象）',
+    'review.record': '记录评审决策',
+    'review.notReviewable': '当前状态不可评审；评审适用于评审中 / 已请求修改的任务或运行中 / 已成功的图',
+    'review.state': '状态 {state}',
+    'review.confirm': '我理解：集成 / 评审只作用于 Runtime 持有的产物；评审通过不是发布批准；这里不会发生任何 merge、push、tag、publish、deploy 或 release。',
+    'review.recording': '{label}：正在记录决策…',
+    'review.recorded': '{label} 已记录（{decision}）。重载后依然持久可见。',
+    'review.rejected': '{label} 被拒绝：{message}',
+    'review.integrating': '正在把已验证的子任务提交集成进 Runtime 持有的聚合评审 worktree…',
+    'review.integrated': '集成已记录。请查看聚合事实后再记录决策。',
+    'review.integrationFailed': '集成被拒绝：{message}',
+    'review.integrationComplete': '集成完成',
+    'review.evidenceInvalid': '评审证据必须是合法的 JSON 对象文本。',
+    'review.chooseDecision': '请选择评审决策。',
+    'author.title': '创作新工作',
+    'author.panelTitle': '创作新工作',
+    'author.hint': '先验证 · 预检无副作用 · 创建只持久化 Runtime 记录',
+    'author.emptyAgents': '尚未配置 Agent。请先在 Agents 视图配置后再创作。',
+    'author.singleTask': '单个任务',
+    'author.taskTitleLabel': '标题',
+    'author.specLabel': '规格说明',
+    'author.taskIdLabel': '确定性 ID（可选）',
+    'author.createTask': '创建任务',
+    'author.graphTitle': 'Task Graph v1',
+    'author.intentMapHint': '可选 Intent Map v1',
+    'author.parentId': '父任务 ID',
+    'author.graphTitleLabel': '标题',
+    'author.maxConcurrency': '最大并发',
+    'author.intentMap': 'Intent Map（写入意图）',
+    'author.scopePolicy': '范围策略',
+    'author.scopeWarn': 'warn（默认）',
+    'author.scopeObserve': 'observe',
+    'author.scopeStrict': 'strict',
+    'author.subtasks': '子任务',
+    'author.addSubtask': '+ 添加子任务',
+    'author.subtaskHint': '某行留空写入意图表示显式空意图；关闭 Intent Map 表示缺失（未验证）覆盖。',
+    'author.validate': '验证',
+    'author.createGraph': '创建图（仅持久化）',
+    'agents.title': 'Agents',
+    'agents.discover': '发现 CLIs',
+    'agents.note': '配置本地编码 Agent、其 Adapter 与精确可执行命令。解析顺序保持项目命令 → 用户命令 → Adapter 默认。只有点击「发现」才会运行检测；Workspace 从不自动登录、远程查询、下载包或启动任意进程。',
+    'agents.discoverHint': '点击「发现 CLIs」检查已安装的编码 CLI 与已注册的 Adapter。',
+    'agents.agentId': 'Agent ID',
+    'agents.agentIdPh': '例如 codex / antigravity',
+    'agents.adapter': 'Adapter',
+    'agents.command': '可执行命令',
+    'agents.commandPh': '精确命令，例如 agy-proxy',
+    'agents.role': '工作流角色',
+    'agents.apply': '应用配置',
+    'agents.configured': '已配置的运行 Agent',
+    'agents.scopeNote': '只有显式注册或加载的本地 Adapter 模块才被视为可信本地代码；配置 Agent 不授予任何浏览器文件系统或进程沙箱绕过能力。Workspace 从不渲染或持久化凭据、令牌、Cookie 或密钥。',
+    'agents.configureThis': '配置此命令',
+    'agents.discovering': '正在发现本机编码 CLI…',
+    'agents.discoveryFailed': '发现失败（{code}）：{message}',
+    'agents.discoveryOk': '发现完成。请在下方配置命令，或选择「配置此命令」。',
+    'agents.configuring': '正在应用配置…',
+    'agents.configFailed': '配置失败：{message}',
+    'agents.configOk': '已配置 {id}（{adapter}）→ {command} [{source}] · 工作流 {roles}',
+    'agents.required': 'Agent ID 与可执行命令必填。',
+    'agents.adapterOf': 'adapter {adapter}',
+    'agents.commandOf': 'command {command}',
+    'agents.configuredPill': '已配置',
+    'agents.available': '可用',
+    'agents.unavailable': '不可用',
+    'agents.notConfiguredHere': '未在此项目配置',
+    'agents.builtin': '内置',
+    'agents.localAdapter': '已注册本地 Adapter',
+    'agents.noCapabilities': '无能力',
+    'agents.roles': '角色',
+    'agents.unassigned': '未分配',
+    'agents.queue': '队列 {new} 新 · {processing} 处理中',
+    'agents.lastActivity': '最近活动 {activity}',
+    'agents.unregistered': '未注册',
+    'roles.planner': '规划者',
+    'roles.implementer': '实现者',
+    'roles.reviewer': '评审者',
+    'roles.unassigned': '未分配',
+    'roles.noneConfigured': '（未配置 Agent）',
+    'session.send': '发送输入',
+    'session.inputPh': '向此持有的会话发送有界输入…',
+    'session.close': '关闭会话',
+    'session.closing': '正在关闭会话…',
+    'session.closed': '会话已关闭。',
+    'session.closeRejected': '关闭被拒绝：{message}',
+    'session.sending': '正在发送有界输入…',
+    'session.sent': '输入已接受。',
+    'session.rejected': '输入被拒绝：{message}',
+    'session.tasks': '任务：{tasks}',
+    'session.recorded': '已记录事件',
+    'session.derived': '派生 / 旧版历史',
+    'status.creator': '已创建',
+    'date.justNow': '刚刚',
+    'generic.ok': '确定',
+    'generic.error': '错误',
+    'generic.details': '详情',
+    'generic.validating': '验证中…',
+    'generic.loading': '加载中…',
+    'generic.failed': '失败',
+    'author.validated': '图通过验证：{count} 个子任务',
+    'author.missingIntent': '意图覆盖缺失（未验证）',
+    'author.intentPresent': '意图事实存在',
+    'author.validatedOk': '验证通过。创建后可查看预检，或继续修改表单。',
+    'author.preflightFailed': '预检不可用',
+    'author.preflightTitle': '图预检',
+    'author.creatingGraph': '正在创建已验证的 Runtime 记录（不派发）…',
+    'author.createFailed': '创建失败。',
+    'author.createdGraph': '已创建 {id}',
+    'author.loadingPreflight': '正在加载预检…',
+    'execution.factTask': '任务 / 父任务',
+    'execution.factSubtasks': '子任务数',
+    'execution.factState': '状态',
+    'execution.factSession': '会话',
+    'execution.factCommit': '提交',
+    'execution.factWaves': '已执行波次',
+    'execution.factStop': '停止原因',
+    'execution.factAgent': 'Agent',
+    'lb.Specification': '规格说明',
+    'lb.Executable': '可执行命令',
+    'lb.Worktree / branch / commit': 'Worktree / 分支 / 提交',
+    'lb.Evidence': '证据',
+    'lb.Scope audit': '范围审计',
+    'lb.Recovery': '恢复',
+    'lb.Cleanup': '清理',
+    'lb.Last error': '最后错误',
+    'lb.Max concurrency': '最大并发',
+    'lb.Current frontier': '当前前沿',
+    'lb.Selected preflight wave': '选定预检波次',
+    'lb.Write-intent conflicts': '写入意图冲突',
+    'lb.Intent coverage': '意图覆盖',
+    'lb.Recovery classifications': '恢复分类',
+    'lb.Integration': '集成',
+    'lb.Integration facts': '集成事实',
+    'lb.Review': '评审',
+    'lb.Review history': '评审历史',
+    'lb.Aggregate commit': '聚合提交',
+    'lb.Applied refs': '已应用引用',
+    'lb.Review worktree': '评审 worktree',
+    'lb.Branch': '分支',
+    'lb.Conflicts': '冲突',
+    'lb.Frontier': '前沿',
+    'lb.Selected wave': '选定波次',
+    'lb.Scope policy': '范围策略',
+    'lb.Risks': '风险',
+    'lb.Estimated resources': '资源估算',
+    'lb.Base commit': '基础提交',
+    'lb.Commit': '提交',
+    'lb.Frontier & preflight wave': '前沿与预检波次',
+    'lb.Conflicts & scope audit': '冲突与范围审计',
+    'lb.Integration & review': '集成与评审',
+    'generic.copy': '复制',
+    'subtask.dependsOn': '依赖',
+    'subtask.writeIntent': '写入意图（可选）',
+    'subtask.remove': '移除',
+  },
+};
+
+const STATUS_I18N = {
+  'en-US': {
+    CREATED: 'Created', PLANNING: 'Planning', SPEC_READY: 'Spec ready',
+    IMPLEMENTING: 'Implementing', WAITING_IMPLEMENTER: 'Waiting for implementer',
+    REVIEWING: 'Reviewing', CHANGES_REQUESTED: 'Changes requested', APPROVED: 'Approved',
+    ERROR: 'Error', STOPPED: 'Stopped', RUNNING: 'Running', SUCCEEDED: 'Succeeded',
+    FAILED: 'Failed', BLOCKED: 'Blocked', WAITING: 'Waiting', READY: 'Ready',
+    REVIEW_APPROVED: 'Review approved', IDLE: 'Idle', BUSY: 'Busy', AVAILABLE: 'Available',
+    UNAVAILABLE: 'Unavailable', UNKNOWN: 'Unknown', STARTING: 'Starting',
+    RECOVERING: 'Recovering', RECOVERED: 'Recovered', REVIEW: 'Review', PLANNED: 'Planned',
+    QUEUED: 'Queued', SESSION_STARTED: 'Session started',
+  },
+  'zh-CN': {
+    CREATED: '已创建', PLANNING: '规划中', SPEC_READY: '规格就绪',
+    IMPLEMENTING: '实现中', WAITING_IMPLEMENTER: '等待实现者',
+    REVIEWING: '评审中', CHANGES_REQUESTED: '已请求修改', APPROVED: '已批准',
+    ERROR: '出错', STOPPED: '已停止', RUNNING: '运行中', SUCCEEDED: '已成功',
+    FAILED: '失败', BLOCKED: '受阻', WAITING: '等待中', READY: '就绪',
+    REVIEW_APPROVED: '评审通过', IDLE: '空闲', BUSY: '忙碌', AVAILABLE: '可用',
+    UNAVAILABLE: '不可用', UNKNOWN: '未知', STARTING: '启动中',
+    RECOVERING: '恢复中', RECOVERED: '已恢复', REVIEW: '评审', PLANNED: '已规划',
+    QUEUED: '排队中', SESSION_STARTED: '会话已启动',
+  },
+};
+
+function t(key, vars = {}) {
+  let text = (I18N[locale] && I18N[locale][key]) ?? I18N['en-US'][key] ?? key;
+  for (const [name, value] of Object.entries(vars)) {
+    text = text.replaceAll(`{${name}}`, String(value));
+  }
+  return text;
+}
+
+function statusText(raw) {
+  const key = `${raw ?? ''}`.toUpperCase().replace(/\s+/g, '_');
+  if (STATUS_I18N[locale] && STATUS_I18N[locale][key]) return STATUS_I18N[locale][key];
+  if (STATUS_I18N['en-US'][key]) return STATUS_I18N['en-US'][key];
+  return raw ? `${raw}`.replaceAll('_', ' ') : t('msg.unknownStatus');
+}
+
+function eventText(raw) {
+  const key = `${raw ?? ''}`.toUpperCase().replace(/\s+/g, '_');
+  if (STATUS_I18N[locale] && STATUS_I18N[locale][key]) return STATUS_I18N[locale][key];
+  if (STATUS_I18N['en-US'][key]) return STATUS_I18N['en-US'][key];
+  if (raw) return `${raw}`.replaceAll('_', ' ');
+  return t('msg.unknownEvent');
+}
+
+function labelText(label) {
+  const text = `${label}`;
+  const translated = (I18N[locale] && I18N[locale][`lb.${text}`]) ?? I18N['en-US'][`lb.${text}`];
+  return translated ?? text;
+}
+
+function applyStaticI18n() {
+  document.documentElement.lang = locale === 'zh-CN' ? 'zh-CN' : 'en-US';
+  document.querySelectorAll('[data-i18n]').forEach(element => {
+    element.textContent = t(element.dataset.i18n);
+  });
+  document.querySelectorAll('[data-i18n-placeholder]').forEach(element => {
+    element.placeholder = t(element.dataset.i18nPlaceholder);
+  });
+  document.querySelectorAll('[data-i18n-title]').forEach(element => {
+    element.title = t(element.dataset.i18nTitle);
+  });
+  // Document title keeps the product anchor "Coordinate Agents Workspace".
+  document.title = locale === 'zh-CN' ? 'Coordinate Agents 工作台' : 'Coordinate Agents Workspace';
+}
+
+function persistLocale(next) {
+  locale = next === 'zh-CN' ? 'zh-CN' : 'en-US';
+  try { localStorage.setItem(LOCALE_KEY, locale); } catch { /* storage may be unavailable */ }
+  applyStaticI18n();
+  renderLanguageControls();
+  updateSendLabel();
+  setViewHeading(state.currentView);
+  renderChatArea();
+  refresh();
+}
+
+function renderLanguageControls() {
+  const zh = document.getElementById('lang-zh');
+  const en = document.getElementById('lang-en');
+  if (!zh || !en) return;
+  zh.setAttribute('aria-pressed', String(locale === 'zh-CN'));
+  en.setAttribute('aria-pressed', String(locale === 'en-US'));
+}
+
+function detectInitialLocale() {
+  let saved = null;
+  try { saved = localStorage.getItem(LOCALE_KEY); } catch { /* ignore */ }
+  if (saved === 'zh-CN' || saved === 'en-US') return saved;
+  const nav = `${navigator.language || ''}`.toLowerCase();
+  return nav.startsWith('zh') ? 'zh-CN' : 'en-US';
+}
+
+let locale = detectInitialLocale();
+
 const STATUS_ORDER = [
   'CREATED',
   'PLANNING',
@@ -11,6 +750,11 @@ const STATUS_ORDER = [
   'STOPPED',
 ];
 
+/* Local, truthful record of explicit actions performed in this browser
+ * session (creation, dispatch, review, …). Never fabricated: each entry is
+ * written only after the Runtime acknowledged the operation. */
+const localActions = new Map(); // taskId -> array of {label, kind, at}
+
 const state = {
   tasks: [],
   agents: [],
@@ -21,11 +765,12 @@ const state = {
   selectedTask: null,
   selectedSubtask: null,
   graphDetail: null,
+  currentView: 'chat',
+  contextOpen: true,
+  detailOpen: false,
+  authorOpen: false,
 };
 
-// Server-issued per-launch capability for guarded browser actions (#46). The
-// read-only surfaces never use it; later control panels attach it to POST
-// /api/action requests as x-coordinate-agents-capability.
 const capabilityMeta = document.querySelector('meta[name="coordinate-agents-capability"]');
 const workspaceCapability = capabilityMeta?.content && capabilityMeta.content !== '__COORDINATE_AGENTS_CAPABILITY__'
   ? capabilityMeta.content
@@ -50,7 +795,7 @@ const elements = Object.fromEntries([
   'timeline', 'detail-agent-flow', 'evidence', 'spec', 'sessions', 'session-count',
   'events', 'refresh-button', 'close-detail', 'graph-detail', 'graph-topology',
   'graph-frontier', 'graph-conflicts', 'graph-integration', 'repository',
-  'repo-name', 'repo-branch', 'repo-facts', 'graph-map-region', 'graph-map',
+  'repo-name', 'repo-branch', 'repo-facts', 'repo-facts-toggle', 'graph-map-region', 'graph-map',
   'graph-node-detail', 'graph-map-note', 'graph-legend',
   'discover-agents', 'agents-discovery', 'agent-configure', 'cfg-agent',
   'cfg-adapter', 'cfg-command', 'cfg-role', 'apply-agent', 'agent-status',
@@ -64,6 +809,13 @@ const elements = Object.fromEntries([
   'author-graph-errors', 'author-graph-validated', 'author-graph-preflight',
   'execution-panel', 'execution-title', 'execution-controls', 'execution-status', 'execution-result',
   'review-panel', 'review-controls', 'review-status', 'review-result',
+  'view-title', 'view-subtitle', 'chat-welcome', 'chat-feed', 'recent-list', 'recent-toggle',
+  'context-panel', 'context-body', 'context-selection', 'context-toggle', 'context-close',
+  'new-task-button', 'composer-input', 'composer-agent', 'composer-mode', 'composer-send',
+  'composer-hint', 'composer-status', 'toast-region',
+  'drawer-scrim', 'detail-drawer', 'drawer-title', 'drawer-close',
+  'author-drawer', 'author-drawer-close', 'chat-scroll',
+  'sidebar', 'sidebar-open', 'sidebar-close', 'lang-zh', 'lang-en',
 ].map(id => [id, document.getElementById(id)]));
 
 function escapeHtml(value) {
@@ -78,7 +830,15 @@ function escapeHtml(value) {
 function formatDate(value) {
   if (!value) return '—';
   const date = new Date(value);
-  return Number.isNaN(date.valueOf()) ? escapeHtml(value) : date.toLocaleString();
+  if (Number.isNaN(date.valueOf())) return `${value}`;
+  return date.toLocaleString(locale === 'zh-CN' ? 'zh-CN' : 'en-US');
+}
+
+function formatTime(value) {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.valueOf())) return `${value}`;
+  return date.toLocaleTimeString(locale === 'zh-CN' ? 'zh-CN' : 'en-US', { hour: '2-digit', minute: '2-digit' });
 }
 
 function statusClass(status) {
@@ -86,7 +846,7 @@ function statusClass(status) {
 }
 
 function statusLabel(status) {
-  return `${status || 'UNKNOWN'}`.replaceAll('_', ' ');
+  return statusText(status);
 }
 
 function shortId(value) {
@@ -100,26 +860,183 @@ async function fetchJson(path) {
   return response.json();
 }
 
-function renderTasks() {
-  elements['task-count'].textContent = state.tasks.length;
-  if (state.tasks.length === 0) {
-    elements.tasks.innerHTML = '<div class="empty-state">No Tasks found in this project.</div>';
+/* ------------------------------------------------------------------ */
+/* Toast                                                              */
+/* ------------------------------------------------------------------ */
+function toast(message, kind = 'info', timeout = 4000) {
+  const region = elements['toast-region'];
+  if (!region) return;
+  const node = document.createElement('div');
+  node.className = `toast ${kind}`;
+  node.textContent = message;
+  node.setAttribute('role', kind === 'error' ? 'alert' : 'status');
+  region.appendChild(node);
+  window.setTimeout(() => {
+    node.classList.add('leaving');
+    window.setTimeout(() => node.remove(), 300);
+  }, timeout);
+}
+
+/* ------------------------------------------------------------------ */
+/* Navigation & layout                                                */
+/* ------------------------------------------------------------------ */
+function setViewHeading(view) {
+  const title = elements['view-title'];
+  const subtitle = elements['view-subtitle'];
+  if (title) title.textContent = t(`view.${view}`);
+  if (subtitle) subtitle.textContent = t(`view.subtitle${view.charAt(0).toUpperCase()}${view.slice(1)}`);
+}
+
+function switchView(view) {
+  if (!['chat', 'tasks', 'agents', 'sessions', 'activity'].includes(view)) return;
+  state.currentView = view;
+  document.querySelectorAll('[data-view-panel]').forEach(panel => {
+    const active = panel.dataset.viewPanel === view;
+    panel.hidden = !active;
+    panel.classList.toggle('active', active);
+  });
+  document.querySelectorAll('.nav-item[data-view]').forEach(item => {
+    const active = item.dataset.view === view;
+    item.classList.toggle('active', active);
+    if (active) item.setAttribute('aria-current', 'true');
+    else item.removeAttribute('aria-current');
+  });
+  setViewHeading(view);
+  if (view !== 'chat') {
+    closeSidebarIfMobile();
+  }
+  if (view === 'chat') renderChatArea();
+}
+
+function isNarrowSidebar() {
+  return window.matchMedia('(max-width: 1024px)').matches;
+}
+
+function openSidebar() {
+  elements.sidebar?.classList.add('open');
+  document.body.classList.add('sidebar-open');
+  elements['sidebar-close']?.removeAttribute('hidden');
+  if (elements['sidebar-close']) elements['sidebar-close'].focus();
+}
+
+function closeSidebarIfMobile() {
+  if (!isNarrowSidebar()) return;
+  elements.sidebar?.classList.remove('open');
+  document.body.classList.remove('sidebar-open');
+  if (elements['sidebar-close']) elements['sidebar-close'].hidden = true;
+}
+
+function updateContextState() {
+  const open = state.contextOpen;
+  const panel = elements['context-panel'];
+  if (!panel) return;
+  const narrow = window.matchMedia('(max-width: 1180px)').matches;
+  document.body.classList.toggle('cx-open', open && narrow);
+  panel.setAttribute('aria-hidden', String(!open));
+  const toggle = elements['context-toggle'];
+  if (toggle) toggle.setAttribute('aria-expanded', String(open));
+  // Wide layout: hide via the hidden attribute. Narrow layout: the panel
+  // slides in/out via the transform controlled by .cx-open.
+  panel.hidden = !open && !narrow;
+}
+
+function toggleContext() {
+  state.contextOpen = !state.contextOpen;
+  updateContextState();
+}
+
+function openDetailDrawer(focusId = null) {
+  state.detailOpen = true;
+  elements['detail-drawer'].hidden = false;
+  elements['drawer-scrim'].hidden = false;
+  document.body.classList.add('drawer-open');
+  elements['detail-drawer'].setAttribute('aria-hidden', 'false');
+  window.setTimeout(() => {
+    const target = focusId ? elements['detail-drawer'].querySelector(`#${CSS.escape(focusId)}`) : null;
+    if (target) target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    (elements['drawer-close'] || elements['detail-drawer']).focus();
+  }, 30);
+}
+
+function openAuthorDrawer() {
+  state.authorOpen = true;
+  elements['author-drawer'].hidden = false;
+  elements['drawer-scrim'].hidden = false;
+  document.body.classList.add('drawer-open');
+  elements['author-drawer'].setAttribute('aria-hidden', 'false');
+  window.setTimeout(() => (elements['author-drawer-close'] || elements['author-drawer']).focus(), 30);
+}
+
+function closeTopDrawer() {
+  if (state.authorOpen) {
+    state.authorOpen = false;
+    elements['author-drawer'].hidden = true;
+    elements['author-drawer'].setAttribute('aria-hidden', 'true');
+  } else if (state.detailOpen) {
+    state.detailOpen = false;
+    elements['detail-drawer'].hidden = true;
+    elements['detail-drawer'].setAttribute('aria-hidden', 'true');
+  } else {
     return;
   }
-  elements.tasks.innerHTML = state.tasks.map(task => `
-    <button class="task-card ${task.graph ? 'graph-card' : ''} ${state.selectedTask === task.id ? 'selected' : ''}" data-task-id="${escapeHtml(task.id)}" type="button">
-      <span class="task-card-top"><span class="task-id">${escapeHtml(shortId(task.id))}</span><span class="round">${task.graph ? 'GRAPH' : `R${escapeHtml(task.round)}`}</span></span>
-      <strong>${escapeHtml(task.title)}</strong>
-      <span class="status-pill ${statusClass(task.status)}">${escapeHtml(statusLabel(task.status))}</span>
-      ${task.graph ? `<span class="graph-card-meta">${escapeHtml(task.subtaskCount)} subtasks · concurrency ${escapeHtml(task.maxConcurrency)}</span>` : ''}
-      <span class="task-updated">Updated ${formatDate(task.updatedAt)}</span>
-    </button>
-  `).join('');
-  elements.tasks.querySelectorAll('[data-task-id]').forEach(button => {
+  if (!state.authorOpen && !state.detailOpen) {
+    elements['drawer-scrim'].hidden = true;
+    document.body.classList.remove('drawer-open');
+    if (state.selectedTask) {
+      const source = document.querySelector(`[data-task-id="${CSS.escape(state.selectedTask)}"]`);
+      source?.focus();
+    }
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* Sidebar & recent list                                              */
+/* ------------------------------------------------------------------ */
+function renderRecentList() {
+  const container = elements['recent-list'];
+  if (!container) return;
+  const tasks = (state.tasks || []).slice(0, 6);
+  const sessions = (state.sessions || []).slice(0, 3);
+  if (!tasks.length && !sessions.length) {
+    container.innerHTML = `<div class="recent-empty">${escapeHtml(t('empty.recent'))}</div>`;
+    return;
+  }
+  const taskItems = tasks.map(task => `
+    <button class="recent-item ${state.selectedTask === task.id ? 'selected' : ''}" type="button"
+      data-task-id="${escapeHtml(task.id)}" title="${escapeHtml(task.title || task.id)}">
+      <span class="recent-item-type">${task.graph ? 'GRAPH' : 'TASK'}</span>
+      <span class="recent-item-main"><strong>${escapeHtml(task.title || task.id)}</strong>
+      <span class="recent-item-sub"><span class="state-dot ${statusClass(task.status)}"></span>${escapeHtml(statusText(task.status))}</span></span>
+      <time>${escapeHtml(formatTime(task.updatedAt))}</time>
+    </button>`).join('');
+  const sessionItems = sessions.map(session => `
+    <button class="recent-item" type="button" data-session-id="${escapeHtml(session.sessionId)}"
+      title="${escapeHtml(session.agent || session.sessionId)}">
+      <span class="recent-item-type">SESS</span>
+      <span class="recent-item-main"><strong>${escapeHtml(session.agent || shortId(session.sessionId))}</strong>
+      <span class="recent-item-sub"><span class="state-dot ${statusClass(session.status)}"></span>${escapeHtml(statusText(session.status))}</span></span>
+      <time>${escapeHtml(formatTime(session.lastActivity))}</time>
+    </button>`).join('');
+  container.innerHTML = (taskItems ? `<div class="recent-group-label">${escapeHtml(t('nav.tasks'))}</div>${taskItems}` : '')
+    + (sessionItems ? `<div class="recent-group-label">${escapeHtml(t('nav.sessions'))}</div>${sessionItems}` : '');
+  container.querySelectorAll('[data-task-id]').forEach(button => {
     button.addEventListener('click', () => selectTask(button.dataset.taskId));
+  });
+  container.querySelectorAll('[data-session-id]').forEach(button => {
+    button.addEventListener('click', () => selectSession(button.dataset.sessionId));
   });
 }
 
+function selectSession(sessionId) {
+  switchView('sessions');
+  const target = elements.sessions?.querySelector(`[data-session="${CSS.escape(sessionId)}"]`);
+  target?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  target?.focus();
+}
+
+/* ------------------------------------------------------------------ */
+/* Repository                                                         */
+/* ------------------------------------------------------------------ */
 function renderRepository() {
   const repository = state.repository;
   if (!repository) {
@@ -127,24 +1044,37 @@ function renderRepository() {
     return;
   }
   elements.repository.hidden = false;
-  elements['repo-name'].textContent = repository.name || repository.root || 'Repository';
-  elements['repo-branch'].textContent = repository.branch || (repository.detached ? 'detached' : '—');
+  elements['repo-name'].textContent = repository.name || repository.root || t('repo.repo');
+  elements['repo-branch'].textContent = repository.branch || (repository.detached ? t('repo.detached') : '—');
   const facts = [];
   if (repository.head) {
-    facts.push(`<div class="repo-fact"><span>HEAD</span><code>${escapeHtml(repository.head.short || '—')}</code></div>`);
-    facts.push(`<div class="repo-fact repo-fact-wide"><span>${repository.branch ? `Latest commit on ${escapeHtml(repository.branch)}` : 'Latest commit'}</span><strong>${escapeHtml(repository.head.subject || '—')}</strong></div>`);
+    facts.push(`<div class="repo-fact"><span>${escapeHtml(t('repo.head'))}</span><code>${escapeHtml(repository.head.short || '—')}</code></div>`);
+    facts.push(`<div class="repo-fact repo-fact-wide"><span>${escapeHtml(repository.branch ? t('repo.latestOn', { branch: repository.branch }) : t('repo.latest'))}</span><strong>${escapeHtml(repository.head.subject || '—')}</strong></div>`);
     if (repository.head.committedAt) {
-      facts.push(`<div class="repo-fact"><span>Committed</span><time>${formatDate(repository.head.committedAt)}</time></div>`);
+      facts.push(`<div class="repo-fact"><span>${escapeHtml(t('repo.committed'))}</span><time>${escapeHtml(formatDate(repository.head.committedAt))}</time></div>`);
     }
   } else {
-    facts.push('<div class="repo-fact"><span>HEAD</span><code>no commits yet</code></div>');
+    facts.push(`<div class="repo-fact"><span>${escapeHtml(t('repo.head'))}</span><code>${escapeHtml(t('repo.noCommits'))}</code></div>`);
   }
-  facts.push(`<div class="repo-fact"><span>Remote</span><code>${escapeHtml(repository.remoteUrl || 'no origin remote')}</code></div>`);
-  facts.push(`<div class="repo-fact repo-fact-wide"><span>Bound root</span><code>${escapeHtml(repository.root || '—')}</code></div>`);
-  if (repository.error) facts.push(`<div class="repo-fact repo-fact-wide"><span>Repository facts</span><code>${escapeHtml(repository.error)}</code></div>`);
+  facts.push(`<div class="repo-fact"><span>${escapeHtml(t('repo.remote'))}</span><code>${escapeHtml(repository.remoteUrl || t('repo.noOrigin'))}</code></div>`);
+  facts.push(`<div class="repo-fact repo-fact-wide"><span>${escapeHtml(t('repo.boundRoot'))}</span><code>${escapeHtml(repository.root || '—')}</code></div>`);
+  if (repository.error) facts.push(`<div class="repo-fact repo-fact-wide"><span>${escapeHtml(t('repo.factsError'))}</span><code>${escapeHtml(repository.error)}</code></div>`);
   elements['repo-facts'].innerHTML = facts.join('');
 }
 
+function toggleRepoFacts() {
+  const facts = elements['repo-facts'];
+  const toggle = elements['repo-facts-toggle'];
+  if (!facts || !toggle) return;
+  const willShow = facts.hidden;
+  facts.hidden = !willShow;
+  toggle.textContent = willShow ? t('repo.hideDetails') : t('repo.details');
+  toggle.setAttribute('aria-expanded', String(willShow));
+}
+
+/* ------------------------------------------------------------------ */
+/* Agent discovery / configuration (Agents view)                      */
+/* ------------------------------------------------------------------ */
 function commandSourceClass(source) {
   const value = `${source || ''}`.toLowerCase();
   if (value.startsWith('project')) return 'project';
@@ -154,6 +1084,7 @@ function commandSourceClass(source) {
 
 function setAgentStatus(message, kind = 'info') {
   const element = elements['agent-status'];
+  if (!element) return;
   element.textContent = message;
   element.className = `agent-status ${kind}`;
 }
@@ -174,7 +1105,7 @@ function fillConfigureForm(entry) {
 
 function renderAgentsDiscovery(snapshot) {
   if (!snapshot) {
-    elements['agents-discovery'].innerHTML = '<div class="empty-state">No discovery snapshot available.</div>';
+    elements['agents-discovery'].innerHTML = `<div class="empty-state">${escapeHtml(t('empty.discovery'))}</div>`;
     return;
   }
   const agents = Array.isArray(snapshot.agents) ? snapshot.agents : [];
@@ -192,15 +1123,15 @@ function renderAgentsDiscovery(snapshot) {
     return `<article class="agent-row">
       <div class="agent-row-main">
         <strong>${escapeAgent(identity)}</strong>
-        <span class="status-pill ${available ? 'idle' : 'error'}">${available ? 'available' : 'unavailable'}</span>
-        ${agent.configured ? '<span class="history-label">configured</span>' : ''}
-        ${agent.adapter ? `<span class="agent-muted">adapter ${escapeAgent(agent.adapter)}</span>` : ''}
-        ${agent.command ? `<span class="agent-muted">command <code>${escapeAgent(agent.command)}</code></span>` : ''}
+        <span class="status-pill ${available ? 'idle' : 'error'}">${available ? escapeHtml(t('agents.available')) : escapeHtml(t('agents.unavailable'))}</span>
+        ${agent.configured ? `<span class="history-label">${escapeHtml(t('agents.configuredPill'))}</span>` : ''}
+        ${agent.adapter ? `<span class="agent-muted">${escapeHtml(t('agents.adapterOf', { adapter: agent.adapter }))}</span>` : ''}
+        ${agent.command ? `<span class="agent-muted">${escapeHtml(t('agents.commandOf', { command: agent.command }))}<code>${escapeAgent(agent.command)}</code></span>` : ''}
       </div>
       <div class="agent-row-detail">${escapeAgent(agent.details || agent.code || '')}</div>
-      <button class="button ghost agent-fill" type="button" data-json="${escapeHtml(JSON.stringify({ agent: identity, command: agent.command, adapter: agent.adapter || '' }))}">Configure this command</button>
+      <button class="button ghost agent-fill" type="button" data-json="${escapeHtml(JSON.stringify({ agent: identity, command: agent.command, adapter: agent.adapter || '' }))}">${escapeHtml(t('agents.configureThis'))}</button>
     </article>`;
-  }).join('') || '<div class="empty-state">No coding CLIs detected on this machine.</div>';
+  }).join('') || `<div class="empty-state">${escapeHtml(t('empty.discoveryAgents'))}</div>`;
 
   const adapterBlocks = adapters.map(adapter => {
     const capabilities = Object.entries(adapter.capabilities || {})
@@ -210,25 +1141,25 @@ function renderAgentsDiscovery(snapshot) {
     const configured = (adapter.configuredAgents || []).map(item => `
       <div class="configured-agent-row">
         <code>${escapeAgent(item.id)}</code>
-        <span class="agent-muted">adapter ${escapeAgent(item.adapter || adapter.id)}</span>
+        <span class="agent-muted">${escapeHtml(t('agents.adapterOf', { adapter: item.adapter || adapter.id }))}</span>
         <code>${escapeAgent(item.command || '—')}</code>
         <span class="source-badge ${commandSourceClass(item.commandSource)}">${escapeAgent(item.commandSource || 'adapter-default')}</span>
-      </div>`).join('') || '<span class="agent-muted">not configured in this project</span>';
+      </div>`).join('') || `<span class="agent-muted">${escapeHtml(t('agents.notConfiguredHere'))}</span>`;
     return `<article class="adapter-card">
       <div class="adapter-card-heading">
         <strong>${escapeAgent(adapter.id)}</strong>
-        <span class="history-label">${adapter.builtin ? 'built-in' : 'registered local adapter'}</span>
+        <span class="history-label">${adapter.builtin ? escapeHtml(t('agents.builtin')) : escapeHtml(t('agents.localAdapter'))}</span>
         <span class="agent-muted">contract v${escapeAgent(adapter.contractVersion)}</span>
       </div>
-      <div class="agent-muted">${capabilities || 'no capabilities'}</div>
+      <div class="agent-muted">${capabilities || escapeHtml(t('agents.noCapabilities'))}</div>
       <div class="configured-agents-list">${configured}</div>
     </article>`;
   }).join('');
 
   elements['agents-discovery'].innerHTML = `
     <div class="discovery-grid">
-      <div><h3>Detected coding CLIs</h3><div class="discovery-list">${agentRows}</div></div>
-      <div><h3>Adapters & command sources</h3><div class="discovery-list">${adapterBlocks || '<div class="empty-state">No adapters registered.</div>'}</div></div>
+      <div><h3>${escapeHtml(t('lb.Detected coding CLIs'))}</h3><div class="discovery-list">${agentRows}</div></div>
+      <div><h3>${escapeHtml(t('lb.Adapters & command sources'))}</h3><div class="discovery-list">${adapterBlocks || `<div class="empty-state">${escapeHtml(t('empty.discoveryAdapters'))}</div>`}</div></div>
     </div>`;
   elements['agents-discovery'].querySelectorAll('.agent-fill').forEach(button => {
     button.addEventListener('click', () => {
@@ -240,21 +1171,21 @@ function renderAgentsDiscovery(snapshot) {
 function renderConfiguredAgents(agents) {
   const list = Array.isArray(agents) ? agents : [];
   if (list.length === 0) {
-    elements['configured-agents'].innerHTML = '<div class="empty-state">No Agents are registered in this repository yet.</div>';
+    elements['configured-agents'].innerHTML = `<div class="empty-state">${escapeHtml(t('empty.configuredAgents'))}</div>`;
     return;
   }
   elements['configured-agents'].innerHTML = list.map(agent => `
     <article class="configured-agent">
       <div class="configured-agent-head">
         <strong>${escapeAgent(agent.id)}</strong>
-        <span class="status-pill ${statusClass(agent.status)}">${escapeAgent(statusLabel(agent.status))}</span>
+        <span class="status-pill ${statusClass(agent.status)}">${escapeHtml(statusText(agent.status))}</span>
       </div>
       <div class="configured-agent-facts">
-        <span>adapter <code>${escapeAgent(agent.adapter || '—')}</code></span>
-        <span>roles <code>${escapeAgent(agent.roles?.join(', ') || 'unassigned')}</code></span>
-        <span>queue ${escapeAgent(agent.queue?.new || 0)} new · ${escapeAgent(agent.queue?.processing || 0)} processing</span>
+        <span>${escapeHtml(t('agents.adapterOf', { adapter: agent.adapter || '—' }))}</span>
+        <span>${escapeHtml(t('agents.roles'))} <code>${escapeAgent(agent.roles?.join(', ') || t('agents.unassigned'))}</code></span>
+        <span>${escapeHtml(t('agents.queue', { new: agent.queue?.new || 0, processing: agent.queue?.processing || 0 }))}</span>
       </div>
-      ${agent.lastActivity ? `<div class="agent-muted">last activity ${escapeAgent(agent.lastActivity)}</div>` : ''}
+      ${agent.lastActivity ? `<div class="agent-muted">${escapeHtml(t('agents.lastActivity', { activity: agent.lastActivity }))}</div>` : ''}
     </article>`).join('');
 }
 
@@ -269,19 +1200,20 @@ function refreshAgentSelects() {
     'author-task-planner', 'author-task-implementer', 'author-task-reviewer',
     'author-graph-planner', 'author-graph-reviewer',
   ];
+  const emptyLabel = t('roles.noneConfigured');
   const options = ids.map(id => `<option value="${escapeHtml(id)}">${escapeHtml(id)}</option>`).join('');
   for (const name of selects) {
     const element = elements[name];
     if (!element) continue;
     const previous = element.value;
-    element.innerHTML = options || '<option value="">(no agents configured)</option>';
+    element.innerHTML = options || `<option value="">${escapeHtml(emptyLabel)}</option>`;
     if (previous && ids.includes(previous)) element.value = previous;
     else if (element.name === 'implementer' && ids.includes('antigravity')) element.value = 'antigravity';
   }
   document.querySelectorAll('[data-implementer-select]').forEach(select => {
     if (!select) return;
     const previous = select.value;
-    select.innerHTML = options || '<option value="">(no agents configured)</option>';
+    select.innerHTML = options || `<option value="">${escapeHtml(emptyLabel)}</option>`;
     if (previous && ids.includes(previous)) select.value = previous;
   });
 }
@@ -291,12 +1223,12 @@ function addSubtaskRow(preset = {}) {
   row.className = 'subtask-row';
   row.innerHTML = `
     <label>ID<input class="sub-id" maxlength="64" placeholder="sub-a" value="${escapeHtml(preset.id || '')}"></label>
-    <label>Title<input class="sub-title" maxlength="1024" placeholder="${escapeHtml(preset.title || '')}"></label>
-    <label>Implementer<select class="sub-implementer" data-implementer-select></select></label>
-    <label>Spec<input class="sub-spec" maxlength="262144" placeholder="What this subtask must change"></label>
-    <label>Depends on<input class="sub-depends" maxlength="1024" placeholder="sub-a sub-b (ids)"></label>
-    <label>Write intent (optional)<input class="sub-intent" maxlength="2048" placeholder="src/a/** docs/a/**"></label>
-    <button class="button ghost sub-remove" type="button" aria-label="Remove subtask">Remove</button>`;
+    <label>${escapeHtml(t('author.graphTitleLabel'))}<input class="sub-title" maxlength="1024" placeholder="${escapeHtml(preset.title || '')}"></label>
+    <label>${escapeHtml(t('roles.implementer'))}<select class="sub-implementer" data-implementer-select></select></label>
+    <label>${escapeHtml(t('author.specLabel'))}<input class="sub-spec" maxlength="262144" placeholder="What this subtask must change"></label>
+    <label>${escapeHtml(t('subtask.dependsOn'))}<input class="sub-depends" maxlength="1024" placeholder="sub-a sub-b (ids)"></label>
+    <label>${escapeHtml(t('subtask.writeIntent'))}<input class="sub-intent" maxlength="2048" placeholder="src/a/** docs/a/**"></label>
+    <button class="button ghost sub-remove" type="button" aria-label="Remove subtask">${escapeHtml(t('subtask.remove'))}</button>`;
   row.querySelector('.sub-remove').addEventListener('click', () => row.remove());
   elements['author-subtask-rows'].appendChild(row);
   refreshAgentSelects();
@@ -319,6 +1251,7 @@ function readSubtaskRows() {
 
 function setGraphStatus(message, kind = 'info') {
   const element = elements['author-graph-status'];
+  if (!element) return;
   element.textContent = message;
   element.className = `author-status ${kind}`;
 }
@@ -364,7 +1297,7 @@ function graphInputs() {
 
 function renderActionError(container, payload) {
   const error = payload?.error || {};
-  container.innerHTML = `<div class="empty-state error-state">${escapeHtml(error.code || 'ACTION_FAILED')} — ${escapeHtml(error.message || 'Request failed.')}${error.details ? `<div>${escapeHtml(error.details)}</div>` : ''}</div>`;
+  container.innerHTML = `<div class="empty-state error-state">${escapeHtml(error.code || 'ACTION_FAILED')} — ${escapeHtml(error.message || t('generic.error'))}${error.details ? `<div>${escapeHtml(error.details)}</div>` : ''}</div>`;
   container.hidden = false;
 }
 
@@ -376,7 +1309,7 @@ async function validateGraphNow() {
     setGraphStatus('Graph title, parent ID, and at least one subtask are required.', 'error');
     return;
   }
-  setGraphStatus('Validating…');
+  setGraphStatus(t('generic.validating'));
   try {
     const { status, payload } = await postAction('taskGraphValidate', {
       graph,
@@ -387,9 +1320,10 @@ async function validateGraphNow() {
       setGraphStatus('Validation failed.', 'error');
       return;
     }
-    elements['author-graph-validated'].innerHTML = `<div class="author-ok-banner">Graph validates: ${escapeHtml(payload.subtaskCount ?? payload.subtasks?.length ?? 'ok')} subtask(s) · ${payload.missingIntentCoverage ? 'intent coverage missing (unverified)' : 'intent facts present'} · scope ${escapeHtml(payload.scopePolicy || payload.intentCoverage?.scopePolicy || '—')}</div>`;
+    const count = payload.subtaskCount ?? payload.subtasks?.length ?? 'ok';
+    elements['author-graph-validated'].innerHTML = `<div class="author-ok-banner">${escapeHtml(t('author.validated', { count }))} ${payload.missingIntentCoverage ? escapeHtml(t('author.missingIntent')) : escapeHtml(t('author.intentPresent'))} · scope ${escapeHtml(payload.scopePolicy || payload.intentCoverage?.scopePolicy || '—')}</div>`;
     elements['author-graph-validated'].hidden = false;
-    setGraphStatus('Validation passed. Review Preflight after creating, or fix the form.', 'ok');
+    setGraphStatus(t('author.validatedOk'), 'ok');
   } catch (error) {
     setGraphStatus(`Validation request failed: ${error.message}`, 'error');
   }
@@ -398,16 +1332,16 @@ async function validateGraphNow() {
 async function showGraphPreflight(taskId) {
   const region = elements['author-graph-preflight'];
   region.hidden = false;
-  region.innerHTML = '<div class="empty-state">Loading Graph Preflight…</div>';
+  region.innerHTML = `<div class="empty-state">${escapeHtml(t('generic.loading'))}</div>`;
   try {
     const { status, payload } = await postAction('taskGraphPlan', { taskId });
     if (status !== 200 || payload?.ok !== true) {
-      region.innerHTML = `<div class="empty-state error-state">Preflight unavailable: ${escapeHtml(payload?.error?.message || `HTTP ${status}`)}</div>`;
+      region.innerHTML = `<div class="empty-state error-state">${escapeHtml(t('author.preflightFailed'))}: ${escapeHtml(payload?.error?.message || `HTTP ${status}`)}</div>`;
       return;
     }
     const plan = payload.plan && typeof payload.plan === 'object' ? payload.plan : {};
     region.innerHTML = `
-      <h3>Graph Preflight</h3>
+      <h3>${escapeHtml(t('author.preflightTitle'))}</h3>
       <div class="preflight-grid">
         ${factBlock('Frontier', payload.frontier)}
         ${factBlock('Selected wave', plan.wave)}
@@ -418,7 +1352,7 @@ async function showGraphPreflight(taskId) {
         ${factBlock('Estimated resources', plan.resourceEstimates)}
       </div>`;
   } catch (error) {
-    region.innerHTML = `<div class="empty-state error-state">Preflight request failed: ${escapeHtml(error.message)}</div>`;
+    region.innerHTML = `<div class="empty-state error-state">${escapeHtml(t('author.preflightFailed'))}: ${escapeHtml(error.message)}</div>`;
   }
 }
 
@@ -428,7 +1362,7 @@ async function createGraphNow() {
     setGraphStatus('Parent ID, title, and at least one subtask are required.', 'error');
     return;
   }
-  setGraphStatus('Creating the validated Runtime record (no dispatch)…');
+  setGraphStatus(t('author.creatingGraph'));
   elements['author-graph-create'].disabled = true;
   try {
     const { status, payload } = await postAction('taskGraphCreate', {
@@ -437,11 +1371,12 @@ async function createGraphNow() {
     });
     if (status !== 200 || payload?.ok !== true) {
       renderActionError(elements['author-graph-errors'], payload);
-      setGraphStatus('Create failed.', 'error');
+      setGraphStatus(t('author.createFailed'), 'error');
       return;
     }
-    setGraphStatus(`Created ${payload.parentTaskId || payload.graphId} (state ${escapeHtml(payload.state || payload.status || 'CREATED')}). Loading Preflight…`, 'ok');
-    await showGraphPreflight(payload.parentTaskId || payload.graphId || parentId);
+    const createdId = payload.parentTaskId || payload.graphId || parentId;
+    setGraphStatus(`${escapeHtml(t('author.createdGraph', { id: createdId }))} (${escapeHtml(statusText(payload.state || payload.status || 'CREATED'))}). ${escapeHtml(t('author.loadingPreflight'))}`, 'ok');
+    await showGraphPreflight(createdId);
     await refresh();
   } catch (error) {
     setGraphStatus(`Create request failed: ${error.message}`, 'error');
@@ -461,46 +1396,50 @@ async function createSingleTask(event) {
   };
   const id = elements['author-task-id'].value.trim();
   if (id) params.id = id;
+  const statusNode = elements['author-task-status'];
   if (!params.title) {
-    elements['author-task-status'].textContent = 'Task title is required.';
-    elements['author-task-status'].className = 'author-status error';
+    statusNode.textContent = t('composer.titleRequired');
+    statusNode.className = 'author-status error';
     return;
   }
-  elements['author-task-status'].textContent = 'Creating Task…';
+  statusNode.textContent = t('composer.creating');
   try {
     const { status, payload } = await postAction('taskCreate', params);
     if (status !== 200 || payload?.ok !== true) {
       const error = payload?.error || {};
-      elements['author-task-status'].textContent = `Create failed: ${error.code || `HTTP ${status}`} — ${error.message || ''}`;
-      elements['author-task-status'].className = 'author-status error';
+      statusNode.textContent = t('composer.failed', { message: `${error.code || `HTTP ${status}`} — ${error.message || ''}` });
+      statusNode.className = 'author-status error';
       return;
     }
-    elements['author-task-status'].textContent = `Created ${payload.task?.id || payload.id || params.title}.`;
-    elements['author-task-status'].className = 'author-status ok';
+    const taskId = payload.task?.id || payload.id;
+    statusNode.textContent = t('composer.created', { title: params.title, id: taskId || '' });
+    statusNode.className = 'author-status ok';
     elements['author-task-id'].value = '';
     elements['author-task-title'].value = '';
+    elements['author-task-spec'].value = '';
     await refresh();
+    if (taskId) selectTask(taskId);
   } catch (error) {
-    elements['author-task-status'].textContent = `Create request failed: ${error.message}`;
-    elements['author-task-status'].className = 'author-status error';
+    statusNode.textContent = t('composer.failed', { message: error.message });
+    statusNode.className = 'author-status error';
   }
 }
 
 async function discoverAgents() {
-  setAgentStatus('Discovering local coding CLIs…');
+  setAgentStatus(t('agents.discovering'));
   try {
     const { status, payload } = await postAction('setupDiscover', {});
     if (status !== 200 || payload?.ok !== true) {
       const code = payload?.error?.code || `HTTP ${status}`;
-      elements['agents-discovery'].innerHTML = `<div class="empty-state error-state">Discovery failed (${escapeHtml(code)}): ${escapeHtml(payload?.error?.message || 'unknown error')}</div>`;
-      setAgentStatus('Discovery failed.', 'error');
+      elements['agents-discovery'].innerHTML = `<div class="empty-state error-state">${escapeHtml(t('agents.discoveryFailed', { code, message: payload?.error?.message || 'unknown error' }))}</div>`;
+      setAgentStatus(t('generic.failed'), 'error');
       return;
     }
     state.discovery = payload;
     renderAgentsDiscovery(payload);
-    setAgentStatus('Discovery complete. Configure a command below or pick “Configure this command”.', 'ok');
+    setAgentStatus(t('agents.discoveryOk'), 'ok');
   } catch (error) {
-    setAgentStatus(`Discovery request failed: ${error.message}`, 'error');
+    setAgentStatus(`${t('agents.discovering')} ${t('generic.failed')}: ${error.message}`, 'error');
   }
 }
 
@@ -513,24 +1452,37 @@ async function applyAgentConfigure(event) {
     role: elements['cfg-role'].value,
   };
   if (!params.agent || !params.command) {
-    setAgentStatus('Agent ID and executable command are required.', 'error');
+    setAgentStatus(t('agents.required'), 'error');
     return;
   }
-  setAgentStatus('Applying configuration…');
+  setAgentStatus(t('agents.configuring'));
   elements['apply-agent'].disabled = true;
   try {
     const { status, payload } = await postAction('setupConfigure', params);
     if (status !== 200 || payload?.ok !== true) {
       const error = payload?.error || {};
-      setAgentStatus(`Configuration failed: ${error.code || `HTTP ${status}`} — ${error.message || 'unknown error'}${error.details ? ` (${error.details})` : ''}`, 'error');
+      setAgentStatus(t('agents.configFailed', { message: `${error.code || `HTTP ${status}`} — ${error.message || 'unknown error'}${error.details ? ` (${error.details})` : ''}` }), 'error');
       return;
     }
     const configured = payload.agent || {};
-    setAgentStatus(`Configured ${configured.id} (${configured.adapter}) → ${configured.command} [${configured.commandSource}] · workflow ${Object.keys(payload.workflow || {}).join(', ')}`, 'ok');
+    setAgentStatus(t('agents.configOk', {
+      id: configured.id,
+      adapter: configured.adapter,
+      command: configured.command,
+      source: configured.commandSource,
+      roles: Object.keys(payload.workflow || {}).join(', '),
+    }), 'ok');
+    toast(t('agents.configOk', {
+      id: configured.id,
+      adapter: configured.adapter,
+      command: configured.command,
+      source: configured.commandSource,
+      roles: Object.keys(payload.workflow || {}).join(', '),
+    }), 'ok');
     await discoverAgents();
     await refresh();
   } catch (error) {
-    setAgentStatus(`Configuration request failed: ${error.message}`, 'error');
+    setAgentStatus(`${t('agents.configFailed', { message: error.message })}`, 'error');
   } finally {
     elements['apply-agent'].disabled = false;
   }
@@ -544,12 +1496,12 @@ function renderAgentFlow() {
   const roles = ['planner', 'implementer', 'reviewer'];
   elements['agent-flow'].innerHTML = roles.map((role, index) => {
     const configured = state.agents.find(agent => agent.roles?.includes(role));
-    const agent = configured || { id: 'unassigned', status: 'UNKNOWN', adapter: '—', roles: [] };
+    const agent = configured || { id: t('roles.unassigned'), status: 'UNKNOWN', adapter: '—', roles: [] };
     return `
       <div class="flow-node">
         <span class="flow-role">${escapeHtml(role)}</span>
         <strong>${escapeHtml(agent.id)}</strong>
-        <span class="status-line"><span class="state-dot ${statusClass(agent.status)}"></span>${escapeHtml(statusLabel(agent.status))}</span>
+        <span class="status-line"><span class="state-dot ${statusClass(agent.status)}"></span>${escapeHtml(statusText(agent.status))}</span>
         <span class="adapter">${escapeHtml(agent.adapter)}</span>
       </div>
       ${index < roles.length - 1 ? '<span class="flow-arrow" aria-hidden="true">→</span>' : ''}
@@ -557,55 +1509,61 @@ function renderAgentFlow() {
   }).join('');
 }
 
+/* ------------------------------------------------------------------ */
+/* Sessions (Sessions view)                                           */
+/* ------------------------------------------------------------------ */
 function renderSessions() {
   elements['session-count'].textContent = state.sessions.length;
   if (state.sessions.length === 0) {
-    elements.sessions.innerHTML = '<div class="empty-state">No Execution Sessions recorded.</div>';
+    elements.sessions.innerHTML = `<div class="empty-state">${escapeHtml(t('empty.sessions'))}</div>`;
     return;
   }
   elements.sessions.innerHTML = state.sessions.map(session => `
-    <article class="session-card">
+    <article class="session-card" data-session="${escapeHtml(session.sessionId)}">
       <div class="session-header">
         <div>
-          <span class="eyebrow">${escapeHtml(session.agent || 'agent')}</span>
+          <span class="eyebrow">${escapeHtml(session.agent || t('chat.runtime'))}</span>
           <h3>${escapeHtml(shortId(session.sessionId))}</h3>
         </div>
-        <span class="status-pill ${statusClass(session.status)}">${escapeHtml(statusLabel(session.status))}</span>
+        <span class="status-pill ${statusClass(session.status)}">${escapeHtml(statusText(session.status))}</span>
       </div>
-      <div class="session-meta"><span>Created ${formatDate(session.createdAt)}</span><span>Last activity ${formatDate(session.lastActivity)}</span></div>
-      <pre class="session-output">${escapeHtml(session.recentOutput || 'No recent output available.')}</pre>
-      ${session.taskIds?.length ? `<div class="session-tasks">Tasks: ${session.taskIds.map(escapeHtml).join(', ')}</div>` : ''}
+      <div class="session-meta"><span>${escapeHtml(t('msg.created', { time: formatDate(session.createdAt) }))}</span><span>${escapeHtml(t('msg.lastActivity', { time: formatDate(session.lastActivity) }))}</span></div>
+      <pre class="session-output">${escapeHtml(session.recentOutput || t('msg.noOutput'))}</pre>
+      ${session.taskIds?.length ? `<div class="session-tasks">${escapeHtml(t('session.tasks', { tasks: session.taskIds.join(', ') }))}</div>` : ''}
       ${['starting', 'running', 'idle', 'busy'].includes(session.status) ? `
       <div class="session-controls">
         <form class="session-input-form" data-session="${escapeHtml(session.sessionId)}">
-          <input class="session-input-text" maxlength="4096" placeholder="Bounded input to this owned Session…">
-          <button class="button" type="submit">Send input</button>
+          <input class="session-input-text" maxlength="4096" placeholder="${escapeHtml(t('session.inputPh'))}">
+          <button class="button" type="submit">${escapeHtml(t('session.send'))}</button>
         </form>
-        <button class="button ghost session-close-btn" type="button" data-session="${escapeHtml(session.sessionId)}">Close Session</button>
+        <button class="button ghost session-close-btn" type="button" data-session="${escapeHtml(session.sessionId)}">${escapeHtml(t('session.close'))}</button>
       </div>` : ''}
       <span class="session-control-status" data-session="${escapeHtml(session.sessionId)}" aria-live="polite"></span>
       <div class="session-history">
-        <span class="history-label">${session.historySource === 'recorded' ? 'Recorded Events' : 'Derived / Legacy History'}</span>
-        ${(session.events || []).slice(-8).map(event => `<div><code>${event.sequence ? `#${escapeHtml(event.sequence)}` : '—'}</code><strong>${escapeHtml(event.event)}</strong><time>${formatDate(event.timestamp)}</time></div>`).join('')}
+        <span class="history-label">${session.historySource === 'recorded' ? escapeHtml(t('session.recorded')) : escapeHtml(t('session.derived'))}</span>
+        ${(session.events || []).slice(-8).map(event => `<div><code>${event.sequence ? `#${escapeHtml(event.sequence)}` : '—'}</code><strong>${escapeHtml(eventText(event.event))}</strong><time>${escapeHtml(formatDate(event.timestamp))}</time></div>`).join('')}
       </div>
     </article>
   `).join('');
 }
 
+/* ------------------------------------------------------------------ */
+/* Events (Activity view)                                             */
+/* ------------------------------------------------------------------ */
 function renderEvents() {
   if (state.events.length === 0) {
-    elements.events.innerHTML = '<div class="empty-state">No Runtime events found.</div>';
+    elements.events.innerHTML = `<div class="empty-state">${escapeHtml(t('empty.events'))}</div>`;
     return;
   }
   elements.events.innerHTML = state.events.map(event => `
     <article class="event-row">
-      <time>${event.sequence ? `#${escapeHtml(event.sequence)} · ` : ''}${formatDate(event.timestamp)}</time>
+      <time>${event.sequence ? `#${escapeHtml(event.sequence)} · ` : ''}${escapeHtml(formatDate(event.timestamp))}</time>
       <span class="event-marker ${statusClass(event.event)}"></span>
       <div class="event-body">
-        <div class="event-title"><strong>${escapeHtml(event.event)}</strong><span>${escapeHtml([event.agent || event.from || 'runtime', event.sessionId ? shortId(event.sessionId) : null].filter(Boolean).join(' · '))}</span></div>
+        <div class="event-title"><strong>${escapeHtml(eventText(event.event))}</strong><span>${escapeHtml([event.agent || event.from || t('chat.runtime'), event.sessionId ? shortId(event.sessionId) : null].filter(Boolean).join(' · '))}</span></div>
         <div class="event-details">${escapeHtml(event.details || '—')}</div>
         ${event.taskId ? `<button class="event-task" data-task-id="${escapeHtml(event.taskId)}" type="button">${escapeHtml(event.taskId)}</button>` : ''}
-        <span class="history-label">${event.recorded ? 'Recorded Event' : 'Derived / Legacy History'}</span>
+        <span class="history-label">${event.recorded ? escapeHtml(t('msg.recordedEvent')) : escapeHtml(t('msg.legacyHistory'))}</span>
       </div>
     </article>
   `).join('');
@@ -614,17 +1572,43 @@ function renderEvents() {
   });
 }
 
+/* ------------------------------------------------------------------ */
+/* Tasks view grid                                                    */
+/* ------------------------------------------------------------------ */
+function renderTasks() {
+  elements['task-count'].textContent = state.tasks.length;
+  if (state.tasks.length === 0) {
+    elements.tasks.innerHTML = `<div class="empty-state">${escapeHtml(t('empty.tasks'))}</div>`;
+    return;
+  }
+  elements.tasks.innerHTML = state.tasks.map(task => `
+    <button class="task-card ${task.graph ? 'graph-card' : ''} ${state.selectedTask === task.id ? 'selected' : ''}" data-task-id="${escapeHtml(task.id)}" type="button">
+      <span class="task-card-top"><span class="task-id">${escapeHtml(shortId(task.id))}</span><span class="round">${task.graph ? 'GRAPH' : escapeHtml(t('tasks.cardRound', { round: task.round }))}</span></span>
+      <strong>${escapeHtml(task.title)}</strong>
+      <span class="status-pill ${statusClass(task.status)}">${escapeHtml(statusText(task.status))}</span>
+      ${task.graph ? `<span class="graph-card-meta">${escapeHtml(t('msg.graphSubtask', { n: task.subtaskCount }))} · ${escapeHtml(t('msg.concurrency', { n: task.maxConcurrency }))}</span>` : ''}
+      <span class="task-updated">${escapeHtml(t('msg.updated', { time: formatDate(task.updatedAt) }))}</span>
+    </button>
+  `).join('');
+  elements.tasks.querySelectorAll('[data-task-id]').forEach(button => {
+    button.addEventListener('click', () => selectTask(button.dataset.taskId));
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/* Task detail renderers (used by the detail drawer)                  */
+/* ------------------------------------------------------------------ */
 function renderTimeline(timeline = []) {
   if (timeline.length === 0) {
-    elements.timeline.innerHTML = '<div class="empty-state">No Task events recorded yet.</div>';
+    elements.timeline.innerHTML = `<div class="empty-state">${escapeHtml(t('empty.detailTimeline'))}</div>`;
     return;
   }
   elements.timeline.innerHTML = timeline.map((event, index) => `
     <div class="timeline-item ${event.status ? 'has-status' : ''}">
       <div class="timeline-rail"><span class="timeline-dot ${event.status ? statusClass(event.status) : ''}"></span>${index < timeline.length - 1 ? '<span class="timeline-line"></span>' : ''}</div>
       <div class="timeline-content">
-        <div class="timeline-title"><strong>${event.sequence ? `#${escapeHtml(event.sequence)} ` : ''}${escapeHtml(event.status ? statusLabel(event.status) : event.event)}</strong><time>${formatDate(event.timestamp)}</time></div>
-        <div class="timeline-meta">${escapeHtml(event.agent || 'runtime')} · ${event.recorded ? 'Recorded Event' : 'Derived / Legacy History'}${event.sessionId ? ` · ${escapeHtml(shortId(event.sessionId))}` : ''}</div>
+        <div class="timeline-title"><strong>${event.sequence ? `#${escapeHtml(event.sequence)} ` : ''}${escapeHtml(event.status ? statusText(event.status) : eventText(event.event))}</strong><time>${escapeHtml(formatDate(event.timestamp))}</time></div>
+        <div class="timeline-meta">${escapeHtml(event.agent || t('chat.runtime'))} · ${event.recorded ? escapeHtml(t('msg.recordedEvent')) : escapeHtml(t('msg.legacyHistory'))}${event.sessionId ? ` · ${escapeHtml(shortId(event.sessionId))}` : ''}</div>
         ${event.details ? `<p>${escapeHtml(event.details)}</p>` : ''}
       </div>
     </div>
@@ -638,7 +1622,7 @@ function compactJson(value) {
 function factBlock(label, value) {
   if (value === null || value === undefined || value === '' || (Array.isArray(value) && value.length === 0)) return '';
   const rendered = typeof value === 'object' ? `<pre>${compactJson(value)}</pre>` : `<code>${escapeHtml(value)}</code>`;
-  return `<div class="graph-fact"><span>${escapeHtml(label)}</span>${rendered}</div>`;
+  return `<div class="graph-fact"><span>${escapeHtml(labelText(label))}</span>${rendered}</div>`;
 }
 
 const GRAPH_MAP_MAX_NODES = 120;
@@ -651,7 +1635,7 @@ const GRAPH_MAP_PAD = 12;
 
 function renderGraphLegend() {
   elements['graph-legend'].innerHTML = GRAPH_MAP_STATES
-    .map(state => `<span class="legend-item"><i class="legend-dot ${statusClass(state)}"></i>${escapeHtml(statusLabel(state))}</span>`)
+    .map(state => `<span class="legend-item"><i class="legend-dot ${statusClass(state)}"></i>${escapeHtml(statusText(state))}</span>`)
     .join('');
 }
 
@@ -681,12 +1665,12 @@ function renderGraphNodeDetail(detail, subtaskId) {
   const agent = subtask.agent || {};
   const blocks = [
     `<div class="graph-node-detail-heading"><span class="eyebrow">${escapeHtml(subtask.id)}</span>
-       <span class="status-pill ${statusClass(subtask.state)}">${escapeHtml(statusLabel(subtask.state))}</span>
-       <button class="button ghost graph-node-close" type="button" aria-label="Close subtask detail">Close</button></div>`,
+       <span class="status-pill ${statusClass(subtask.state)}">${escapeHtml(statusText(subtask.state))}</span>
+       <button class="button ghost graph-node-close" type="button" aria-label="Close subtask detail">${escapeHtml(t('drawer.close'))}</button></div>`,
     `<p class="graph-node-detail-title">${escapeHtml(subtask.title || subtask.id)}</p>`,
     factBlock('Specification', subtask.spec),
-    `<div class="graph-dependencies">Depends on: ${subtask.dependsOn?.length ? subtask.dependsOn.map(item => `<code>${escapeHtml(item)}</code>`).join(' ') : '<span>none</span>'}</div>`,
-    `<div class="graph-node-meta"><span>Agent <strong>${escapeHtml(subtask.implementer || '—')}</strong></span><span>Adapter <strong>${escapeHtml(agent.adapter || '—')}</strong></span><span>Registered <strong>${agent.registered === true ? 'yes' : 'no'}</strong></span><span>Session <code>${escapeHtml(shortId(subtask.sessionId) || '—')}</code></span></div>`,
+    `<div class="graph-dependencies">${escapeHtml(t('lb.Depends on'))}: ${subtask.dependsOn?.length ? subtask.dependsOn.map(item => `<code>${escapeHtml(item)}</code>`).join(' ') : `<span>${escapeHtml(t('empty.dependencies'))}</span>`}</div>`,
+    `<div class="graph-node-meta"><span>${escapeHtml(t('msg.agent'))} <strong>${escapeHtml(subtask.implementer || '—')}</strong></span><span>Adapter <strong>${escapeHtml(agent.adapter || '—')}</strong></span><span>Registered <strong>${agent.registered === true ? 'yes' : 'no'}</strong></span><span>${escapeHtml(t('msg.session'))} <code>${escapeHtml(shortId(subtask.sessionId) || '—')}</code></span></div>`,
     factBlock('Executable', subtask.executable),
     factBlock('Worktree / branch / commit', { ...(subtask.worktree || {}), implementationCommit: subtask.implementationCommit }),
     factBlock('Evidence', subtask.evidence),
@@ -707,7 +1691,7 @@ function renderGraphMap(detail) {
   const subtasks = Array.isArray(detail?.subtasks) ? detail.subtasks : [];
   elements['graph-map-note'].textContent = '';
   if (!subtasks.length) {
-    elements['graph-map'].innerHTML = '<div class="empty-state error-state">Task Graph record has no readable subtasks.</div>';
+    elements['graph-map'].innerHTML = `<div class="empty-state error-state">${escapeHtml(t('empty.graphNoReadable'))}</div>`;
     elements['graph-node-detail'].innerHTML = '';
     return;
   }
@@ -715,7 +1699,7 @@ function renderGraphMap(detail) {
   const truncated = subtasks.length > GRAPH_MAP_MAX_NODES;
   const visible = truncated ? subtasks.slice(0, GRAPH_MAP_MAX_NODES) : subtasks;
   if (truncated) {
-    elements['graph-map-note'].textContent = `Large graph: rendering the first ${GRAPH_MAP_MAX_NODES} of ${subtasks.length} subtasks in deterministic order; the complete bounded topology remains below.`;
+    elements['graph-map-note'].textContent = t('graph.largeGraph', { max: GRAPH_MAP_MAX_NODES, total: subtasks.length });
   }
 
   const maxLevel = Math.max(0, ...visible.map(item => levels.get(item.id) || 0));
@@ -736,12 +1720,11 @@ function renderGraphMap(detail) {
     const y = GRAPH_MAP_PAD + row * (GRAPH_MAP_NODE_H + GRAPH_MAP_GAP_Y);
     nodeRect.set(item.id, { x, y });
     const selected = state.selectedSubtask === item.id;
-    const edgeLabels = [];
     return `<button type="button" class="graph-map-node ${statusClass(item.state)}${selected ? ' selected' : ''}"
       data-subtask="${escapeHtml(item.id)}" style="left:${x}px;top:${y}px;width:${GRAPH_MAP_NODE_W}px;height:${GRAPH_MAP_NODE_H}px"
-      aria-pressed="${selected}" aria-label="Subtask ${escapeHtml(item.id)}: ${escapeHtml(item.title || item.id)} (${escapeHtml(statusLabel(item.state))})">
+      aria-pressed="${selected}" aria-label="${escapeHtml(t('graph.nodeLabel', { id: item.id, title: item.title || item.id, state: statusText(item.state) }))}">
       <span class="graph-map-node-title">${escapeHtml(item.title || item.id)}</span>
-      <span class="graph-map-node-meta"><code>${escapeHtml(item.id)}</code><i class="state-dot ${statusClass(item.state)}"></i>${escapeHtml(statusLabel(item.state))}</span>
+      <span class="graph-map-node-meta"><code>${escapeHtml(item.id)}</code><i class="state-dot ${statusClass(item.state)}"></i>${escapeHtml(statusText(item.state))}</span>
     </button>`;
   }).join('');
 
@@ -772,7 +1755,7 @@ function renderGraphMap(detail) {
   if (state.selectedSubtask && subtasks.some(item => item.id === state.selectedSubtask)) {
     renderGraphNodeDetail(detail, state.selectedSubtask);
   } else {
-    elements['graph-node-detail'].innerHTML = '<div class="empty-state">Select a map node to inspect its bounded Runtime evidence.</div>';
+    elements['graph-node-detail'].innerHTML = `<div class="empty-state">${escapeHtml(t('empty.selectNode'))}</div>`;
   }
   elements['graph-map-region'].hidden = false;
 }
@@ -784,22 +1767,22 @@ function closeGraphMap() {
 
 function recoveryControls(detail) {
   const graph = Boolean(detail?.graph);
-  const state = detail?.state || detail?.status;
+  const detailState = detail?.state || detail?.status;
   const buttons = [];
   const add = (action, label, taskId, extra = '') => buttons.push(
     `<button class="button ghost" type="button" data-run-action="${action}" data-label="${escapeHtml(label)}" data-params="${escapeHtml(JSON.stringify({ taskId: taskId || detail.id }))}">${escapeHtml(label)}</button>${extra}`);
   if (!graph) {
-    if (['IMPLEMENTING', 'WAITING_IMPLEMENTER'].includes(state)) add('taskStop', 'Stop Task', detail.id);
-    if (['ERROR', 'STOPPED'].includes(state)) add('taskResume', 'Resume Task', detail.id);
+    if (['IMPLEMENTING', 'WAITING_IMPLEMENTER'].includes(detailState)) add('taskStop', t('execution.stopTask'), detail.id);
+    if (['ERROR', 'STOPPED'].includes(detailState)) add('taskResume', t('execution.resumeTask'), detail.id);
   } else {
-    const note = `<span class="agent-muted">state ${escapeHtml(state || 'unknown')}</span>`;
-    if (state === 'RUNNING') add('taskGraphStop', 'Stop graph', detail.id, note);
-    if (['FAILED', 'RECOVERING'].includes(state)) add('taskGraphRecover', 'Recover graph', detail.id, note);
-    if (['FAILED', 'STOPPED', 'BLOCKED', 'RECOVERING'].includes(state)) add('taskGraphResume', 'Resume graph', detail.id, note);
-    if (['STOPPED', 'FAILED', 'SUCCEEDED', 'APPROVED'].includes(state)) add('taskGraphCleanup', 'Clean up worktrees', detail.id, note);
-    if (!buttons.length) return `<span class="agent-muted">${escapeHtml(state || '')} — no automatic recovery action; review the Runtime facts and act explicitly.</span>`;
+    const note = `<span class="agent-muted">${escapeHtml(t('review.state', { state: detailState || 'unknown' }))}</span>`;
+    if (detailState === 'RUNNING') add('taskGraphStop', t('execution.stopGraph'), detail.id, note);
+    if (['FAILED', 'RECOVERING'].includes(detailState)) add('taskGraphRecover', t('execution.recoverGraph'), detail.id, note);
+    if (['FAILED', 'STOPPED', 'BLOCKED', 'RECOVERING'].includes(detailState)) add('taskGraphResume', t('execution.resumeGraph'), detail.id, note);
+    if (['STOPPED', 'FAILED', 'SUCCEEDED', 'APPROVED'].includes(detailState)) add('taskGraphCleanup', t('execution.cleanup'), detail.id, note);
+    if (!buttons.length) return `<span class="agent-muted">${escapeHtml(t('execution.noRecovery', { state: detailState || '' }))}</span>`;
   }
-  return buttons.length ? `<span class="recovery-sep">Recovery & ownership</span>${buttons.join(' ')}` : '';
+  return buttons.length ? `<span class="recovery-sep">${escapeHtml(t('execution.recoverySep'))}</span>${buttons.join(' ')}` : '';
 }
 
 function setSessionControlStatus(sessionId, message, kind = 'info') {
@@ -815,32 +1798,32 @@ async function submitSessionInput(form) {
   const text = input.value.trim();
   if (!text) return;
   input.value = '';
-  setSessionControlStatus(sessionId, 'Sending bounded input…');
+  setSessionControlStatus(sessionId, t('session.sending'));
   try {
     const { status, payload } = await postAction('sessionWrite', { sessionId, input: text });
     if (status !== 200 || payload?.ok !== true) {
-      setSessionControlStatus(sessionId, `Input rejected: ${payload?.error?.code || `HTTP ${status}`} — ${payload?.error?.message || ''}`, 'error');
+      setSessionControlStatus(sessionId, t('session.rejected', { message: `${payload?.error?.code || `HTTP ${status}`} — ${payload?.error?.message || ''}` }), 'error');
       return;
     }
-    setSessionControlStatus(sessionId, 'Input accepted.', 'ok');
+    setSessionControlStatus(sessionId, t('session.sent'), 'ok');
     await refresh();
   } catch (error) {
-    setSessionControlStatus(sessionId, `Input failed: ${error.message}`, 'error');
+    setSessionControlStatus(sessionId, t('session.rejected', { message: error.message }), 'error');
   }
 }
 
 async function closeOwnedSession(sessionId) {
-  setSessionControlStatus(sessionId, 'Closing Session…');
+  setSessionControlStatus(sessionId, t('session.closing'));
   try {
     const { status, payload } = await postAction('sessionClose', { sessionId });
     if (status !== 200 || payload?.ok !== true) {
-      setSessionControlStatus(sessionId, `Close rejected: ${payload?.error?.code || `HTTP ${status}`} — ${payload?.error?.message || ''}`, 'error');
+      setSessionControlStatus(sessionId, t('session.closeRejected', { message: `${payload?.error?.code || `HTTP ${status}`} — ${payload?.error?.message || ''}` }), 'error');
       return;
     }
-    setSessionControlStatus(sessionId, 'Session closed.', 'ok');
+    setSessionControlStatus(sessionId, t('session.closed'), 'ok');
     await refresh();
   } catch (error) {
-    setSessionControlStatus(sessionId, `Close failed: ${error.message}`, 'error');
+    setSessionControlStatus(sessionId, t('session.closeRejected', { message: error.message }), 'error');
   }
 }
 
@@ -859,6 +1842,7 @@ function bindSessionActions(container) {
 
 function setExecutionStatus(message, kind = 'info') {
   const element = elements['execution-status'];
+  if (!element) return;
   element.textContent = message;
   element.className = `author-status ${kind}`;
 }
@@ -868,36 +1852,37 @@ function renderExecutionResult(label, payload) {
   region.hidden = false;
   if (!payload || payload.ok !== true) {
     const error = payload?.error || {};
-    region.innerHTML = `<div class="empty-state error-state"><strong>${escapeHtml(label)} failed</strong> — ${escapeHtml(error.code || 'ACTION_FAILED')}: ${escapeHtml(error.message || 'Request failed.')}${error.details ? `<div class="execution-detail">${escapeHtml(error.details)}</div>` : ''}</div>`;
-    setExecutionStatus(`${label} failed (${error.code || 'error'}). Refreshing authoritative Runtime state…`, 'error');
+    region.innerHTML = `<div class="empty-state error-state"><strong>${escapeHtml(t('execution.failed', { label }))}</strong> — ${escapeHtml(error.code || 'ACTION_FAILED')}: ${escapeHtml(error.message || t('generic.error'))}${error.details ? `<div class="execution-detail">${escapeHtml(error.details)}</div>` : ''}</div>`;
+    setExecutionStatus(t('execution.failed', { label }) + ' (' + escapeHtml(error.code || 'error') + '). ' + t('msg.actionWillRefresh'), 'error');
     return;
   }
   const pick = keys => keys.map(key => payload[key]).find(value => value !== undefined && value !== null && value !== '');
   const facts = [];
-  const show = (labelText, value) => {
-    if (value !== undefined && value !== null && value !== '') facts.push(`<div class="execution-fact"><span>${escapeHtml(labelText)}</span><code>${escapeHtml(Array.isArray(value) ? value.join(', ') : value)}</code></div>`);
+  const show = (labelTextKey, value) => {
+    if (value !== undefined && value !== null && value !== '') facts.push(`<div class="execution-fact"><span>${escapeHtml(t(labelTextKey))}</span><code>${escapeHtml(Array.isArray(value) ? value.join(', ') : value)}</code></div>`);
   };
-  show('Task / parent', pick(['taskId', 'parentTaskId', 'id']));
-  show('Subtasks', payload.subtaskIds || payload.subtasks?.length);
-  show('State', pick(['state', 'status']));
-  show('Session', pick(['sessionId', 'sessions']) && !Array.isArray(payload.sessions) ? pick(['sessionId']) : Array.isArray(payload.sessions) ? payload.sessions.length : undefined);
-  show('Commit', pick(['implementationCommit', 'commit', 'aggregateCommit']));
-  show('Waves executed', payload.wavesExecuted || payload.waveCount);
-  show('Stop reason', payload.stopReason);
-  show('Agent', pick(['agent', 'implementer']));
-  region.innerHTML = `<div class="execution-ok"><strong>${escapeHtml(label)} completed</strong><div class="execution-facts">${facts.join('') || '<div class="agent-muted">(no identity facts returned)</div>'}</div>${payload.error ? `<div class="execution-detail">${escapeHtml(payload.error.message || '')}</div>` : ''}</div>`;
-  setExecutionStatus(`${label} completed. Refreshing views…`, 'ok');
+  show('execution.factTask', pick(['taskId', 'parentTaskId', 'id']));
+  show('execution.factSubtasks', payload.subtaskIds || payload.subtasks?.length);
+  show('execution.factState', pick(['state', 'status']));
+  const sessionValue = pick(['sessionId']) || (Array.isArray(payload.sessions) ? payload.sessions.length : undefined);
+  show('execution.factSession', sessionValue);
+  show('execution.factCommit', pick(['implementationCommit', 'commit', 'aggregateCommit']));
+  show('execution.factWaves', payload.wavesExecuted || payload.waveCount);
+  show('execution.factStop', payload.stopReason);
+  show('execution.factAgent', pick(['agent', 'implementer']));
+  region.innerHTML = `<div class="execution-ok"><strong>${escapeHtml(t('execution.completed', { label }))}</strong><div class="execution-facts">${facts.join('') || `<div class="agent-muted">${escapeHtml(t('execution.noSessionFacts'))}</div>`}</div>${payload.error ? `<div class="execution-detail">${escapeHtml(payload.error.message || '')}</div>` : ''}</div>`;
+  setExecutionStatus(t('execution.completed', { label }) + '. ' + t('msg.actionWillRefresh'), 'ok');
 }
 
 async function runExecutionAction(actionName, params, label) {
-  setExecutionStatus(`${label}: executing…`);
+  setExecutionStatus(t('execution.executing', { label }));
   const region = elements['execution-result'];
   region.hidden = true;
   try {
     const { status, payload } = await postAction(actionName, params);
-    renderExecutionResult(label, status === 200 ? payload : { ok: false, error: { code: `HTTP ${status}`, message: payload?.error?.message || payload?.error || 'Request failed.' } });
+    renderExecutionResult(label, status === 200 ? payload : { ok: false, error: { code: `HTTP ${status}`, message: payload?.error?.message || payload?.error || t('generic.error') } });
   } catch (error) {
-    setExecutionStatus(`${label} request failed: ${error.message}`, 'error');
+    setExecutionStatus(t('execution.requestFailed', { label, message: error.message }), 'error');
   }
   await refresh();
 }
@@ -921,6 +1906,9 @@ function bindExecutionControls(container, detail) {
       button.disabled = true;
       try {
         await runExecutionAction(button.dataset.runAction, JSON.parse(button.dataset.params || '{}'), button.dataset.label || 'Execution');
+        recordLocalAction(state.selectedTask, button.dataset.label || button.dataset.runAction, 'ok');
+      } catch (error) {
+        recordLocalAction(state.selectedTask, button.dataset.runAction, 'error');
       } finally {
         if (confirm) confirm.checked = false;
         button.disabled = false;
@@ -939,36 +1927,37 @@ function renderExecution(detail) {
   elements['execution-result'].hidden = true;
   setExecutionStatus('');
   const graph = Boolean(detail.graph);
-  elements['execution-title'].textContent = graph ? `Execution · ${detail.title || detail.id}` : `Execution · ${detail.title || detail.id}`;
-  const confirmText = 'I understand: this explicitly launches an Agent process that may write to the repository; failures are never retried automatically and no merge, push, tag, publish, deploy, or release occurs.';
+  elements['execution-title'].textContent = graph
+    ? t('execution.titleGraph', { title: detail.title || detail.id })
+    : t('execution.titleTask', { title: detail.title || detail.id });
+  const confirmText = t('execution.confirm');
   const id = detail.id;
   let controls = '';
   if (!graph) {
     const dispatchable = ['CREATED', 'PLANNING', 'SPEC_READY', 'CHANGES_REQUESTED'].includes(detail.status);
     controls = `
       ${executionConfirmRow(confirmText)}
-      <button class="button" type="button" data-run-action="taskDispatch" data-label="Dispatch ${escapeHtml(id)}" data-params="${escapeHtml(JSON.stringify({ taskId: id }))}" ${dispatchable ? '' : 'disabled title="Current status prevents dispatch; the Runtime will still validate"'}>Dispatch task</button>
-      ${dispatchable ? '' : `<span class="agent-muted">status ${escapeHtml(detail.status)} — dispatch applies to created / planning / spec-ready / changes-requested Tasks with a specification.</span>`}`;
+      <button class="button" type="button" data-run-action="taskDispatch" data-label="${escapeHtml(t('execution.dispatch'))}" data-params="${escapeHtml(JSON.stringify({ taskId: id }))}" ${dispatchable ? '' : 'disabled title="Current status prevents dispatch; the Runtime will still validate"'}>${escapeHtml(t('execution.dispatch'))}</button>
+      ${dispatchable ? '' : `<span class="agent-muted">${escapeHtml(t('execution.notDispatchable', { status: detail.status || '' }))}</span>`}`;
   } else {
     controls = `
       ${executionConfirmRow(confirmText)}
-      <label class="execution-field">Session wait (ms, 0–10000)<input type="number" class="execution-session-wait" min="0" max="10000" value="2000"></label>
-      <button class="button" type="button" data-run-action="taskGraphRun" data-label="Run eligible wave of ${escapeHtml(id)}">Run eligible wave</button>
-      <label class="execution-field">maxWaves (1–32)<input type="number" class="execution-max-waves" min="1" max="32" value="1"></label>
-      <button class="button" type="button" data-run-action="taskGraphAdvance" data-label="Advance ${escapeHtml(id)}">Advance graph</button>`;
+      <label class="execution-field">${escapeHtml(t('execution.sessionWait'))}<input type="number" class="execution-session-wait" min="0" max="10000" value="2000"></label>
+      <button class="button" type="button" data-run-action="taskGraphRun" data-label="${escapeHtml(t('execution.runWave'))}">${escapeHtml(t('execution.runWave'))}</button>
+      <label class="execution-field">${escapeHtml(t('execution.maxWaves'))}<input type="number" class="execution-max-waves" min="1" max="32" value="1"></label>
+      <button class="button" type="button" data-run-action="taskGraphAdvance" data-label="${escapeHtml(t('execution.advance'))}">${escapeHtml(t('execution.advance'))}</button>`;
   }
   elements['execution-controls'].innerHTML = controls + recoveryControls(detail);
   const waitInput = elements['execution-controls'].querySelector('.execution-session-wait');
   const wavesInput = elements['execution-controls'].querySelector('.execution-max-waves');
-  if (waitInput) {
+  const setRunParams = () => {
     elements['execution-controls'].querySelectorAll('[data-run-action="taskGraphRun"]').forEach(button => {
-      button.dataset.params = JSON.stringify({ taskId: id, sessionWaitMs: Number(waitInput.value) || 0 });
+      button.dataset.params = JSON.stringify({ taskId: id, sessionWaitMs: Number(waitInput?.value) || 0 });
     });
-    waitInput.addEventListener('input', () => {
-      elements['execution-controls'].querySelectorAll('[data-run-action="taskGraphRun"]').forEach(button => {
-        button.dataset.params = JSON.stringify({ taskId: id, sessionWaitMs: Number(waitInput.value) || 0 });
-      });
-    });
+  };
+  if (waitInput) {
+    setRunParams();
+    waitInput.addEventListener('input', setRunParams);
   }
   if (wavesInput) {
     const updateAdvance = () => {
@@ -985,6 +1974,7 @@ function renderExecution(detail) {
 
 function setReviewStatus(message, kind = 'info') {
   const element = elements['review-status'];
+  if (!element) return;
   element.textContent = message;
   element.className = `author-status ${kind}`;
 }
@@ -999,7 +1989,7 @@ function reviewParams(detail) {
       evidence = JSON.parse(evidenceText);
       if (typeof evidence !== 'object' || evidence === null || Array.isArray(evidence)) throw new Error('object');
     } catch {
-      setReviewStatus('Review evidence must be valid JSON object text.', 'error');
+      setReviewStatus(t('review.evidenceInvalid'), 'error');
       return null;
     }
   }
@@ -1013,38 +2003,40 @@ async function submitReview(detail) {
   const params = reviewParams(detail);
   if (!params) return;
   if (!params.decision) {
-    setReviewStatus('Choose a review decision.', 'error');
+    setReviewStatus(t('review.chooseDecision'), 'error');
     return;
   }
   const action = Boolean(detail.graph) ? 'taskGraphReview' : 'taskReview';
   const label = Boolean(detail.graph) ? 'Graph review' : 'Task review';
-  setReviewStatus(`${label}: recording decision…`);
+  setReviewStatus(t('review.recording', { label }));
   try {
     const { status, payload } = await postAction(action, params);
     if (status !== 200 || payload?.ok !== true) {
       const error = payload?.error || {};
-      setReviewStatus(`${label} rejected: ${error.code || `HTTP ${status}`} — ${error.message || ''}${error.details ? ` (${error.details})` : ''}`, 'error');
+      setReviewStatus(t('review.rejected', { label, message: `${error.code || `HTTP ${status}`} — ${error.message || ''}${error.details ? ` (${error.details})` : ''}` }), 'error');
       return;
     }
-    setReviewStatus(`${label} recorded (${payload.review?.decision || payload.status || params.decision}). Durable after reload.`, 'ok');
+    const decision = payload.review?.decision || payload.status || params.decision;
+    setReviewStatus(t('review.recorded', { label, decision }), 'ok');
+    recordLocalAction(detail.id, `${label}: ${decision}`, 'ok');
     await refresh();
   } catch (error) {
-    setReviewStatus(`${label} request failed: ${error.message}`, 'error');
+    setReviewStatus(t('review.rejected', { label, message: error.message }), 'error');
   }
 }
 
 async function integrateGraph(detail) {
-  setReviewStatus('Integrating verified subtask commits into the Runtime-owned aggregate review worktree…');
+  setReviewStatus(t('review.integrating'));
   try {
     const { status, payload } = await postAction('taskGraphIntegrate', { taskId: detail.id });
     if (status !== 200 || payload?.ok !== true) {
       const error = payload?.error || {};
-      setReviewStatus(`Integration rejected: ${error.code || `HTTP ${status}`} — ${error.message || ''}${error.details ? ` (${error.details})` : ''}`, 'error');
+      setReviewStatus(t('review.integrationFailed', { message: `${error.code || `HTTP ${status}`} — ${error.message || ''}${error.details ? ` (${error.details})` : ''}` }), 'error');
       return;
     }
     const region = elements['review-result'];
     region.hidden = false;
-    region.innerHTML = `<div class="execution-ok"><strong>Integration complete</strong>
+    region.innerHTML = `<div class="execution-ok"><strong>${escapeHtml(t('review.integrationComplete'))}</strong>
       <div class="execution-facts">
         ${factBlock('Aggregate commit', payload.integration?.aggregateCommit || payload.aggregateCommit)}
         ${factBlock('Applied refs', payload.integration?.appliedCommits)}
@@ -1052,10 +2044,11 @@ async function integrateGraph(detail) {
         ${factBlock('Branch', payload.integration?.branch)}
         ${factBlock('Conflicts', payload.integration?.conflicts)}
       </div></div>`;
-    setReviewStatus('Integration recorded. Review the aggregate facts, then record a decision.', 'ok');
+    setReviewStatus(t('review.integrated'), 'ok');
+    recordLocalAction(detail.id, t('review.integrationComplete'), 'ok');
     await refresh();
   } catch (error) {
-    setReviewStatus(`Integration request failed: ${error.message}`, 'error');
+    setReviewStatus(t('review.integrationFailed', { message: error.message }), 'error');
   }
 }
 
@@ -1069,24 +2062,24 @@ function renderReview(detail) {
   elements['review-result'].hidden = true;
   setReviewStatus('');
   const graph = Boolean(detail.graph);
-  const state = detail.state || detail.status;
+  const detailState = detail.state || detail.status;
   const reviewable = graph
-    ? ['RUNNING', 'SUCCEEDED', 'APPROVED', 'REVIEW_APPROVED', 'CHANGES_REQUESTED'].includes(state)
-    : ['REVIEWING', 'CHANGES_REQUESTED'].includes(state);
+    ? ['RUNNING', 'SUCCEEDED', 'APPROVED', 'REVIEW_APPROVED', 'CHANGES_REQUESTED'].includes(detailState)
+    : ['REVIEWING', 'CHANGES_REQUESTED'].includes(detailState);
   const controls = [];
-  controls.push(`<label class="author-toggle review-confirm-row"><input type="checkbox" class="review-confirm"> I understand: integration/review targets Runtime-owned artifacts only; review approval is not release approval; no merge, push, tag, publish, deploy, or release happens here.</label>`);
+  controls.push(`<label class="author-toggle review-confirm-row"><input type="checkbox" class="review-confirm"> ${escapeHtml(t('review.confirm'))}</label>`);
   if (graph) {
-    controls.push(`<button class="button" type="button" id="review-integrate">Integrate verified subtasks</button>`);
+    controls.push(`<button class="button" type="button" id="review-integrate">${escapeHtml(t('review.integrate'))}</button>`);
   }
   controls.push(`<div class="review-form">
-    <label>Decision<select class="review-decision">
+    <label>${escapeHtml(t('review.decision'))}<select class="review-decision">
       <option value="REVIEW_APPROVED">REVIEW_APPROVED</option>
       <option value="CHANGES_REQUESTED">CHANGES_REQUESTED</option>
     </select></label>
-    <label>Feedback<textarea class="review-feedback" rows="3" maxlength="16384" placeholder="Bounded review feedback…"></textarea></label>
-    <label>Evidence (optional JSON object)<textarea class="review-evidence" rows="2" maxlength="65536" placeholder="{ &quot;tests&quot;: &quot;passed&quot; }"></textarea></label>
-    <button class="button" type="button" id="review-submit" ${reviewable ? '' : 'disabled title="Current state is not reviewable; review applies to reviewed/changes-requested Tasks or running/succeeded graphs"'}>Record review decision</button>
-    <span class="agent-muted">state ${escapeHtml(state || 'unknown')}</span>
+    <label>${escapeHtml(t('review.feedback'))}<textarea class="review-feedback" rows="3" maxlength="16384" placeholder="Bounded review feedback…"></textarea></label>
+    <label>${escapeHtml(t('review.evidence'))}<textarea class="review-evidence" rows="2" maxlength="65536" placeholder='{ "tests": "passed" }'></textarea></label>
+    <button class="button" type="button" id="review-submit" ${reviewable ? '' : 'disabled title="Current state is not reviewable; review applies to reviewed/changes-requested Tasks or running/succeeded graphs"'}>${escapeHtml(t('review.record'))}</button>
+    <span class="agent-muted">${escapeHtml(t('review.state', { state: detailState || 'unknown' }))}</span>
   </div>`);
   elements['review-controls'].innerHTML = controls.join('');
   const confirm = elements['review-controls'].querySelector('.review-confirm');
@@ -1126,13 +2119,13 @@ function renderGraphDetail(task) {
     <article class="graph-node">
       <div class="graph-node-heading">
         <div><span class="eyebrow">${escapeHtml(subtask.id)}</span><strong>${escapeHtml(subtask.title || subtask.id)}</strong></div>
-        <span class="status-pill ${statusClass(subtask.state)}">${escapeHtml(statusLabel(subtask.state))}</span>
+        <span class="status-pill ${statusClass(subtask.state)}">${escapeHtml(statusText(subtask.state))}</span>
       </div>
-      <div class="graph-dependencies">Depends on: ${subtask.dependsOn?.length ? subtask.dependsOn.map(item => `<code>${escapeHtml(item)}</code>`).join(' ') : '<span>none</span>'}</div>
+      <div class="graph-dependencies">${escapeHtml(t('lb.Depends on'))}: ${subtask.dependsOn?.length ? subtask.dependsOn.map(item => `<code>${escapeHtml(item)}</code>`).join(' ') : `<span>${escapeHtml(t('empty.dependencies'))}</span>`}</div>
       <div class="graph-node-meta">
-        <span>Agent <strong>${escapeHtml(subtask.implementer)}</strong></span>
+        <span>${escapeHtml(t('msg.agent'))} <strong>${escapeHtml(subtask.implementer)}</strong></span>
         <span>Adapter <strong>${escapeHtml(subtask.agent?.adapter || '—')}</strong></span>
-        <span>Session <code>${escapeHtml(shortId(subtask.sessionId) || '—')}</code></span>
+        <span>${escapeHtml(t('msg.session'))} <code>${escapeHtml(shortId(subtask.sessionId) || '—')}</code></span>
       </div>
       ${factBlock('Executable', subtask.executable)}
       ${factBlock('Worktree / branch / commit', { ...subtask.worktree, implementationCommit: subtask.implementationCommit })}
@@ -1141,11 +2134,11 @@ function renderGraphDetail(task) {
       ${factBlock('Recovery', subtask.recovery)}
       ${factBlock('Last error', subtask.lastError)}
     </article>
-  `).join('') || '<div class="empty-state">No persisted subtasks.</div>';
+  `).join('') || `<div class="empty-state">${escapeHtml(t('empty.subtasks'))}</div>`;
   const edgeList = dependencies.length
     ? dependencies.map(edge => `<code>${escapeHtml(edge.from)} → ${escapeHtml(edge.to)}</code>`).join(' ')
-    : '<span>none</span>';
-  elements['graph-topology'].insertAdjacentHTML('afterbegin', `<div class="graph-edge-list"><strong>Dependency edges</strong>${edgeList}</div>`);
+    : `<span>${escapeHtml(t('empty.dependencies'))}</span>`;
+  elements['graph-topology'].insertAdjacentHTML('afterbegin', `<div class="graph-edge-list"><strong>${escapeHtml(t('lb.Dependency edges'))}</strong>${edgeList}</div>`);
   elements['graph-frontier'].innerHTML = [
     factBlock('Max concurrency', task.maxConcurrency),
     factBlock('Current frontier', task.frontier),
@@ -1155,13 +2148,13 @@ function renderGraphDetail(task) {
     factBlock('Write-intent conflicts', task.conflicts),
     factBlock('Intent coverage', task.intentCoverage),
     factBlock('Recovery classifications', task.recovery),
-  ].join('') || '<div class="empty-state">No conflict or scope facts recorded.</div>';
+  ].join('') || `<div class="empty-state">${escapeHtml(t('msg.graphNoConflict'))}</div>`;
   elements['graph-integration'].innerHTML = [
     factBlock('Integration', task.integration),
     factBlock('Integration facts', task.integrationFacts),
     factBlock('Review', task.review),
     factBlock('Review history', task.reviewHistory),
-  ].join('') || '<div class="empty-state">Integration and review have not been recorded.</div>';
+  ].join('') || `<div class="empty-state">${escapeHtml(t('msg.graphNoIntegration'))}</div>`;
 }
 
 function renderTaskDetail(task) {
@@ -1174,10 +2167,10 @@ function renderTaskDetail(task) {
   elements['task-detail'].hidden = false;
   elements['detail-title'].textContent = task.title;
   elements['detail-summary'].innerHTML = `
-    <span class="status-pill ${statusClass(task.status)}">${escapeHtml(statusLabel(task.status))}</span>
-    <span>${task.graph ? 'Task Graph' : `Round ${escapeHtml(task.round)}`}</span>
+    <span class="status-pill ${statusClass(task.status)}">${escapeHtml(statusText(task.status))}</span>
+    <span>${task.graph ? escapeHtml(t('msg.graph')) : escapeHtml(t('msg.round', { round: task.round }))}</span>
     <span>${escapeHtml(task.id)}</span>
-    <span>Updated ${formatDate(task.updatedAt)}</span>
+    <span>${escapeHtml(t('msg.updated', { time: formatDate(task.updatedAt) }))}</span>
   `;
   renderExecution(task);
   renderReview(task);
@@ -1189,7 +2182,7 @@ function renderTaskDetail(task) {
       <div class="detail-agent-row">
         <span class="flow-role">${escapeHtml(item.role)}</span>
         <strong>${escapeHtml(item.agent)}</strong>
-        <span class="status-line"><span class="state-dot ${statusClass(agent.status)}"></span>${escapeHtml(statusLabel(agent.status))}</span>
+        <span class="status-line"><span class="state-dot ${statusClass(agent.status)}"></span>${escapeHtml(statusText(agent.status))}</span>
       </div>
       ${index < (task.agentFlow || []).length - 1 ? '<div class="detail-agent-arrow">↓</div>' : ''}
     `;
@@ -1197,39 +2190,367 @@ function renderTaskDetail(task) {
   const evidence = task.evidence || [];
   const reviews = task.reviewHistory || [];
   elements.evidence.innerHTML = `
-    <div class="evidence-row"><span>${task.graph ? 'Base commit' : 'Commit'}</span><code>${escapeHtml(task.graph ? (task.baseCommit || '—') : (task.implementationCommit || '—'))}</code></div>
-    <div class="evidence-row"><span>Evidence records</span><strong>${evidence.length}</strong></div>
+    <div class="evidence-row"><span>${escapeHtml(labelText(task.graph ? 'Base commit' : 'Commit'))}</span><code>${escapeHtml(task.graph ? (task.baseCommit || '—') : (task.implementationCommit || '—'))}</code></div>
+    <div class="evidence-row"><span>${escapeHtml(t('lb.Evidence records'))}</span><strong>${evidence.length}</strong></div>
     ${evidence.map(item => `<div class="evidence-block"><strong>${escapeHtml(item.type || 'Evidence')}</strong><p>${escapeHtml(item.details || item.relatedCommit || '—')}</p></div>`).join('')}
-    ${reviews.map(item => `<div class="review-block"><span class="status-pill ${statusClass(item.decision)}">${escapeHtml(statusLabel(item.decision))}</span><p>${escapeHtml(item.feedback || 'No feedback')}</p></div>`).join('')}
+    ${reviews.map(item => `<div class="review-block"><span class="status-pill ${statusClass(item.decision)}">${escapeHtml(statusText(item.decision))}</span><p>${escapeHtml(item.feedback || t('msg.noFeedback'))}</p></div>`).join('')}
     ${task.lastError ? `<div class="error-block"><strong>${escapeHtml(task.lastError.code || 'ERROR')}</strong><p>${escapeHtml(task.lastError.message || task.lastError.details || '')}</p></div>` : ''}
   `;
-  elements.spec.textContent = task.spec || 'No specification recorded.';
+  elements.spec.textContent = task.spec || t('empty.noSpec');
 }
 
+/* ------------------------------------------------------------------ */
+/* Chat area                                                          */
+/* ------------------------------------------------------------------ */
+function renderChatWelcome() {
+  const region = elements['chat-welcome'];
+  if (!region) return;
+  region.hidden = false;
+  const name = state.repository?.name || state.repository?.root || '';
+  region.innerHTML = `
+    <div class="welcome-card">
+      <p class="eyebrow">${escapeHtml(t('welcome.title'))}</p>
+      <h2>${escapeHtml(name ? `${name}` : t('welcome.title'))}</h2>
+      <p class="welcome-sub">${escapeHtml(t('welcome.subtitle'))}</p>
+      <div class="welcome-columns">
+        <div>
+          <h3>${escapeHtml(t('welcome.whatYouCan'))}</h3>
+          <ul>
+            <li>${escapeHtml(t('welcome.w1'))}</li>
+            <li>${escapeHtml(t('welcome.w2'))}</li>
+            <li>${escapeHtml(t('welcome.w3'))}</li>
+            <li>${escapeHtml(t('welcome.w4'))}</li>
+          </ul>
+        </div>
+        <div class="welcome-actions">
+          <button class="button primary-button" type="button" id="welcome-start">${escapeHtml(t('welcome.startTask'))}</button>
+          <button class="button ghost" type="button" id="welcome-agents">${escapeHtml(t('welcome.configAgents'))}</button>
+          <p class="welcome-hint">${escapeHtml(t('welcome.hint'))}</p>
+        </div>
+      </div>
+    </div>`;
+  region.querySelector('#welcome-start')?.addEventListener('click', () => {
+    switchView('chat');
+    elements['composer-input']?.focus();
+  });
+  region.querySelector('#welcome-agents')?.addEventListener('click', () => switchView('agents'));
+}
+
+function chatMessageCard(task, entry) {
+  // entry: {kind: 'task'|'state'|'event'|'session'|'review'|'error'|'action'|'evidence',
+  //          title, sub, body, raw, time, dot, pill}
+  const dotClass = entry.dot ? ` dot-${statusClass(entry.dot)}` : '';
+  const side = entry.kind === 'action' ? 'side-right' : '';
+  return `
+    <article class="chat-msg msg-${entry.kind}${side}" data-chat-kind="${entry.kind}">
+      <div class="chat-msg-head">
+        <span class="chat-dot${dotClass}" aria-hidden="true"></span>
+        <strong>${escapeHtml(entry.title)}</strong>
+        ${entry.pill ? `<span class="status-pill ${statusClass(entry.pill)}">${escapeHtml(statusText(entry.pill))}</span>` : ''}
+        ${entry.time ? `<time>${escapeHtml(entry.time)}</time>` : ''}
+      </div>
+      ${entry.sub ? `<div class="chat-msg-sub">${escapeHtml(entry.sub)}</div>` : ''}
+      ${entry.body !== undefined && entry.body !== null && entry.body !== '' ? `<div class="chat-msg-body">${typeof entry.body === 'string' ? escapeHtml(entry.body) : compactJson(entry.body)}</div>` : ''}
+      ${entry.raw ? `<code class="chat-msg-code">${escapeHtml(entry.raw)}</code>` : ''}
+    </article>`;
+}
+
+function renderChatFeed(task) {
+  const feed = elements['chat-feed'];
+  const welcome = elements['chat-welcome'];
+  if (!task) {
+    welcome.hidden = false;
+    feed.innerHTML = '';
+    renderChatWelcome();
+    return;
+  }
+  welcome.hidden = true;
+  const messages = [];
+  // Header card: the authoritative Task record.
+  messages.push(chatMessageCard(task, {
+    kind: task.graph ? 'task' : 'task',
+    title: task.title || task.id,
+    sub: `${task.id} · ${task.graph ? t('msg.graph') : t('msg.round', { round: task.round })} · ${t('msg.updated', { time: formatDate(task.updatedAt) })}`,
+    pill: task.status || (task.graph ? 'RUNNING' : ''),
+    body: task.spec || null,
+    dot: task.status || 'UNKNOWN',
+  }));
+
+  const timeline = Array.isArray(task.timeline) ? task.timeline : [];
+  for (const event of timeline) {
+    const title = event.status ? statusText(event.status) : eventText(event.event);
+    const actor = event.agent || event.from || t('chat.runtime');
+    const subParts = [actor];
+    if (event.sessionId) subParts.push(`${t('msg.session')} ${shortId(event.sessionId)}`);
+    const kind = isErrorEvent(event) ? 'error' : (event.status ? 'state' : 'event');
+    messages.push(chatMessageCard(task, {
+      kind,
+      title,
+      sub: subParts.join(' · '),
+      time: formatDate(event.timestamp),
+      body: event.details || null,
+      raw: event.event && !event.status ? event.event : null,
+      dot: event.status || (kind === 'error' ? 'ERROR' : null),
+      pill: event.status || null,
+    }));
+  }
+
+  if (task.graph) {
+    const counts = (task.subtasks || []).reduce((acc, item) => {
+      acc[item.state || 'UNKNOWN'] = (acc[item.state || 'UNKNOWN'] || 0) + 1;
+      return acc;
+    }, {});
+    messages.push(chatMessageCard(task, {
+      kind: 'event',
+      title: t('msg.graphSubtask', { n: (task.subtasks || []).length }),
+      sub: Object.entries(counts).map(([k, v]) => `${statusText(k)} ${v}`).join(' · '),
+      body: null,
+      dot: 'RUNNING',
+    }));
+  }
+
+  for (const review of (task.reviewHistory || [])) {
+    messages.push(chatMessageCard(task, {
+      kind: 'review',
+      title: t('msg.reviewDecision'),
+      pill: review.decision,
+      sub: review.actor ? String(review.actor) : null,
+      time: review.timestamp ? formatDate(review.timestamp) : null,
+      body: review.feedback || null,
+      dot: review.decision,
+    }));
+  }
+
+  const localList = localActions.get(task.id) || [];
+  for (const item of localList) {
+    messages.push(chatMessageCard(task, {
+      kind: item.kind === 'error' ? 'error' : 'action',
+      title: item.label,
+      time: formatTime(item.at),
+      body: null,
+      dot: item.kind === 'error' ? 'ERROR' : 'OK',
+    }));
+  }
+
+  if (task.lastError) {
+    messages.push(chatMessageCard(task, {
+      kind: 'error',
+      title: `${task.lastError.code || 'ERROR'} · ${task.id}`,
+      body: task.lastError.message || task.lastError.details || null,
+      time: formatDate(task.updatedAt),
+      dot: 'ERROR',
+    }));
+  }
+
+  if (!messages.length) {
+    feed.innerHTML = `<div class="empty-state">${escapeHtml(t('empty.detailTimeline'))}</div>`;
+    return;
+  }
+  const nearBottom = feed.scrollHeight - feed.scrollTop - feed.clientHeight < 180;
+  feed.innerHTML = messages.join('');
+  if (nearBottom) {
+    feed.scrollTop = feed.scrollHeight;
+  }
+}
+
+function isErrorEvent(event) {
+  const text = `${event.event || ''} ${event.status || ''}`.toUpperCase();
+  return /ERROR|FAIL|NONZERO|REJECTED|BLOCKED|STOPPED/.test(text) && !/STOPPED_OK/.test(text);
+}
+
+function recordLocalAction(taskId, label, kind = 'ok') {
+  if (!taskId) return;
+  if (!localActions.has(taskId)) localActions.set(taskId, []);
+  localActions.get(taskId).push({ label, kind, at: new Date() });
+}
+
+/* ------------------------------------------------------------------ */
+/* Context panel                                                      */
+/* ------------------------------------------------------------------ */
+function renderContextSelection() {
+  const container = elements['context-selection'];
+  if (!container) return;
+  const taskId = state.selectedTask;
+  if (!taskId) {
+    const taskCount = (state.tasks || []).length;
+    const sessionCount = (state.sessions || []).length;
+    container.innerHTML = `
+      <div class="context-intro">
+        <p class="context-intro-text">${escapeHtml(t('context.selectionHint'))}</p>
+        <div class="context-counts">
+          <span class="count-badge">${escapeHtml(t('context.recentTasks', { n: taskCount }))}</span>
+          <span class="count-badge">${escapeHtml(t('context.recentSessions', { n: sessionCount }))}</span>
+        </div>
+        <div class="context-quick">
+          <button class="button" type="button" id="context-new-task">${escapeHtml(t('context.newTask'))}</button>
+          <button class="button ghost" type="button" id="context-agents">${escapeHtml(t('context.browseAgents'))}</button>
+        </div>
+      </div>`;
+    container.querySelector('#context-new-task')?.addEventListener('click', openAuthorDrawer);
+    container.querySelector('#context-agents')?.addEventListener('click', () => switchView('agents'));
+    return;
+  }
+  // Resolve the freshest summary from the list first.
+  const summary = (state.tasks || []).find(item => item.id === taskId);
+  const title = summary?.title || taskId;
+  const graph = Boolean(summary?.graph);
+  const status = summary?.status || (graph ? 'RUNNING' : 'CREATED');
+  container.innerHTML = `
+    <div class="context-task">
+      <div class="context-task-title">
+        <span class="state-dot ${statusClass(status)}"></span>
+        <strong>${escapeHtml(title)}</strong>
+      </div>
+      <div class="context-task-meta">
+        <span class="status-pill ${statusClass(status)}">${escapeHtml(statusText(status))}</span>
+        <code>${escapeHtml(taskId)}</code>
+      </div>
+      ${graph ? `<div class="context-task-meta">${escapeHtml(t('msg.graphSubtask', { n: summary.subtaskCount }))} · ${escapeHtml(t('msg.concurrency', { n: summary.maxConcurrency }))}</div>` : ''}
+      <div class="context-actions">
+        <button class="button" type="button" data-context-action="details">${escapeHtml(t('context.openDetails'))}</button>
+        <button class="button ghost" type="button" data-context-action="execution">${escapeHtml(t('context.execution'))}</button>
+        <button class="button ghost" type="button" data-context-action="review">${escapeHtml(t('context.review'))}</button>
+      </div>
+    </div>`;
+  container.querySelector('[data-context-action="details"]')?.addEventListener('click', () => openDetailDrawer(graph ? 'graph-detail' : 'timeline'));
+  container.querySelector('[data-context-action="execution"]')?.addEventListener('click', () => openDetailDrawer('execution-panel'));
+  container.querySelector('[data-context-action="review"]')?.addEventListener('click', () => openDetailDrawer('review-panel'));
+}
+
+function renderContext() {
+  renderContextSelection();
+  renderAgentFlow();
+}
+
+/* ------------------------------------------------------------------ */
+/* Composer                                                           */
+/* ------------------------------------------------------------------ */
+function renderComposerAgents() {
+  const select = elements['composer-agent'];
+  if (!select) return;
+  const ids = authorAgentIds();
+  const previous = select.value;
+  select.innerHTML = `<option value="">—</option>${ids.map(id => `<option value="${escapeHtml(id)}">${escapeHtml(id)}</option>`).join('')}`;
+  if (previous && ids.includes(previous)) select.value = previous;
+  const hint = elements['composer-hint'];
+  if (hint) {
+    const notice = ids.length === 0 ? `<span class="composer-warning">${escapeHtml(t('composer.noAgents'))}</span>` : '';
+    hint.innerHTML = `${notice}<span>${escapeHtml(t('composer.enterHint'))}</span>`;
+  }
+}
+
+function setComposerStatus(message, kind = 'info') {
+  const status = elements['composer-status'];
+  if (!status) return;
+  if (!message) {
+    status.hidden = true;
+    status.textContent = '';
+    status.className = 'composer-status';
+    return;
+  }
+  status.hidden = false;
+  status.textContent = message;
+  status.className = `composer-status ${kind}`;
+}
+
+function updateSendLabel() {
+  const mode = elements['composer-mode']?.value;
+  const send = elements['composer-send'];
+  if (!send || !mode) return;
+  send.textContent = mode === 'graph' ? t('composer.openGraph') : t('composer.send');
+}
+
+async function composerSend() {
+  const input = elements['composer-input'];
+  const text = input.value.trim();
+  const firstLine = text.split(/\r?\n/, 1)[0].trim();
+  if (!firstLine) {
+    setComposerStatus(t('composer.titleRequired'), 'error');
+    toast(t('composer.titleRequired'), 'error', 3200);
+    input.focus();
+    return;
+  }
+  const mode = elements['composer-mode']?.value || 'task';
+  const agentId = elements['composer-agent']?.value || '';
+  if (mode === 'graph') {
+    openAuthorDrawer();
+    elements['author-graph-title'].value = firstLine;
+    elements['author-graph-spec'].value = text;
+    setComposerStatus(t('composer.graphHint'), 'info');
+    window.setTimeout(() => elements['author-graph-title'].focus(), 60);
+    return;
+  }
+  const params = { title: firstLine };
+  if (text.length > firstLine.length) params.spec = text;
+  if (agentId) params.implementer = agentId;
+  const send = elements['composer-send'];
+  send.disabled = true;
+  setComposerStatus(t('composer.creating'), 'info');
+  try {
+    const { status, payload } = await postAction('taskCreate', params);
+    if (status !== 200 || payload?.ok !== true) {
+      const error = payload?.error || {};
+      setComposerStatus(t('composer.failed', { message: `${error.code || `HTTP ${status}`} — ${error.message || ''}` }), 'error');
+      toast(t('composer.failed', { message: error.message || error.code || `HTTP ${status}` }), 'error', 5000);
+      return;
+    }
+    const taskId = payload.task?.id || payload.id;
+    setComposerStatus('');
+    toast(t('composer.sent'), 'ok', 3000);
+    input.value = '';
+    await refresh();
+    if (taskId) {
+      switchView('chat');
+      selectTask(taskId);
+    }
+  } catch (error) {
+    setComposerStatus(t('composer.failed', { message: error.message }), 'error');
+    toast(t('composer.failed', { message: error.message }), 'error', 5000);
+  } finally {
+    send.disabled = false;
+  }
+}
+
+function onComposerKeydown(event) {
+  if (event.key === 'Enter' && !event.shiftKey && !event.isComposing) {
+    event.preventDefault();
+    composerSend();
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* Selection                                                          */
+/* ------------------------------------------------------------------ */
 async function selectTask(id) {
   try {
     state.selectedTask = id;
     state.selectedSubtask = null;
     state.graphDetail = null;
     window.location.hash = encodeURIComponent(id);
+    switchView('chat');
     renderTasks();
+    renderRecentList();
     const task = await fetchJson(`/api/tasks/${encodeURIComponent(id)}`);
     renderTaskDetail(task);
-    elements['task-detail'].scrollIntoView({ behavior: 'smooth', block: 'start' });
+    renderChatFeed(task);
+    renderContext();
+    // Keep the details drawer populated if it is open.
+    if (!state.detailOpen) {
+      // Do not auto-open on desktop; the context panel offers the entry.
+    }
   } catch (error) {
-    elements['detail-title'].textContent = error.message;
+    renderChatWelcome();
+    toast(error.message, 'error', 4000);
   }
 }
 
 function closeDetail() {
-  state.selectedTask = null;
-  state.selectedSubtask = null;
-  state.graphDetail = null;
-  history.replaceState(null, '', window.location.pathname);
-  renderTasks();
-  renderTaskDetail(null);
+  closeTopDrawer();
 }
 
+/* ------------------------------------------------------------------ */
+/* Refresh & init                                                     */
+/* ------------------------------------------------------------------ */
 async function refresh() {
   try {
     const [tasks, agents, sessions, events] = await Promise.all([
@@ -1249,8 +2570,15 @@ async function refresh() {
     renderSessions();
     bindSessionActions(elements.sessions);
     renderEvents();
+    renderRecentList();
+    renderComposerAgents();
+    renderContext();
     if (state.selectedTask) {
-      try { renderTaskDetail(await fetchJson(`/api/tasks/${encodeURIComponent(state.selectedTask)}`)); } catch { /* The list remains useful if a task is removed during refresh. */ }
+      try {
+        const task = await fetchJson(`/api/tasks/${encodeURIComponent(state.selectedTask)}`);
+        renderTaskDetail(task);
+        renderChatFeed(task);
+      } catch { /* The list remains useful if a task is removed during refresh. */ }
     }
   } catch (error) {
     elements.tasks.innerHTML = `<div class="empty-state error-state">${escapeHtml(error.message)}</div>`;
@@ -1261,27 +2589,101 @@ async function refresh() {
     state.repository = null;
   }
   renderRepository();
+  if (state.currentView === 'chat' && !state.selectedTask) renderChatWelcome();
 }
 
-elements['refresh-button'].addEventListener('click', refresh);
-elements['close-detail'].addEventListener('click', closeDetail);
-elements['discover-agents'].addEventListener('click', discoverAgents);
-elements['agent-configure'].addEventListener('submit', applyAgentConfigure);
-elements['author-subtask-add'].addEventListener('click', () => addSubtaskRow());
-elements['author-graph-validate'].addEventListener('click', validateGraphNow);
-elements['author-graph-create'].addEventListener('click', createGraphNow);
-elements['task-create-form'].addEventListener('submit', createSingleTask);
-elements['author-graph-intent'].addEventListener('change', event => {
-  elements['author-graph-scope'].disabled = !event.target.checked;
-});
-window.addEventListener('keydown', event => {
-  if (event.key === 'Escape') closeGraphMap();
-});
-addSubtaskRow({ id: 'sub-a' });
-const initialTask = decodeURIComponent(window.location.hash.slice(1));
-if (initialTask) state.selectedTask = initialTask;
-refresh();
-setInterval(refresh, 5_000);
+function renderAllDynamic() {
+  if (!elements.tasks) return;
+  renderTasks();
+  renderAgentFlow();
+  renderConfiguredAgents(state.agents);
+  renderSessions();
+  renderEvents();
+  renderRecentList();
+  renderComposerAgents();
+  renderContext();
+  if (state.selectedTask) {
+    const task = state.tasks.find(item => item.id === state.selectedTask);
+    renderChatWelcome();
+  }
+  renderChatArea();
+}
+
+function renderChatArea() {
+  if (state.currentView !== 'chat') return;
+  if (!state.selectedTask) {
+    renderChatWelcome();
+    elements['chat-feed'].innerHTML = '';
+    return;
+  }
+  // The freshest timeline lives in the per-task detail; keep chat in sync lazily.
+}
+
+function bindEvents() {
+  document.querySelectorAll('.nav-item[data-view]').forEach(item => {
+    item.addEventListener('click', () => switchView(item.dataset.view));
+  });
+  elements['refresh-button']?.addEventListener('click', refresh);
+  elements['sidebar-open']?.addEventListener('click', openSidebar);
+  elements['sidebar-close']?.addEventListener('click', () => { closeSidebarIfMobile(); });
+  elements['new-task-button']?.addEventListener('click', openAuthorDrawer);
+  elements['close-detail']?.addEventListener('click', closeDetail);
+  elements['drawer-close']?.addEventListener('click', closeTopDrawer);
+  elements['author-drawer-close']?.addEventListener('click', closeTopDrawer);
+  elements['drawer-scrim']?.addEventListener('click', closeTopDrawer);
+  elements['context-toggle']?.addEventListener('click', toggleContext);
+  elements['context-close']?.addEventListener('click', toggleContext);
+  elements['repo-facts-toggle']?.addEventListener('click', toggleRepoFacts);
+  elements['discover-agents']?.addEventListener('click', discoverAgents);
+  elements['agent-configure']?.addEventListener('submit', applyAgentConfigure);
+  elements['author-subtask-add']?.addEventListener('click', () => addSubtaskRow());
+  elements['author-graph-validate']?.addEventListener('click', validateGraphNow);
+  elements['author-graph-create']?.addEventListener('click', createGraphNow);
+  elements['task-create-form']?.addEventListener('submit', createSingleTask);
+  elements['author-graph-intent']?.addEventListener('change', event => {
+    elements['author-graph-scope'].disabled = !event.target.checked;
+  });
+  elements['composer-send']?.addEventListener('click', composerSend);
+  elements['composer-mode']?.addEventListener('change', updateSendLabel);
+  elements['composer-input']?.addEventListener('keydown', onComposerKeydown);
+  elements['lang-zh']?.addEventListener('click', () => persistLocale('zh-CN'));
+  elements['lang-en']?.addEventListener('click', () => persistLocale('en-US'));
+
+  document.querySelectorAll('#view-tasks [data-task-id]').forEach(() => { /* tasks grid handles its own */ });
+  window.addEventListener('keydown', event => {
+    if (event.key === 'Escape') {
+      if (state.authorOpen || state.detailOpen) {
+        closeTopDrawer();
+      } else {
+        closeGraphMap();
+      }
+    }
+  });
+  window.addEventListener('resize', () => {
+    if (!isNarrowSidebar()) closeSidebarIfMobile();
+    updateContextState();
+  });
+}
+
+function init() {
+  applyStaticI18n();
+  bindEvents();
+  if (window.matchMedia('(max-width: 1180px)').matches) state.contextOpen = false;
+  updateContextState();
+  updateSendLabel();
+  renderLanguageControls();
+  addSubtaskRow({ id: 'sub-a' });
+  switchView('chat');
+  const initialTask = decodeURIComponent(window.location.hash.slice(1));
+  if (initialTask) {
+    state.selectedTask = initialTask;
+    switchView('chat');
+  } else {
+    renderChatWelcome();
+  }
+  refresh();
+  setInterval(refresh, 5_000);
+}
 
 let refreshTimer = null;
 function scheduleRefresh() {
@@ -1291,6 +2693,8 @@ function scheduleRefresh() {
     refresh();
   }, 150);
 }
+
+init();
 
 if ('EventSource' in window) {
   const stream = new EventSource('/api/events/stream');

--- a/inspector/web-workspace/index.html
+++ b/inspector/web-workspace/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <link rel="icon" href="data:,">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="color-scheme" content="dark">
     <meta name="description" content="Coordinate Agents Web Workspace: a localhost-only control plane for your local AI coding team.">
@@ -9,271 +10,366 @@
     <title>Coordinate Agents Workspace</title>
     <link rel="stylesheet" href="/styles.css">
   </head>
-  <body>
-    <header class="topbar">
-      <div>
-        <p class="eyebrow">LOCAL WEB WORKSPACE</p>
-        <h1>Coordinate Agents Workspace</h1>
-        <p class="subtitle">Control plane for your local AI coding team</p>
+  <body data-locale="en">
+    <div class="app" id="app">
+      <!-- ============ Left Sidebar ============ -->
+      <aside class="sidebar" id="sidebar" aria-label="Workspace sidebar">
+        <div class="sidebar-top">
+          <div class="brand">
+            <span class="brand-mark" aria-hidden="true"></span>
+            <div class="brand-text">
+              <strong>Coordinate Agents</strong>
+              <span class="brand-sub">Web Workspace</span>
+            </div>
+          </div>
+          <button id="sidebar-close" class="icon-button sidebar-close" type="button" aria-label="Close sidebar" hidden>×</button>
+        </div>
+
+        <section id="repository" class="repo-chip" aria-label="Bound repository">
+          <p class="eyebrow repo-eyebrow">BOUND REPOSITORY</p>
+          <div class="repo-chip-main">
+            <h2 id="repo-name" class="repo-name" data-i18n="repo.loading">Loading repository…</h2>
+            <span id="repo-branch" class="count-badge branch-badge" title="Current branch">—</span>
+          </div>
+          <button id="repo-facts-toggle" class="text-button" type="button" data-i18n="repo.details">Show repository details</button>
+          <div id="repo-facts" class="repo-facts repo-facts-pop" aria-live="polite" hidden></div>
+        </section>
+
+        <button id="new-task-button" class="button new-task-button" type="button" data-i18n="nav.newTask">New task</button>
+
+        <nav class="nav" aria-label="Workspace sections">
+          <button class="nav-item active" type="button" data-view="chat" aria-current="true" data-i18n="nav.chat">Chat</button>
+          <button class="nav-item" type="button" data-view="tasks" data-i18n="nav.tasks">Tasks</button>
+          <button class="nav-item" type="button" data-view="agents" data-i18n="nav.agents">Agents</button>
+          <button class="nav-item" type="button" data-view="sessions" data-i18n="nav.sessions">Sessions</button>
+          <button class="nav-item" type="button" data-view="activity" data-i18n="nav.activity">Activity</button>
+        </nav>
+
+        <div class="recent-head" id="recent-head">
+          <span class="recent-label" data-i18n="nav.recent">Recent</span>
+          <button id="recent-toggle" class="text-button" type="button" data-i18n="nav.recentsToggle" aria-expanded="true">Tasks & sessions</button>
+        </div>
+        <div id="recent-list" class="recent-list" aria-live="polite"></div>
+
+        <div class="sidebar-footer">
+          <span class="live-dot" aria-hidden="true"></span>
+          <span class="sidebar-live-text" data-i18n="status.connected">localhost · live</span>
+        </div>
+      </aside>
+
+      <!-- ============ Center column ============ -->
+      <div class="center">
+        <header class="main-topbar">
+          <button id="sidebar-open" class="icon-button menu-button" type="button" aria-label="Open sidebar">☰</button>
+          <div class="topbar-title">
+            <h1 id="view-title" class="view-title">Chat</h1>
+            <span id="view-subtitle" class="view-subtitle" data-i18n="subtitle.workspace">Workspace for your local AI coding team</span>
+          </div>
+          <div class="topbar-actions">
+            <div class="lang-toggle" role="group" aria-label="Language / 语言">
+              <button id="lang-zh" class="lang-button" type="button" lang="zh-CN" aria-pressed="false">中文</button>
+              <button id="lang-en" class="lang-button" type="button" lang="en-US" aria-pressed="true">English</button>
+            </div>
+            <button id="refresh-button" class="icon-button" type="button" aria-label="Refresh" title="Refresh">⟳</button>
+            <button id="context-toggle" class="icon-button context-toggle" type="button" aria-label="Toggle context panel" aria-expanded="true">▤</button>
+          </div>
+        </header>
+
+        <main class="chat-scroll" id="chat-scroll">
+          <!-- Chat view -->
+          <section class="view active" id="view-chat" data-view-panel="chat" aria-live="polite">
+            <div id="chat-welcome" class="welcome" hidden></div>
+            <div id="chat-feed" class="chat-feed" aria-live="polite"></div>
+          </section>
+
+          <!-- Tasks view -->
+          <section class="view" id="view-tasks" data-view-panel="tasks" hidden>
+            <div class="view-heading">
+              <h2 data-i18n="view.tasksTitle">Tasks</h2>
+              <span id="task-count" class="count-badge">0</span>
+            </div>
+            <div id="tasks" class="task-grid" aria-live="polite"></div>
+          </section>
+
+          <!-- Agents view -->
+          <section class="view" id="view-agents" data-view-panel="agents" hidden>
+            <section id="agents-panel" class="panel agents-panel">
+              <div class="section-heading">
+                <div>
+                  <p class="eyebrow">AGENT SETUP</p>
+                  <h2 data-i18n="agents.title">Agents</h2>
+                </div>
+                <button id="discover-agents" class="button" type="button" data-i18n="agents.discover">Discover CLIs</button>
+              </div>
+              <p class="agents-note" data-i18n="agents.note">Configure a local coding Agent, its Adapter, and its exact executable
+                command. Resolution order stays project command → user command → Adapter default. Detection
+                runs only when you click Discover; the Workspace never performs automatic login, remote lookup,
+                package download, or arbitrary process launch.</p>
+              <div id="agents-discovery" class="agents-discovery" aria-live="polite">
+                <div class="empty-state" data-i18n="agents.discoverHint">Click “Discover CLIs” to inspect installed coding CLIs and registered Adapters.</div>
+              </div>
+              <form id="agent-configure" class="agent-form" novalidate>
+                <label data-i18n="agents.agentId">Agent ID<input id="cfg-agent" name="agent" list="agent-id-options" maxlength="64" placeholder="e.g. codex / antigravity" data-i18n-placeholder="agents.agentIdPh" required></label>
+                <datalist id="agent-id-options"></datalist>
+                <label data-i18n="agents.adapter">Adapter<select id="cfg-adapter" name="adapter">
+                  <option value="codex-cli">codex-cli (built-in)</option>
+                  <option value="antigravity-cli">antigravity-cli (built-in)</option>
+                  <option value="generic-cli">generic-cli</option>
+                </select></label>
+                <label data-i18n="agents.command">Executable command<input id="cfg-command" name="command" maxlength="512" placeholder="exact command, e.g. agy-proxy" data-i18n-placeholder="agents.commandPh" required></label>
+                <label data-i18n="agents.role">Workflow role<select id="cfg-role" name="role">
+                  <option value="implementer" data-i18n="roles.implementer">implementer</option>
+                  <option value="planner" data-i18n="roles.planner">planner</option>
+                  <option value="reviewer" data-i18n="roles.reviewer">reviewer</option>
+                </select></label>
+                <button id="apply-agent" class="button" type="submit" data-i18n="agents.apply">Apply configuration</button>
+                <span id="agent-status" class="agent-status" aria-live="polite"></span>
+              </form>
+              <h3 data-i18n="agents.configured">Configured runtime agents</h3>
+              <div id="configured-agents" class="configured-agents" aria-live="polite"></div>
+              <p class="agents-scope-note" data-i18n="agents.scopeNote">Only explicitly registered or loaded local Adapter modules are treated
+                as trusted local code; configuring an Agent grants no browser filesystem or process sandbox
+                bypass. The Workspace never renders or persists credentials, tokens, cookies, or secrets.</p>
+            </section>
+          </section>
+
+          <!-- Sessions view -->
+          <section class="view" id="view-sessions" data-view-panel="sessions" hidden>
+            <section class="panel sessions-panel">
+              <div class="section-heading">
+                <div>
+                  <p class="eyebrow">EXECUTION RUNTIME</p>
+                  <h2 data-i18n="view.sessionsTitle">Sessions</h2>
+                </div>
+                <span id="session-count" class="count-badge">0</span>
+              </div>
+              <div id="sessions" class="session-list" aria-live="polite"></div>
+            </section>
+          </section>
+
+          <!-- Activity view -->
+          <section class="view" id="view-activity" data-view-panel="activity" hidden>
+            <div class="view-heading">
+              <h2 data-i18n="view.activityTitle">Recent events</h2>
+              <span class="muted-label" data-i18n="view.activityHint">recorded events · legacy fallback</span>
+            </div>
+            <div id="events" class="event-list" aria-live="polite"></div>
+          </section>
+        </main>
+
+        <!-- Composer -->
+        <footer class="composer" id="composer" aria-label="Composer">
+          <div class="composer-row">
+            <textarea id="composer-input" class="composer-input" rows="2" maxlength="1024"
+              placeholder="Describe a task for your local AI team… (Enter to create, Shift+Enter for a new line)"
+              data-i18n-placeholder="composer.placeholder" aria-label="Task description"></textarea>
+            <div class="composer-actions">
+              <label class="composer-field" data-i18n="composer.agent">Agent
+                <select id="composer-agent"><option value="">—</option></select>
+              </label>
+              <label class="composer-field" data-i18n="composer.mode">Mode
+                <select id="composer-mode">
+                  <option value="task" data-i18n="composer.modeTask">Single task</option>
+                  <option value="graph" data-i18n="composer.modeGraph">Task Graph…</option>
+                </select>
+              </label>
+              <button id="composer-send" class="button primary-button" type="button" data-i18n="composer.send">Send</button>
+            </div>
+          </div>
+          <div class="composer-hint" id="composer-hint" aria-live="polite">
+            <span data-i18n="composer.enterHint">Enter to create a Task · Shift+Enter for a new line</span>
+          </div>
+          <div class="composer-status" id="composer-status" aria-live="polite" hidden></div>
+        </footer>
       </div>
-      <div class="topbar-meta">
-        <span class="live-dot"></span>
-        <span>localhost · read-only</span>
-        <button id="refresh-button" class="button" type="button">Refresh</button>
-      </div>
-    </header>
 
-    <main class="shell">
-      <section id="repository" class="panel repository-panel" hidden>
-        <div class="section-heading">
-          <div>
-            <p class="eyebrow">BOUND REPOSITORY</p>
-            <h2 id="repo-name">Loading repository…</h2>
-          </div>
-          <span id="repo-branch" class="count-badge branch-badge" title="Current branch">—</span>
+      <!-- ============ Right Context panel ============ -->
+      <aside class="context-panel" id="context-panel" aria-label="Context panel">
+        <div class="context-head">
+          <h2 data-i18n="context.title">Context</h2>
+          <button id="context-close" class="icon-button" type="button" aria-label="Close context panel">×</button>
         </div>
-        <div id="repo-facts" class="repo-facts" aria-live="polite"></div>
-      </section>
+        <div id="context-body" class="context-body">
+          <div id="context-selection" class="context-selection" aria-live="polite"></div>
+          <section class="context-section" aria-label="Agent flow">
+            <h3 data-i18n="context.agentFlow">Agent flow</h3>
+            <div id="agent-flow" class="agent-flow context-flow" aria-live="polite"></div>
+          </section>
+        </div>
+      </aside>
 
-      <section id="agents-panel" class="panel agents-panel">
-        <div class="section-heading">
-          <div>
-            <p class="eyebrow">AGENT SETUP</p>
-            <h2>Agents</h2>
-          </div>
-          <button id="discover-agents" class="button" type="button">Discover CLIs</button>
-        </div>
-        <p class="agents-note">Configure a local coding Agent, its Adapter, and its exact executable
-          command. Resolution order stays project command → user command → Adapter default. Detection
-          runs only when you click Discover; the Workspace never performs automatic login, remote lookup,
-          package download, or arbitrary process launch.</p>
-        <div id="agents-discovery" class="agents-discovery" aria-live="polite">
-          <div class="empty-state">Click “Discover CLIs” to inspect installed coding CLIs and registered Adapters.</div>
-        </div>
-        <form id="agent-configure" class="agent-form" novalidate>
-          <label>Agent ID<input id="cfg-agent" name="agent" list="agent-id-options" maxlength="64" placeholder="e.g. codex / antigravity" required></label>
-          <datalist id="agent-id-options"></datalist>
-          <label>Adapter<select id="cfg-adapter" name="adapter">
-            <option value="codex-cli">codex-cli (built-in)</option>
-            <option value="antigravity-cli">antigravity-cli (built-in)</option>
-            <option value="generic-cli">generic-cli</option>
-          </select></label>
-          <label>Executable command<input id="cfg-command" name="command" maxlength="512" placeholder="exact command, e.g. agy-proxy" required></label>
-          <label>Workflow role<select id="cfg-role" name="role">
-            <option value="implementer">implementer</option>
-            <option value="planner">planner</option>
-            <option value="reviewer">reviewer</option>
-          </select></label>
-          <button id="apply-agent" class="button" type="submit">Apply configuration</button>
-          <span id="agent-status" class="agent-status" aria-live="polite"></span>
-        </form>
-        <h3>Configured runtime agents</h3>
-        <div id="configured-agents" class="configured-agents" aria-live="polite"></div>
-        <p class="agents-scope-note">Only explicitly registered or loaded local Adapter modules are treated
-          as trusted local code; configuring an Agent grants no browser filesystem or process sandbox
-          bypass. The Workspace never renders or persists credentials, tokens, cookies, or secrets.</p>
-      </section>
-
-      <section class="hero-grid">
-        <div class="hero-card">
-          <div class="section-heading">
-            <div>
-              <p class="eyebrow">COORDINATION OVERVIEW</p>
-              <h2>Tasks</h2>
-            </div>
-            <span id="task-count" class="count-badge">0</span>
-          </div>
-          <div id="tasks" class="task-grid" aria-live="polite"></div>
-        </div>
-        <div class="hero-card topology-card">
-          <div class="section-heading">
-            <div>
-              <p class="eyebrow">ROLE TOPOLOGY</p>
-              <h2>Agent flow</h2>
-            </div>
-            <span class="muted-label">Planner → Implementer → Reviewer</span>
-          </div>
-          <div id="agent-flow" class="agent-flow" aria-live="polite"></div>
-        </div>
-      </section>
-
-      <section id="task-detail" class="panel task-detail-panel" hidden>
-        <div class="section-heading">
-          <div>
-            <p class="eyebrow">TASK DETAIL</p>
-            <h2 id="detail-title">Select a task</h2>
-          </div>
-          <button id="close-detail" class="button ghost" type="button">Close</button>
-        </div>
-        <div id="detail-summary" class="detail-summary"></div>
-        <div id="execution-panel" class="execution-panel" hidden>
-          <div class="section-heading">
-            <div>
-              <p class="eyebrow">EXECUTION CONTROL · EXPLICIT ONLY</p>
-              <h2 id="execution-title">Execution</h2>
-            </div>
-            <span class="muted-label">never on page load or reconnect · no automatic retry</span>
-          </div>
-          <div id="execution-controls" class="execution-controls"></div>
-          <span id="execution-status" class="author-status" aria-live="polite"></span>
-          <div id="execution-result" class="execution-result" aria-live="polite" hidden></div>
-        </div>
-        <div id="review-panel" class="review-panel" hidden>
-          <div class="section-heading">
-            <div>
-              <p class="eyebrow">REVIEW & INTEGRATE</p>
-              <h2>Review & integrate</h2>
-            </div>
-            <span class="muted-label">review approval is never release approval</span>
-          </div>
-          <p class="agents-note">Integration applies verified subtask commits only to the Runtime-owned aggregate
-            review worktree — never to your checked-out worktree or remote refs. Recording a review decision is
-            durable and visible after reload; requested changes never trigger an automatic retry. This Workspace
-            offers no merge, push, tag, publish, deploy, or release control: releasing requires the separate human
-            <code>RELEASE_APPROVED</code> gate.</p>
-          <div id="review-controls" class="review-controls"></div>
-          <span id="review-status" class="author-status" aria-live="polite"></span>
-          <div id="review-result" class="review-result" aria-live="polite" hidden></div>
-        </div>
-        <section id="graph-detail" class="graph-detail" hidden>
-          <section id="graph-map-region" class="graph-map-region">
+      <!-- ============ Detail drawer (task / graph deep view) ============ -->
+      <div class="drawer-scrim" id="drawer-scrim" hidden></div>
+      <aside class="drawer" id="detail-drawer" role="dialog" aria-modal="true" aria-label="Task and graph details" hidden>
+        <header class="drawer-head">
+          <h2 id="drawer-title" class="drawer-title" data-i18n="drawer.taskDetail">Task & graph details</h2>
+          <button id="drawer-close" class="button ghost" type="button" data-i18n="drawer.close">Close</button>
+        </header>
+        <div class="drawer-body">
+          <section id="task-detail" class="panel task-detail-panel" hidden>
             <div class="section-heading">
               <div>
-                <h3>Graph map</h3>
-                <span id="graph-map-note" class="muted-label" aria-live="polite"></span>
+                <p class="eyebrow">TASK DETAIL</p>
+                <h2 id="detail-title">Select a task</h2>
               </div>
-              <span id="graph-legend" class="graph-legend" aria-hidden="true"></span>
+              <button id="close-detail" class="button ghost" type="button" data-i18n="drawer.close">Close</button>
             </div>
-            <div id="graph-map" class="graph-map" role="img" aria-label="Interactive Task Graph dependency map. Each node is a subtask; arrows point from a dependency to the subtask that depends on it."></div>
-            <div id="graph-node-detail" class="graph-node-detail" aria-live="polite"></div>
+            <div id="detail-summary" class="detail-summary"></div>
+            <div id="execution-panel" class="execution-panel" hidden>
+              <div class="section-heading">
+                <div>
+                  <p class="eyebrow">EXECUTION CONTROL · EXPLICIT ONLY</p>
+                  <h2 id="execution-title">Execution</h2>
+                </div>
+                <span class="muted-label" data-i18n="execution.explicitLabel">never on page load or reconnect · no automatic retry</span>
+              </div>
+              <div id="execution-controls" class="execution-controls"></div>
+              <span id="execution-status" class="author-status" aria-live="polite"></span>
+              <div id="execution-result" class="execution-result" aria-live="polite" hidden></div>
+            </div>
+            <div id="review-panel" class="review-panel" hidden>
+              <div class="section-heading">
+                <div>
+                  <p class="eyebrow">REVIEW & INTEGRATE</p>
+                  <h2 data-i18n="review.title">Review & integrate</h2>
+                </div>
+                <span class="muted-label" data-i18n="review.releaseLabel">review approval is never release approval</span>
+              </div>
+              <p class="agents-note" data-i18n="review.note">Integration applies verified subtask commits only to the Runtime-owned aggregate
+                review worktree — never to your checked-out worktree or remote refs. Recording a review decision is
+                durable and visible after reload; requested changes never trigger an automatic retry. This Workspace
+                offers no merge, push, tag, publish, deploy, or release control: releasing requires the separate human
+                <code>RELEASE_APPROVED</code> gate.</p>
+              <div id="review-controls" class="review-controls"></div>
+              <span id="review-status" class="author-status" aria-live="polite"></span>
+              <div id="review-result" class="review-result" aria-live="polite" hidden></div>
+            </div>
+            <section id="graph-detail" class="graph-detail" hidden>
+              <section id="graph-map-region" class="graph-map-region">
+                <div class="section-heading">
+                  <div>
+                    <h3 data-i18n="graph.map">Graph map</h3>
+                    <span id="graph-map-note" class="muted-label" aria-live="polite"></span>
+                  </div>
+                  <span id="graph-legend" class="graph-legend" aria-hidden="true"></span>
+                </div>
+                <div id="graph-map" class="graph-map" role="img" aria-label="Interactive Task Graph dependency map. Each node is a subtask; arrows point from a dependency to the subtask that depends on it."></div>
+                <div id="graph-node-detail" class="graph-node-detail" aria-live="polite"></div>
+              </section>
+              <div class="graph-overview-grid">
+                <div>
+                  <h3>Task Graph topology</h3>
+                  <div id="graph-topology" class="graph-topology"></div>
+                </div>
+                <div>
+                  <h3 data-i18n="graph.frontier">Frontier & preflight wave</h3>
+                  <div id="graph-frontier" class="graph-facts"></div>
+                </div>
+              </div>
+              <div class="graph-overview-grid">
+                <div>
+                  <h3 data-i18n="graph.conflicts">Conflicts & scope audit</h3>
+                  <div id="graph-conflicts" class="graph-facts"></div>
+                </div>
+                <div>
+                  <h3 data-i18n="graph.integration">Integration & review</h3>
+                  <div id="graph-integration" class="graph-facts"></div>
+                </div>
+              </div>
+            </section>
+            <div class="detail-grid">
+              <div>
+                <h3 data-i18n="detail.timelineTitle">Event timeline</h3>
+                <div id="timeline" class="timeline"></div>
+              </div>
+              <div>
+                <h3 data-i18n="detail.agentFlowTitle">Agent flow</h3>
+                <div id="detail-agent-flow" class="detail-agent-flow"></div>
+              </div>
+            </div>
+            <div class="detail-grid lower-grid">
+              <div>
+                <h3 data-i18n="detail.evidenceTitle">Evidence & review</h3>
+                <div id="evidence" class="evidence-list"></div>
+              </div>
+              <div>
+                <h3 data-i18n="detail.specTitle">Specification</h3>
+                <pre id="spec" class="code-block"></pre>
+              </div>
+            </div>
           </section>
-          <div class="graph-overview-grid">
-            <div>
-              <h3>Task Graph topology</h3>
-              <div id="graph-topology" class="graph-topology"></div>
-            </div>
-            <div>
-              <h3>Frontier & preflight wave</h3>
-              <div id="graph-frontier" class="graph-facts"></div>
-            </div>
-          </div>
-          <div class="graph-overview-grid">
-            <div>
-              <h3>Conflicts & scope audit</h3>
-              <div id="graph-conflicts" class="graph-facts"></div>
-            </div>
-            <div>
-              <h3>Integration & review</h3>
-              <div id="graph-integration" class="graph-facts"></div>
-            </div>
-          </div>
-        </section>
-        <div class="detail-grid">
-          <div>
-            <h3>Event timeline</h3>
-            <div id="timeline" class="timeline"></div>
-          </div>
-          <div>
-            <h3>Agent flow</h3>
-            <div id="detail-agent-flow" class="detail-agent-flow"></div>
-          </div>
         </div>
-        <div class="detail-grid lower-grid">
-          <div>
-            <h3>Evidence & review</h3>
-            <div id="evidence" class="evidence-list"></div>
-          </div>
-          <div>
-            <h3>Specification</h3>
-            <pre id="spec" class="code-block"></pre>
-          </div>
-        </div>
-      </section>
+      </aside>
 
-      <section class="panel sessions-panel">
-        <div class="section-heading">
-          <div>
-            <p class="eyebrow">EXECUTION RUNTIME</p>
-            <h2>Sessions</h2>
-          </div>
-          <span id="session-count" class="count-badge">0</span>
-        </div>
-        <div id="sessions" class="session-list" aria-live="polite"></div>
-      </section>
-
-      <section class="panel events-panel">
-        <div class="section-heading">
-          <div>
-            <p class="eyebrow">RUNTIME JOURNAL</p>
-            <h2>Recent events</h2>
-          </div>
-          <span class="muted-label">recorded events · legacy fallback</span>
-        </div>
-        <div id="events" class="event-list" aria-live="polite"></div>
-      </section>
-
-      <section id="author-panel" class="panel">
-        <div class="section-heading">
-          <div>
-            <p class="eyebrow">AUTHORING · NO DISPATCH</p>
-            <h2>Author new work</h2>
-          </div>
-          <span class="muted-label">validate first · preflight is side-effect free · create persists the Runtime record only</span>
-        </div>
-        <p id="author-empty-agents" class="agents-note" hidden>No Agents are configured yet. Configure an Agent in the Agents panel above before authoring.</p>
-        <div class="author-grid">
-          <div class="author-col">
-            <h3>Single Task</h3>
-            <form id="task-create-form" class="author-form" novalidate>
-              <label>Title<input id="author-task-title" maxlength="1024" required placeholder="Task title"></label>
-              <label>Specification (optional)<textarea id="author-task-spec" rows="3" placeholder="What must change and how is it verified?"></textarea></label>
-              <label>Planner<select id="author-task-planner"></select></label>
-              <label>Implementer<select id="author-task-implementer"></select></label>
-              <label>Reviewer<select id="author-task-reviewer"></select></label>
-              <label>Deterministic ID (optional)<input id="author-task-id" maxlength="128" placeholder="task-… (created automatically when empty)"></label>
-              <button id="author-task-submit" class="button" type="submit">Create Task</button>
-              <span id="author-task-status" class="author-status" aria-live="polite"></span>
-            </form>
-          </div>
-          <div class="author-col">
-            <h3>Task Graph v1 <span class="muted-label">with optional Intent Map v1</span></h3>
-            <form id="graph-create-form" class="author-form" novalidate>
-              <label>Parent ID<input id="author-graph-id" maxlength="128" placeholder="task-…"></label>
-              <label>Title<input id="author-graph-title" maxlength="1024" required placeholder="Graph title"></label>
-              <label>Specification<textarea id="author-graph-spec" rows="2"></textarea></label>
-              <label>Planner<select id="author-graph-planner"></select></label>
-              <label>Reviewer<select id="author-graph-reviewer"></select></label>
-              <label>Max concurrency<input id="author-graph-max" type="number" min="1" max="32" value="1"></label>
-              <label class="author-toggle"><input id="author-graph-intent" type="checkbox"> Intent Map (write intents)</label>
-              <label>Scope policy<select id="author-graph-scope">
-                <option value="warn">warn (default)</option>
-                <option value="observe">observe</option>
-                <option value="strict">strict</option>
-              </select></label>
-            </form>
-            <div class="author-subtasks-head">
-              <h3>Subtasks</h3>
-              <button id="author-subtask-add" class="button ghost" type="button">+ Add subtask</button>
+      <!-- ============ Authoring drawer ============ -->
+      <aside class="drawer drawer-right" id="author-drawer" role="dialog" aria-modal="true" aria-label="Author new work" hidden>
+        <header class="drawer-head">
+          <h2 class="drawer-title" data-i18n="author.title">Author new work</h2>
+          <button id="author-drawer-close" class="button ghost" type="button" data-i18n="drawer.close">Close</button>
+        </header>
+        <div class="drawer-body">
+          <section id="author-panel" class="panel">
+            <div class="section-heading">
+              <div>
+                <p class="eyebrow">AUTHORING · NO DISPATCH</p>
+                <h2 data-i18n="author.panelTitle">Author new work</h2>
+              </div>
+              <span class="muted-label" data-i18n="author.hint">validate first · preflight is side-effect free · create persists the Runtime record only</span>
             </div>
-            <p class="agents-note">Leave write intent empty in a row for an explicitly empty intent; disable the Intent Map for missing (unverified) coverage.</p>
-            <div id="author-subtask-rows" class="subtask-rows"></div>
-            <div class="author-actions">
-              <button id="author-graph-validate" class="button" type="button">Validate</button>
-              <button id="author-graph-create" class="button" type="button">Create Graph (persist only)</button>
-              <span id="author-graph-status" class="author-status" aria-live="polite"></span>
+            <p id="author-empty-agents" class="agents-note" hidden data-i18n="author.emptyAgents">No Agents are configured yet. Configure an Agent in the Agents panel above before authoring.</p>
+            <div class="author-grid">
+              <div class="author-col">
+                <h3 data-i18n="author.singleTask">Single Task</h3>
+                <form id="task-create-form" class="author-form" novalidate>
+                  <label data-i18n="author.taskTitleLabel">Title<input id="author-task-title" maxlength="1024" required data-i18n-placeholder="author.taskTitlePh" placeholder="Task title"></label>
+                  <label data-i18n="author.specLabel">Specification (optional)<textarea id="author-task-spec" rows="3" data-i18n-placeholder="author.specPh" placeholder="What must change and how is it verified?"></textarea></label>
+                  <label data-i18n="roles.planner">Planner<select id="author-task-planner"></select></label>
+                  <label data-i18n="roles.implementer">Implementer<select id="author-task-implementer"></select></label>
+                  <label data-i18n="roles.reviewer">Reviewer<select id="author-task-reviewer"></select></label>
+                  <label data-i18n="author.taskIdLabel">Deterministic ID (optional)<input id="author-task-id" maxlength="128" data-i18n-placeholder="author.taskIdPh" placeholder="task-… (created automatically when empty)"></label>
+                  <button id="author-task-submit" class="button" type="submit" data-i18n="author.createTask">Create Task</button>
+                  <span id="author-task-status" class="author-status" aria-live="polite"></span>
+                </form>
+              </div>
+              <div class="author-col">
+                <h3 data-i18n="author.graphTitle">Task Graph v1 <span class="muted-label" data-i18n="author.intentMapHint">with optional Intent Map v1</span></h3>
+                <form id="graph-create-form" class="author-form" novalidate>
+                  <label data-i18n="author.parentId">Parent ID<input id="author-graph-id" maxlength="128" placeholder="task-…"></label>
+                  <label data-i18n="author.graphTitleLabel">Title<input id="author-graph-title" maxlength="1024" required placeholder="Graph title"></label>
+                  <label data-i18n="author.specLabel">Specification<textarea id="author-graph-spec" rows="2"></textarea></label>
+                  <label data-i18n="roles.planner">Planner<select id="author-graph-planner"></select></label>
+                  <label data-i18n="roles.reviewer">Reviewer<select id="author-graph-reviewer"></select></label>
+                  <label data-i18n="author.maxConcurrency">Max concurrency<input id="author-graph-max" type="number" min="1" max="32" value="1"></label>
+                  <label class="author-toggle"><input id="author-graph-intent" type="checkbox"> <span data-i18n="author.intentMap">Intent Map (write intents)</span></label>
+                  <label data-i18n="author.scopePolicy">Scope policy<select id="author-graph-scope">
+                    <option value="warn" data-i18n="author.scopeWarn">warn (default)</option>
+                    <option value="observe" data-i18n="author.scopeObserve">observe</option>
+                    <option value="strict" data-i18n="author.scopeStrict">strict</option>
+                  </select></label>
+                </form>
+                <div class="author-subtasks-head">
+                  <h3 data-i18n="author.subtasks">Subtasks</h3>
+                  <button id="author-subtask-add" class="button ghost" type="button" data-i18n="author.addSubtask">+ Add subtask</button>
+                </div>
+                <p class="agents-note" data-i18n="author.subtaskHint">Leave write intent empty in a row for an explicitly empty intent; disable the Intent Map for missing (unverified) coverage.</p>
+                <div id="author-subtask-rows" class="subtask-rows"></div>
+                <div class="author-actions">
+                  <button id="author-graph-validate" class="button" type="button" data-i18n="author.validate">Validate</button>
+                  <button id="author-graph-create" class="button" type="button" data-i18n="author.createGraph">Create Graph (persist only)</button>
+                  <span id="author-graph-status" class="author-status" aria-live="polite"></span>
+                </div>
+                <div id="author-graph-errors" class="author-errors" aria-live="polite" hidden></div>
+                <div id="author-graph-validated" class="author-validated" aria-live="polite" hidden></div>
+                <div id="author-graph-preflight" class="author-preflight" aria-live="polite" hidden></div>
+              </div>
             </div>
-            <div id="author-graph-errors" class="author-errors" aria-live="polite" hidden></div>
-            <div id="author-graph-validated" class="author-validated" aria-live="polite" hidden></div>
-            <div id="author-graph-preflight" class="author-preflight" aria-live="polite" hidden></div>
-          </div>
+          </section>
         </div>
-      </section>
-    </main>
+      </aside>
 
-    <footer class="footer">
-      <span>Coordinate Agents Web Workspace</span>
-      <span>Read-only overview · Tasks · Task Graphs · Agents · Sessions · Runtime events</span>
-    </footer>
+      <!-- Toast region -->
+      <div id="toast-region" class="toast-region" aria-live="polite"></div>
+    </div>
     <script type="module" src="/app.js"></script>
   </body>
 </html>

--- a/inspector/web-workspace/styles.css
+++ b/inspector/web-workspace/styles.css
@@ -345,3 +345,319 @@ h3 { margin-bottom: 1rem; color: var(--muted); font-size: .74rem; letter-spacing
 .review-form textarea { resize: vertical; }
 .review-form .button:disabled { opacity: .45; cursor: not-allowed; }
 .review-result { margin-top: .5rem; }
+
+/* ================================================================== */
+/* Chat-first three-column Workspace layout (overrides appended last) */
+/* ================================================================== */
+html, body { height: 100%; }
+body { overflow: hidden; }
+
+.app {
+  display: grid;
+  grid-template-columns: 17rem minmax(0, 1fr) 20rem;
+  width: 100%;
+  height: 100vh;
+}
+
+/* ---------- Sidebar ---------- */
+.sidebar {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  gap: .9rem;
+  padding: 1rem .9rem;
+  overflow-y: auto;
+  border-right: 1px solid var(--line);
+  background: rgba(12, 17, 34, .72);
+  backdrop-filter: blur(14px);
+}
+.sidebar-top { display: flex; align-items: center; justify-content: space-between; }
+.brand { display: flex; align-items: center; gap: .6rem; }
+.brand-mark { width: 1.7rem; height: 1.7rem; border-radius: .55rem; background: linear-gradient(135deg, var(--accent-strong), var(--purple)); box-shadow: 0 .2rem .6rem rgba(97, 124, 255, .35); }
+.brand-text { display: flex; flex-direction: column; line-height: 1.2; }
+.brand-text strong { font-size: .95rem; letter-spacing: -.01em; }
+.brand-sub { color: var(--muted); font-size: .66rem; letter-spacing: .08em; text-transform: uppercase; }
+.icon-button {
+  display: inline-grid;
+  width: 2rem; height: 2rem;
+  place-items: center;
+  padding: 0;
+  border: 1px solid var(--line);
+  border-radius: .55rem;
+  color: var(--muted);
+  background: transparent;
+  cursor: pointer;
+}
+.icon-button:hover, .icon-button:focus-visible { color: var(--text); border-color: var(--accent); }
+.sidebar-close { display: none; }
+
+.repo-chip {
+  display: flex;
+  flex-direction: column;
+  gap: .35rem;
+  padding: .75rem .8rem;
+  border: 1px solid var(--line);
+  border-radius: .8rem;
+  background: rgba(255, 255, 255, .02);
+}
+.repo-eyebrow { margin-bottom: .15rem; font-size: .6rem; }
+.repo-chip-main { display: flex; align-items: center; justify-content: space-between; gap: .6rem; }
+.repo-name { margin: 0; font-size: .95rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.branch-badge { max-width: 9rem; }
+.text-button { padding: .15rem 0; border: 0; color: var(--accent); background: none; font-size: .7rem; cursor: pointer; text-align: left; }
+.text-button:hover { text-decoration: underline; }
+.repo-facts-pop { margin-top: .15rem; }
+
+.new-task-button { width: 100%; padding: .6rem; font-weight: 700; }
+
+.nav { display: grid; gap: .15rem; }
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: .6rem;
+  padding: .55rem .7rem;
+  border: 0;
+  border-radius: .6rem;
+  color: var(--muted);
+  background: transparent;
+  text-align: left;
+  font-weight: 600;
+  cursor: pointer;
+}
+.nav-item:hover { color: var(--text); background: rgba(255, 255, 255, .04); }
+.nav-item.active { color: var(--text); background: rgba(97, 124, 255, .18); }
+.nav-item.active::before { content: ""; width: .4rem; height: .4rem; border-radius: 50%; background: var(--accent); }
+
+.recent-head { display: flex; align-items: baseline; justify-content: space-between; }
+.recent-label { color: var(--muted); font-size: .66rem; font-weight: 800; letter-spacing: .14em; text-transform: uppercase; }
+.recent-toggle { display: none; }
+.recent-list { display: grid; gap: .3rem; min-height: 0; overflow-y: auto; }
+.recent-group-label { margin: .45rem 0 .1rem; color: var(--muted); font-size: .6rem; font-weight: 700; letter-spacing: .1em; text-transform: uppercase; }
+.recent-empty { padding: .8rem .4rem; color: var(--muted); font-size: .74rem; }
+.recent-item {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: .55rem;
+  padding: .5rem .6rem;
+  border: 1px solid transparent;
+  border-radius: .6rem;
+  color: var(--text);
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+}
+.recent-item:hover { background: rgba(255, 255, 255, .04); }
+.recent-item.selected { border-color: rgba(140, 169, 255, .55); background: rgba(97, 124, 255, .14); }
+.recent-item-type { color: var(--accent); font-size: .55rem; font-weight: 800; letter-spacing: .06em; }
+.recent-item-main { display: flex; min-width: 0; flex-direction: column; gap: .15rem; }
+.recent-item-main strong { overflow: hidden; font-size: .78rem; font-weight: 600; text-overflow: ellipsis; white-space: nowrap; }
+.recent-item-sub { display: flex; align-items: center; gap: .35rem; color: var(--muted); font-size: .64rem; }
+.recent-item-sub .state-dot { width: .4rem; height: .4rem; }
+.recent-item time { color: var(--muted); font-size: .62rem; }
+.sidebar-footer { display: flex; align-items: center; gap: .45rem; margin-top: auto; padding: .5rem 0 0; color: var(--muted); font-size: .7rem; }
+.sidebar-footer .live-dot { width: .45rem; height: .45rem; }
+
+/* ---------- Center column ---------- */
+.center { display: grid; grid-template-rows: auto minmax(0, 1fr) auto; min-width: 0; height: 100vh; }
+.main-topbar {
+  display: flex;
+  align-items: center;
+  gap: .9rem;
+  padding: .65rem 1.1rem;
+  border-bottom: 1px solid var(--line);
+  background: rgba(15, 21, 40, .6);
+  backdrop-filter: blur(14px);
+  z-index: 5;
+}
+.menu-button { display: none; }
+.topbar-title { display: flex; min-width: 0; flex: 1; flex-direction: column; }
+.view-title { margin: 0; font-size: 1.05rem; letter-spacing: -.01em; }
+.view-subtitle { overflow: hidden; color: var(--muted); font-size: .7rem; text-overflow: ellipsis; white-space: nowrap; }
+.topbar-actions { display: flex; align-items: center; gap: .5rem; }
+.lang-toggle { display: inline-flex; padding: .15rem; border: 1px solid var(--line); border-radius: .6rem; background: rgba(255, 255, 255, .03); }
+.lang-button { padding: .28rem .6rem; border: 0; border-radius: .45rem; color: var(--muted); background: transparent; font-size: .72rem; font-weight: 600; cursor: pointer; }
+.lang-button[aria-pressed="true"] { color: var(--text); background: rgba(97, 124, 255, .28); }
+.lang-button:hover { color: var(--text); }
+
+.chat-scroll { min-height: 0; overflow-y: auto; overscroll-behavior: contain; }
+.view { display: none; padding: 1.1rem 1.3rem 2rem; max-width: 60rem; margin: 0 auto; width: 100%; }
+.view.active { display: block; }
+[hidden] { display: none !important; }
+.view-heading { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-bottom: 1rem; }
+.view-heading h2 { margin: 0; }
+
+/* ---------- Chat feed ---------- */
+.chat-feed { display: flex; flex-direction: column; gap: .6rem; padding-bottom: .5rem; }
+.chat-msg {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: .6rem .8rem;
+  padding: .8rem 1rem;
+  border: 1px solid var(--line);
+  border-radius: .9rem;
+  background: rgba(255, 255, 255, .025);
+}
+.chat-msg-head { display: flex; grid-column: 1 / -1; align-items: center; gap: .55rem; min-width: 0; }
+.chat-msg-head strong { overflow-wrap: anywhere; font-size: .86rem; }
+.chat-msg-head time { margin-left: auto; color: var(--muted); font-size: .68rem; white-space: nowrap; }
+.chat-dot { width: .55rem; height: .55rem; flex: none; border-radius: 50%; background: var(--accent); box-shadow: 0 0 0 .15rem rgba(140, 169, 255, .15); }
+.chat-dot.dot-ok, .chat-dot.dot-approved, .chat-dot.dot-succeeded { background: var(--green); box-shadow: 0 0 0 .15rem rgba(87, 217, 154, .15); }
+.chat-dot.dot-error, .chat-dot.dot-failed, .chat-dot.dot-blocked, .chat-dot.dot-stopped { background: var(--red); box-shadow: 0 0 0 .15rem rgba(255, 127, 143, .15); }
+.chat-dot.dot-running, .chat-dot.dot-implementing, .chat-dot.dot-reviewing, .chat-dot.dot-busy, .chat-dot.dot-waiting { background: var(--yellow); box-shadow: 0 0 0 .15rem rgba(244, 201, 107, .15); }
+.chat-msg-sub { grid-column: 2 / -1; color: var(--muted); font-size: .72rem; overflow-wrap: anywhere; }
+.chat-msg-sub:empty { display: none; }
+.chat-msg-body {
+  grid-column: 2 / -1;
+  margin: 0;
+  padding: .55rem .7rem;
+  border: 1px solid var(--line);
+  border-radius: .55rem;
+  color: var(--text);
+  background: rgba(0, 0, 0, .2);
+  font: .74rem/1.55 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.chat-msg-code { grid-column: 2 / -1; color: var(--muted); font-size: .66rem; overflow-wrap: anywhere; }
+.msg-task { border-left: 3px solid var(--accent-strong); }
+.msg-state { border-left: 3px solid var(--yellow); }
+.msg-event { border-left: 3px solid var(--accent); }
+.msg-session { border-left: 3px solid var(--purple); }
+.msg-review { border-left: 3px solid var(--green); }
+.msg-error { border-color: rgba(255, 127, 143, .3); border-left-color: var(--red); background: rgba(255, 127, 143, .05); }
+.msg-action { border: 1px solid rgba(140, 169, 255, .25); background: rgba(97, 124, 255, .12); }
+.side-right { margin-left: 12%; }
+
+/* Welcome */
+.welcome-card { padding: 1.2rem 1.4rem; border: 1px solid var(--line); border-radius: 1rem; background: rgba(255, 255, 255, .025); }
+.welcome-card h2 { margin-bottom: .3rem; font-size: 1.25rem; }
+.welcome-sub { margin-bottom: 1.1rem; color: var(--muted); }
+.welcome-columns { display: grid; grid-template-columns: minmax(0, 1.4fr) minmax(220px, .8fr); gap: 1.4rem; align-items: start; }
+.welcome-columns h3 { margin-bottom: .5rem; }
+.welcome-columns ul { display: grid; gap: .45rem; margin: 0; padding-left: 1.1rem; color: var(--muted); font-size: .84rem; line-height: 1.5; }
+.welcome-actions { display: flex; flex-direction: column; align-items: flex-start; gap: .55rem; }
+.welcome-hint { margin: .5rem 0 0; color: var(--muted); font-size: .72rem; line-height: 1.5; }
+.primary-button { background: linear-gradient(135deg, rgba(97, 124, 255, .55), rgba(97, 124, 255, .3)); font-weight: 700; }
+.primary-button:hover { background: linear-gradient(135deg, rgba(97, 124, 255, .75), rgba(97, 124, 255, .45)); }
+
+/* ---------- Composer ---------- */
+.composer {
+  padding: .7rem 1.1rem .75rem;
+  border-top: 1px solid var(--line);
+  background: rgba(15, 21, 40, .78);
+  backdrop-filter: blur(14px);
+}
+.composer-row { display: flex; align-items: flex-end; gap: .7rem; }
+.composer-input {
+  flex: 1;
+  min-height: 2.6rem;
+  max-height: 12rem;
+  resize: vertical;
+  padding: .6rem .75rem;
+  border: 1px solid var(--line);
+  border-radius: .7rem;
+  color: var(--text);
+  background: var(--panel-strong);
+  font: .84rem/1.5 inherit;
+}
+.composer-input:focus-visible { outline: 2px solid rgba(140, 169, 255, .5); border-color: var(--accent); }
+.composer-actions { display: flex; align-items: flex-end; gap: .6rem; }
+.composer-field { display: flex; flex-direction: column; gap: .3rem; color: var(--muted); font-size: .62rem; font-weight: 700; letter-spacing: .06em; text-transform: uppercase; }
+.composer-field select, .composer-actions .button { padding: .52rem .6rem; border-radius: .55rem; font-size: .78rem; }
+.composer-actions .button { min-width: 4.6rem; }
+.composer-hint { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: .4rem 1rem; margin-top: .35rem; color: var(--muted); font-size: .66rem; }
+.composer-warning { color: var(--yellow); }
+.composer-status { margin-top: .4rem; font-size: .76rem; overflow-wrap: anywhere; }
+.composer-status.ok { color: var(--green); }
+.composer-status.error { color: var(--red); }
+
+/* ---------- Context panel ---------- */
+.context-panel {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  border-left: 1px solid var(--line);
+  background: rgba(12, 17, 34, .72);
+  backdrop-filter: blur(14px);
+  transition: transform .2s ease;
+}
+.context-head { display: flex; align-items: center; justify-content: space-between; padding: .8rem .9rem .5rem; }
+.context-head h2 { margin: 0; font-size: .85rem; letter-spacing: .02em; }
+.context-body { display: flex; min-height: 0; flex: 1; flex-direction: column; gap: 1rem; padding: 0 .9rem 1rem; overflow-y: auto; }
+.context-selection { display: grid; gap: .7rem; }
+.context-intro-text { margin: 0; color: var(--muted); font-size: .76rem; line-height: 1.5; }
+.context-counts { display: flex; flex-wrap: wrap; gap: .4rem; }
+.context-counts .count-badge { min-width: max-content; padding: .2rem .55rem; border-radius: 999px; font-size: .68rem; font-weight: 600; }
+.context-quick { display: flex; flex-wrap: wrap; gap: .5rem; }
+.context-task { display: grid; gap: .6rem; padding: .8rem; border: 1px solid var(--line); border-radius: .8rem; background: rgba(255, 255, 255, .02); }
+.context-task-title { display: flex; align-items: center; gap: .5rem; }
+.context-task-title strong { font-size: .88rem; line-height: 1.3; overflow-wrap: anywhere; }
+.context-task-meta { display: flex; flex-wrap: wrap; align-items: center; gap: .45rem; color: var(--muted); font-size: .72rem; }
+.context-task-meta code { color: var(--text); overflow-wrap: anywhere; }
+.context-actions { display: flex; flex-wrap: wrap; gap: .45rem; }
+.context-actions .button { padding: .42rem .6rem; font-size: .72rem; }
+.context-section h3 { margin-bottom: .5rem; }
+.context-flow { min-height: 0; }
+.context-flow .flow-node { min-width: 0; min-height: 0; padding: .6rem .7rem; border-radius: .6rem; }
+.context-flow .flow-node strong { font-size: .82rem; }
+.context-flow .flow-arrow { font-size: 1rem; }
+
+/* ---------- Drawers ---------- */
+.drawer-scrim { position: fixed; inset: 0; z-index: 40; background: rgba(4, 7, 16, .55); backdrop-filter: blur(2px); }
+.drawer {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  z-index: 50;
+  display: flex;
+  width: min(54rem, calc(100vw - 2rem));
+  flex-direction: column;
+  border-right: 1px solid var(--line);
+  background: var(--bg);
+  box-shadow: 2rem 0 5rem rgba(0, 0, 0, .5);
+}
+.drawer-right { right: 0; border-right: 0; border-left: 1px solid var(--line); }
+.drawer-head { display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: .9rem 1.2rem; border-bottom: 1px solid var(--line); background: rgba(15, 21, 40, .6); }
+.drawer-title { margin: 0; font-size: 1rem; }
+.drawer-body { min-height: 0; flex: 1; padding: 1.2rem; overflow-y: auto; }
+.drawer-body .panel { margin-top: 0; }
+
+/* ---------- Toasts ---------- */
+.toast-region { position: fixed; right: 1rem; bottom: 1rem; z-index: 80; display: flex; max-width: 24rem; flex-direction: column; gap: .5rem; }
+.toast { padding: .65rem .9rem; border: 1px solid var(--line); border-radius: .7rem; color: var(--text); background: var(--panel-strong); box-shadow: 0 .5rem 1.5rem rgba(0, 0, 0, .35); font-size: .78rem; overflow-wrap: anywhere; }
+.toast.ok { border-color: rgba(87, 217, 154, .45); }
+.toast.error { border-color: rgba(255, 127, 143, .5); }
+.toast.leaving { opacity: 0; transform: translateY(.3rem); transition: opacity .25s, transform .25s; }
+
+/* Task cards adapt to the narrower Tasks view (keep grid useful at 1280) */
+#view-tasks .task-grid { grid-template-columns: repeat(auto-fill, minmax(210px, 1fr)); }
+
+/* ---------- Responsive ---------- */
+@media (max-width: 1380px) {
+  .app { grid-template-columns: 15.5rem minmax(0, 1fr) 17.5rem; }
+}
+@media (max-width: 1180px) {
+  .app { grid-template-columns: 15rem minmax(0, 1fr); }
+  .context-panel { position: fixed; top: 0; right: 0; bottom: 0; z-index: 60; width: 20rem; max-width: 88vw; transform: translateX(105%); box-shadow: -1.5rem 0 3rem rgba(0, 0, 0, .45); }
+  body.cx-open .context-panel { transform: none; }
+  .context-toggle { display: inline-grid; }
+}
+@media (max-width: 1024px) {
+  .app { grid-template-columns: 1fr; }
+  .sidebar { position: fixed; top: 0; bottom: 0; left: 0; z-index: 60; width: 17.5rem; max-width: 88vw; transform: translateX(-105%); transition: transform .2s ease; box-shadow: 1.5rem 0 3rem rgba(0, 0, 0, .45); }
+  body.sidebar-open .sidebar { transform: none; }
+  .sidebar-close { display: inline-grid; }
+  .menu-button { display: inline-grid; }
+  .welcome-columns { grid-template-columns: 1fr; }
+}
+@media (max-width: 720px) {
+  .composer-row { flex-direction: column; align-items: stretch; }
+  .composer-actions { justify-content: flex-end; }
+  .chat-msg-head time { display: none; }
+  .side-right { margin-left: 4%; }
+  .view { padding: .9rem .8rem 1.5rem; }
+}
+@media (min-width: 1025px) {
+  body.context-closed .context-panel { display: none; }
+}


### PR DESCRIPTION
## What

Rebuilds the Web Workspace from a dashboard-style Inspector layout into a **chat-first, three-column AI workbench** (product layout follows modern AI-chat tools; no brand, code, or copy copied from any reference). The runtime, server, action gateway, and all APIs are untouched; every Inspector-side DOM/JS/CSS contract test passes unmodified.

Commits: `e0222fd` (UI) + `b3ccc73` (docs sync).

## UI

- Left Sidebar (brand, BOUND REPOSITORY chip, New task, Chat/Tasks/Agents/Sessions/Activity nav, Recent Tasks & Sessions with selection highlight); centre Chat timeline rebuilt only from authoritative Runtime records (Task card + spec, status/event transitions, Session output, reviews, errors, locally-observed explicit actions) — no fabricated thinking/replies/statuses; bottom Composer (multi-line, Agent select, Mode select, Enter send / Shift+Enter newline, no-agent & in-flight & error feedback); right Context panel with compact summary and drawer entry buttons.
- Deep surfaces moved into drawers/modals: Task & Graph detail (timeline, evidence, review history, interactive Graph map, Execution controls, Recovery, Review & integrate) and the Authoring drawer (validate → create → preflight). At 1280 px the three columns are complete; ≤1180 px the Context panel and ≤1024 px the Sidebar collapse to drawers.

## Bilingual zh-CN / en-US

- One I18N dictionary (UI strings + STATUS_I18N for statuses/events) drives all rendering; no scattered language branches in business logic. Static HTML carries data-i18n / data-i18n-placeholder; applyStaticI18n() rewrites on toggle without a reload. Default locale: localStorage `coordinate-agents.locale` → navigator.language (`zh-*` → zh-CN, else en-US).
- User data (titles, specs, IDs, commits, paths, Agent IDs, logs, error codes) is never translated or rewritten; unknown statuses/events fall back to a localised generic label while preserving the original code.

## Preservation

- Repository identity, Tasks/Task Graphs, Agent configuration, Sessions, Event stream, authoring, dispatch/run/advance, recovery/cleanup, integration/review, loopback + per-launch capability boundary, GET-only reads, explicit confirmations for write actions, and no merge/push/tag/publish/deploy/release controls.

## Validation

- npm run test:core: 124 tests (123 pass, 1 skip) green; workspace/inspector/action-gateway/web-acceptance-gate/documentation all green with **zero test file changes**.
- npm run demo: PASS. npm pack --dry-run (ignore-scripts): 108 files / 449.8 kB. The pre-existing Windows-host release-artifact tar-path failure on full npm check matches the baseline.
- Real-browser (Playwright on system Chrome): 1280×900 and 800×900, English & Chinese, locale persistence across reload, composer creation of a real Task — **44 checks PASS, 0 console errors** (screenshots in ui-shots/).
