### PR TITLE
🧪 test: add unit tests for parseConfigValue

### DIFF
--- a/test/user-config.test.mjs
+++ b/test/user-config.test.mjs
@@ -3,6 +3,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
+import { parseConfigValue } from '../lib/commands/config.mjs';
 import {
   defaultUserConfig,
   readUserConfig,
@@ -37,6 +38,71 @@ test('user configuration resolves under the injected home and preserves command 
   } finally {
     rmSync(home, { recursive: true, force: true });
   }
+});
+
+test('parseConfigValue parses non-.args configuration values as-is', () => {
+  assert.equal(parseConfigValue('agent.antigravity.command', 'agy-proxy'), 'agy-proxy');
+  assert.equal(parseConfigValue('some.custom.key', 'hello'), 'hello');
+  assert.equal(parseConfigValue('adapters', '["path/one"]'), '["path/one"]');
+});
+
+test('parseConfigValue parses valid JSON array of strings for .args keys', () => {
+  assert.deepEqual(parseConfigValue('agent.codex.args', '["--verbose", "--port", "8080"]'), ['--verbose', '--port', '8080']);
+  assert.deepEqual(parseConfigValue('agent.antigravity.args', '[]'), []);
+});
+
+test('parseConfigValue rejects malformed or non-array JSON for .args keys', () => {
+  assert.throws(
+    () => parseConfigValue('agent.codex.args', 'not-json'),
+    /Invalid args value:/
+  );
+
+  assert.throws(
+    () => parseConfigValue('agent.codex.args', '{"arg": "val"}'),
+    /Invalid args value: args must be a JSON array of strings\./
+  );
+
+  assert.throws(
+    () => parseConfigValue('agent.codex.args', '123'),
+    /Invalid args value: args must be a JSON array of strings\./
+  );
+
+  assert.throws(
+    () => parseConfigValue('agent.codex.args', 'true'),
+    /Invalid args value: args must be a JSON array of strings\./
+  );
+
+  assert.throws(
+    () => parseConfigValue('agent.codex.args', 'null'),
+    /Invalid args value: args must be a JSON array of strings\./
+  );
+});
+
+test('parseConfigValue rejects JSON arrays containing non-string items for .args keys', () => {
+  assert.throws(
+    () => parseConfigValue('agent.codex.args', '[1, 2, 3]'),
+    /Invalid args value: args must be a JSON array of strings\./
+  );
+
+  assert.throws(
+    () => parseConfigValue('agent.codex.args', '["valid", null]'),
+    /Invalid args value: args must be a JSON array of strings\./
+  );
+
+  assert.throws(
+    () => parseConfigValue('agent.codex.args', '["valid", 123]'),
+    /Invalid args value: args must be a JSON array of strings\./
+  );
+
+  assert.throws(
+    () => parseConfigValue('agent.codex.args', '["valid", true]'),
+    /Invalid args value: args must be a JSON array of strings\./
+  );
+
+  assert.throws(
+    () => parseConfigValue('agent.codex.args', '["valid", {}]'),
+    /Invalid args value: args must be a JSON array of strings\./
+  );
 });
 
 test('writing user configuration creates only the user-level directory', () => {


### PR DESCRIPTION
🎯 **What:** Added unit test coverage for `parseConfigValue` in `lib/commands/config.mjs`.

📊 **Coverage:**
- Verified non-`.args` configuration keys return original string values unmodified.
- Verified `.args` configuration keys properly parse valid JSON arrays of strings (including empty arrays).
- Verified error handling for `.args` keys when supplied invalid JSON string formats.
- Verified error handling for `.args` keys when supplied non-array JSON values (e.g. objects, numbers, booleans, null).
- Verified error handling for `.args` keys when supplied JSON arrays with non-string items (e.g. numbers, booleans, objects, null).

✨ **Result:** Enhanced test coverage and reliability for `parseConfigValue` CLI config parsing.

---
*PR created automatically by Jules for task [7572070657353448410](https://jules.google.com/task/7572070657353448410) started by @hogancv*