### PR TITLE
🧪 Test parseConfigValue in lib/commands/config.mjs

### DIFF
--- a/test/config-command.test.mjs
+++ b/test/config-command.test.mjs
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { parseConfigValue } from '../lib/commands/config.mjs';
+
+test('parseConfigValue returns unparsed string for non-.args keys', () => {
+  assert.equal(parseConfigValue('agent.antigravity.command', 'agy-proxy'), 'agy-proxy');
+  assert.equal(parseConfigValue('some.other.key', '123'), '123');
+  assert.equal(parseConfigValue('args', '["not", "parsed"]'), '["not", "parsed"]');
+  assert.equal(parseConfigValue('agent.args.extra', 'hello'), 'hello');
+  assert.equal(parseConfigValue('agent.antigravity.args.foo', 'bar'), 'bar');
+});
+
+test('parseConfigValue parses valid JSON array of strings for .args keys', () => {
+  assert.deepEqual(parseConfigValue('agent.antigravity.args', '["--verbose", "--flag"]'), ['--verbose', '--flag']);
+  assert.deepEqual(parseConfigValue('agent.codex.args', '[]'), []);
+  assert.deepEqual(parseConfigValue('custom.args', '["single"]'), ['single']);
+});
+
+test('parseConfigValue throws descriptive error for invalid JSON syntax in .args keys', () => {
+  assert.throws(
+    () => parseConfigValue('agent.antigravity.args', 'not json'),
+    /Invalid args value:/
+  );
+  assert.throws(
+    () => parseConfigValue('agent.antigravity.args', '["unclosed array'),
+    /Invalid args value:/
+  );
+});
+
+test('parseConfigValue throws descriptive error for non-array JSON in .args keys', () => {
+  assert.throws(
+    () => parseConfigValue('agent.antigravity.args', '{"foo": "bar"}'),
+    {
+      name: 'Error',
+      message: 'Invalid args value: args must be a JSON array of strings.',
+    }
+  );
+  assert.throws(
+    () => parseConfigValue('agent.antigravity.args', '123'),
+    {
+      name: 'Error',
+      message: 'Invalid args value: args must be a JSON array of strings.',
+    }
+  );
+  assert.throws(
+    () => parseConfigValue('agent.antigravity.args', 'true'),
+    {
+      name: 'Error',
+      message: 'Invalid args value: args must be a JSON array of strings.',
+    }
+  );
+  assert.throws(
+    () => parseConfigValue('agent.antigravity.args', 'null'),
+    {
+      name: 'Error',
+      message: 'Invalid args value: args must be a JSON array of strings.',
+    }
+  );
+});
+
+test('parseConfigValue throws descriptive error for array containing non-string items', () => {
+  assert.throws(
+    () => parseConfigValue('agent.antigravity.args', '[1, 2, 3]'),
+    {
+      name: 'Error',
+      message: 'Invalid args value: args must be a JSON array of strings.',
+    }
+  );
+  assert.throws(
+    () => parseConfigValue('agent.antigravity.args', '["valid", null, "string"]'),
+    {
+      name: 'Error',
+      message: 'Invalid args value: args must be a JSON array of strings.',
+    }
+  );
+  assert.throws(
+    () => parseConfigValue('agent.antigravity.args', '[true]'),
+    {
+      name: 'Error',
+      message: 'Invalid args value: args must be a JSON array of strings.',
+    }
+  );
+  assert.throws(
+    () => parseConfigValue('agent.antigravity.args', '[["nested"]]'),
+    {
+      name: 'Error',
+      message: 'Invalid args value: args must be a JSON array of strings.',
+    }
+  );
+  assert.throws(
+    () => parseConfigValue('agent.antigravity.args', '[{"key": "value"}]'),
+    {
+      name: 'Error',
+      message: 'Invalid args value: args must be a JSON array of strings.',
+    }
+  );
+});


### PR DESCRIPTION
🎯 **What:** Add comprehensive unit tests for `parseConfigValue` in `lib/commands/config.mjs`.

📊 **Coverage:**
- Non-`.args` configuration keys pass through unchanged (including edge cases like `args` or `agent.args.extra`).
- Valid JSON string arrays parse correctly for `.args` keys.
- Invalid JSON syntax throws descriptive error messages.
- Non-array JSON values (e.g. numbers, objects, booleans, null) throw validation error.
- JSON arrays with non-string elements (e.g. numbers, booleans, null, nested arrays, objects) throw validation error.

✨ **Result:** Ensures full unit test coverage and regression protection for configuration value parsing and validation.

---
*PR created automatically by Jules for task [15106851450033930895](https://jules.google.com/task/15106851450033930895) started by @hogancv*